### PR TITLE
feat: 2-way sync for Linear and GitHub at standup time

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -217,6 +217,8 @@ export interface WorkItem {
   completed_date: string | null;
   snoozed_until: string | null;
   submission_id: number | null;
+  external_type: string | null;
+  external_id: string | null;
 }
 
 /** Create work items from today's plans */
@@ -228,6 +230,8 @@ export async function createWorkItems(
     text: string;
     date: string;
     submissionId: number;
+    externalType?: string;
+    externalId?: string;
   }>
 ): Promise<WorkItem[]> {
   if (items.length === 0) return [];
@@ -235,14 +239,30 @@ export async function createWorkItems(
   const results: WorkItem[] = [];
   for (const item of items) {
     const result = await db.query<WorkItem>(
-      `INSERT INTO work_items (slack_user_id, daily_name, text, created_date, status, submission_id)
-       VALUES ($1, $2, $3, $4, 'pending', $5)
+      `INSERT INTO work_items (slack_user_id, daily_name, text, created_date, status, submission_id, external_type, external_id)
+       VALUES ($1, $2, $3, $4, 'pending', $5, $6, $7)
        RETURNING *`,
-      [item.slackUserId, item.dailyName, item.text, item.date, item.submissionId]
+      [item.slackUserId, item.dailyName, item.text, item.date, item.submissionId, item.externalType || null, item.externalId || null]
     );
     if (result[0]) results.push(result[0]);
   }
   return results;
+}
+
+/** Get pending work items that have external references (for sync checks) */
+export async function getPendingExternalItems(
+  db: DbClient,
+  slackUserId: string,
+  dailyName: string
+): Promise<WorkItem[]> {
+  return db.query<WorkItem>(
+    `SELECT * FROM work_items
+     WHERE slack_user_id = $1 AND daily_name = $2
+       AND status IN ('pending', 'carried', 'in_progress')
+       AND external_type IS NOT NULL
+     ORDER BY created_date ASC`,
+    [slackUserId, dailyName]
+  );
 }
 
 /** Mark items as done */

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -329,3 +329,70 @@ export function formatPRRef(pr: GitHubPR): string {
   return slug || `#${pr.number}`;
 }
 
+// ============================================================================
+// Sync: Check PR Merge Status
+// ============================================================================
+
+export interface PRRef {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
+/**
+ * Parse an external ID like "org/repo#123" back to {owner, repo, number}
+ */
+export function parsePRExternalId(externalId: string): PRRef | null {
+  const match = externalId.match(/^([^/]+)\/([^#]+)#(\d+)$/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], number: parseInt(match[3], 10) };
+}
+
+/**
+ * Check which PRs have been merged or closed.
+ * Returns a Set of external ID strings (e.g., "org/repo#123") for merged/closed PRs.
+ */
+export async function checkPRsMerged(
+  token: string,
+  prRefs: PRRef[]
+): Promise<Set<string>> {
+  if (prRefs.length === 0) return new Set();
+
+  const mergedIds = new Set<string>();
+
+  // Check each PR individually (GitHub REST API, no batch endpoint)
+  const results = await Promise.all(
+    prRefs.map(async (ref) => {
+      try {
+        const response = await fetch(
+          `https://api.github.com/repos/${ref.owner}/${ref.repo}/pulls/${ref.number}`,
+          {
+            headers: {
+              'Authorization': `Bearer ${token}`,
+              'Accept': 'application/vnd.github.v3+json',
+              'User-Agent': 'omdim-bot',
+            },
+          }
+        );
+
+        if (!response.ok) return null;
+
+        const data = await response.json() as { merged: boolean; state: string };
+        if (data.merged || data.state === 'closed') {
+          return `${ref.owner}/${ref.repo}#${ref.number}`;
+        }
+        return null;
+      } catch (error) {
+        console.error(`Failed to check PR ${ref.owner}/${ref.repo}#${ref.number}:`, error);
+        return null;
+      }
+    })
+  );
+
+  for (const id of results) {
+    if (id) mergedIds.add(id);
+  }
+
+  return mergedIds;
+}
+

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -23,12 +23,14 @@ import {
   setGitHubUsername,
   setLinearUserId,
   getUsersWithGitHubLinks,
+  getPendingExternalItems,
+  WorkItem,
 } from '../db';
 import { handleAppHomeOpened, AppHomeOpenedEvent, HomeContext } from './home';
-import { fetchUserPRData, UserPRData } from '../github';
-import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue } from '../linear';
+import { fetchUserPRData, UserPRData, checkPRsMerged, parsePRExternalId } from '../github';
+import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue, checkIssuesCompleted, transitionIssueToDone } from '../linear';
 import { postStandupToChannel } from '../format';
-import { buildStandupModal, YesterdayData, SubmissionPrefill } from '../modal';
+import { buildStandupModal, YesterdayData, SubmissionPrefill, ExternalCompletion } from '../modal';
 import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed } from '../prompt';
 import { openModal, parseRichText, RichTextBlock, sendDM } from '../slack';
 import { StandupMode } from '../modal';
@@ -181,6 +183,87 @@ async function fetchGitHubPRsForUser(
   }
 }
 
+/**
+ * Check which previously-planned items have been completed externally
+ * (Linear issues done/canceled, GitHub PRs merged/closed).
+ * Runs DB query + API checks in parallel.
+ */
+async function checkExternalCompletions(
+  daily: ReturnType<typeof getDaily>,
+  userId: string,
+  dailyName: string,
+  ctx: InteractionContext
+): Promise<ExternalCompletion[]> {
+  if (!daily) return [];
+
+  try {
+    const pendingItems = await getPendingExternalItems(ctx.db, userId, dailyName);
+    if (pendingItems.length === 0) return [];
+
+    // Group by type
+    const linearItems = pendingItems.filter(i => i.external_type === 'linear');
+    const githubItems = pendingItems.filter(i => i.external_type === 'github');
+
+    // Extract IDs for batch checking
+    const linearIssueIds = linearItems
+      .map(i => {
+        // external_id format: "teamId:issueId"
+        const parts = i.external_id?.split(':');
+        return parts && parts.length === 2 ? parts[1] : null;
+      })
+      .filter((id): id is string => id !== null);
+
+    const githubPRRefs = githubItems
+      .map(i => i.external_id ? parsePRExternalId(i.external_id) : null)
+      .filter((ref): ref is NonNullable<typeof ref> => ref !== null);
+
+    // Check Linear + GitHub in parallel
+    const linearConfig = getLinearConfig(daily);
+    const githubConfig = getGitHubConfig(daily);
+    const linearToken = linearConfig && ctx.env ? ctx.env[linearConfig.tokenEnvVar] : undefined;
+    const githubToken = githubConfig && ctx.env ? ctx.env[githubConfig.tokenEnvVar] : undefined;
+
+    const [completedLinear, mergedGitHub] = await Promise.all([
+      linearToken && linearIssueIds.length > 0
+        ? checkIssuesCompleted(linearToken, linearIssueIds)
+        : new Set<string>(),
+      githubToken && githubPRRefs.length > 0
+        ? checkPRsMerged(githubToken, githubPRRefs)
+        : new Set<string>(),
+    ]);
+
+    const results: ExternalCompletion[] = [];
+
+    // Match completed Linear issues back to work items
+    for (const item of linearItems) {
+      const parts = item.external_id?.split(':');
+      if (parts && parts.length === 2 && completedLinear.has(parts[1])) {
+        results.push({
+          text: item.text,
+          externalType: 'linear',
+          externalId: item.external_id!,
+        });
+      }
+    }
+
+    // Match merged GitHub PRs back to work items
+    for (const item of githubItems) {
+      if (item.external_id && mergedGitHub.has(item.external_id)) {
+        results.push({
+          text: item.text,
+          externalType: 'github',
+          externalId: item.external_id,
+        });
+      }
+    }
+
+    return results;
+  } catch (error) {
+    console.error('Failed to check external completions:', error);
+    return [];
+  }
+}
+
 // ============================================================================
 // Button Handler: Open Standup
 // ============================================================================
@@ -253,14 +336,15 @@ export async function handleOpenStandup(
     }
   }
 
-  // Fetch Linear issues and GitHub PRs in parallel
-  const [linearIssues, githubResult] = await Promise.all([
+  // Fetch Linear issues, GitHub PRs, and external completions in parallel
+  const [linearIssues, githubResult, externalCompletions] = await Promise.all([
     fetchLinearIssuesForUser(daily, userId, ctx),
     fetchGitHubPRsForUser(daily, userId, ctx),
+    checkExternalCompletions(daily, userId, dailyName, ctx),
   ]);
 
   // Build and open modal
-  const modal = buildStandupModal(dailyName, yesterdayData, daily.questions || [], daily.field_order, userDate, 'today', undefined, linearIssues, githubResult.prData, githubResult.reviewerMap);
+  const modal = buildStandupModal(dailyName, yesterdayData, daily.questions || [], daily.field_order, userDate, 'today', undefined, linearIssues, githubResult.prData, githubResult.reviewerMap, externalCompletions);
   return openModal(ctx.slackToken, triggerId, modal);
 }
 
@@ -337,15 +421,24 @@ export async function handleStandupSubmission(
   const todayPlans = parseLines(values.today_plans?.plans_input?.value);
   const blockers = parseRichText(values.blockers?.blockers_input?.rich_text_value) || '';
 
-  // Parse Linear ticket selections and append to todayPlans
-  // Parse integration checkbox selections — extract display text from the option's text field
+  // Parse integration checkbox selections and track external refs
   // Format is "*IDENTIFIER* Title" in mrkdwn, so strip the bold markers
   const parseOptionText = (text: string): string => text.replace(/^\*([^*]+)\*\s*/, '[$1] ');
+
+  // Map from plan index → external ref (populated as we add integration items to todayPlans)
+  const planExternalRefs = new Map<number, { type: string; id: string }>();
+
+  // Get GitHub org from config (needed to expand short PR refs to full external IDs)
+  const githubConfig = getGitHubConfig(daily!);
+  const githubOrg = githubConfig?.org || '';
 
   const linearSelections = values.linear_tickets?.linear_tickets_input?.selected_options;
   if (linearSelections && linearSelections.length > 0) {
     for (const option of linearSelections) {
+      const planIndex = todayPlans.length;
       todayPlans.push(parseOptionText(option.text?.text || option.value));
+      // option.value is "teamId:issueId" — store as Linear external ref
+      planExternalRefs.set(planIndex, { type: 'linear', id: option.value });
     }
   }
 
@@ -353,13 +446,20 @@ export async function handleStandupSubmission(
   const reviewSelections = values.review_requests?.review_requests_input?.selected_options;
   if (reviewSelections && reviewSelections.length > 0) {
     for (const option of reviewSelections) {
+      const planIndex = todayPlans.length;
       todayPlans.push(parseOptionText(option.text?.text || option.value));
+      // option.value is "repo#123" — expand to "org/repo#123"
+      const externalId = githubOrg ? `${githubOrg}/${option.value}` : option.value;
+      planExternalRefs.set(planIndex, { type: 'github', id: externalId });
     }
   }
   const myPrSelections = values.my_prs?.my_prs_input?.selected_options;
   if (myPrSelections && myPrSelections.length > 0) {
     for (const option of myPrSelections) {
+      const planIndex = todayPlans.length;
       todayPlans.push(parseOptionText(option.text?.text || option.value));
+      const externalId = githubOrg ? `${githubOrg}/${option.value}` : option.value;
+      planExternalRefs.set(planIndex, { type: 'github', id: externalId });
     }
   }
 
@@ -474,22 +574,60 @@ export async function handleStandupSubmission(
         await markItemsInProgress(ctx.db, userId, dailyName, yesterdayInProgress);
       }
 
-      // Create new work items for today's plans
+      // Create new work items for today's plans (with external refs where applicable)
       if (todayPlans.length > 0) {
         await createWorkItems(
           ctx.db,
-          todayPlans.map(text => ({
-            slackUserId: userId,
-            dailyName,
-            text,
-            date: todayStr,
-            submissionId: submission.id,
-          }))
+          todayPlans.map((text, index) => {
+            const extRef = planExternalRefs.get(index);
+            return {
+              slackUserId: userId,
+              dailyName,
+              text,
+              date: todayStr,
+              submissionId: submission.id,
+              externalType: extRef?.type,
+              externalId: extRef?.id,
+            };
+          })
         );
       }
     } catch (error) {
       // Don't fail the submission if work item tracking fails
       console.error('Failed to track work items:', error);
+    }
+
+    // Linear write-back: transition completed Linear issues to "Done"
+    if (yesterdayCompleted.length > 0) {
+      try {
+        const linearConfig = getLinearConfig(daily!);
+        const linearToken = linearConfig && ctx.env ? ctx.env[linearConfig.tokenEnvVar] : undefined;
+        if (linearToken) {
+          // Find work items that were just marked done and have Linear external refs
+          const completedExternalItems = await ctx.db.query<WorkItem>(
+            `SELECT * FROM work_items
+             WHERE slack_user_id = $1 AND daily_name = $2
+               AND status = 'done' AND external_type = 'linear'
+               AND completed_date = $3`,
+            [userId, dailyName, todayStr]
+          );
+
+          // Fire-and-forget: transition each to done in Linear
+          for (const item of completedExternalItems) {
+            if (!item.external_id) continue;
+            const parts = item.external_id.split(':');
+            if (parts.length === 2) {
+              const [teamId, issueId] = parts;
+              transitionIssueToDone(linearToken, issueId, teamId).catch(err =>
+                console.error(`Failed to transition Linear issue ${issueId} to done:`, err)
+              );
+            }
+          }
+        }
+      } catch (error) {
+        // Best-effort: don't fail submission on write-back errors
+        console.error('Linear write-back failed:', error);
+      }
     }
 
     // Get carry counts for in-progress items (for attention warnings)
@@ -507,9 +645,9 @@ export async function handleStandupSubmission(
       // Fetch GitHub PR data and reviewer map if integration is enabled
       let prData: UserPRData | undefined;
       let reviewerSlackMap: Map<string, string> | undefined;
-      const githubConfig = getGitHubConfig(daily);
-      if (githubConfig && ctx.env) {
-        const githubToken = ctx.env[githubConfig.tokenEnvVar];
+      const postGithubConfig = getGitHubConfig(daily);
+      if (postGithubConfig && ctx.env) {
+        const githubToken = ctx.env[postGithubConfig.tokenEnvVar];
         if (githubToken) {
           // Get GitHub username: config mapping takes precedence over DB
           let githubUsername = getGitHubUsernameFromConfig(daily, userId);
@@ -520,7 +658,7 @@ export async function handleStandupSubmission(
           if (githubUsername) {
             try {
               [prData, reviewerSlackMap] = await Promise.all([
-                fetchUserPRData(githubToken, githubUsername, githubConfig.org),
+                fetchUserPRData(githubToken, githubUsername, postGithubConfig.org),
                 buildGitHubUserMap(daily, ctx.db),
               ]);
             } catch (error) {
@@ -692,10 +830,11 @@ export async function handleHomeStartDaily(
     }
   }
 
-  // Fetch Linear issues and GitHub PRs in parallel
-  const [linearIssues, githubResult] = await Promise.all([
+  // Fetch Linear issues, GitHub PRs, and external completions in parallel
+  const [linearIssues, githubResult, externalCompletions] = await Promise.all([
     fetchLinearIssuesForUser(daily, userId, ctx),
     fetchGitHubPRsForUser(daily, userId, ctx),
+    checkExternalCompletions(daily, userId, dailyName, ctx),
   ]);
 
   // Build and open modal
@@ -709,7 +848,8 @@ export async function handleHomeStartDaily(
     prefill,
     linearIssues,
     githubResult.prData,
-    githubResult.reviewerMap
+    githubResult.reviewerMap,
+    externalCompletions
   );
 
   return openModal(ctx.slackToken, triggerId, modal);

--- a/lib/linear.ts
+++ b/lib/linear.ts
@@ -18,6 +18,7 @@ export interface LinearIssue {
   };
   priority: number; // 0=No priority, 1=Urgent, 2=High, 3=Medium, 4=Low
   url: string;
+  teamId?: string; // Team ID the issue belongs to
 }
 
 export interface UserLinearData {
@@ -100,6 +101,7 @@ interface UserAssignedIssuesResponse {
         state: { name: string; type: string };
         priority: number;
         url: string;
+        team: { id: string };
       }>;
     };
   };
@@ -122,6 +124,7 @@ const USER_ASSIGNED_ISSUES_QUERY = `
           state { name type }
           priority
           url
+          team { id }
         }
       }
     }
@@ -154,6 +157,7 @@ export async function fetchUserAssignedIssues(
       state: { name: issue.state.name, type: issue.state.type },
       priority: issue.priority,
       url: issue.url,
+      teamId: issue.team.id,
     }));
 
     // Sort by priority (1=Urgent first) then by state type (started before unstarted)
@@ -254,6 +258,7 @@ export async function fetchUserLinearData(
         state: { name: issue.state.name, type: issue.state.type },
         priority: issue.priority,
         url: issue.url,
+        teamId,
       }));
 
     // Sort by priority (1=Urgent first) then by state type (started before unstarted)
@@ -393,4 +398,151 @@ export function calculateCycleProgress(
     todo,
     completionPct,
   };
+}
+
+// ============================================================================
+// Sync: Check Issue Completion Status
+// ============================================================================
+
+interface IssueStatusResponse {
+  nodes: Array<{
+    id: string;
+    state: { type: string };
+  }>;
+}
+
+const CHECK_ISSUES_QUERY = `
+  query CheckIssues($ids: [String!]!) {
+    nodes(ids: $ids) {
+      ... on Issue {
+        id
+        state { type }
+      }
+    }
+  }
+`;
+
+/**
+ * Check which Linear issues are now completed or canceled.
+ * Returns a Set of issue IDs that are done.
+ */
+export async function checkIssuesCompleted(
+  token: string,
+  issueIds: string[]
+): Promise<Set<string>> {
+  if (issueIds.length === 0) return new Set();
+
+  try {
+    const data = await linearQuery<IssueStatusResponse>(
+      token,
+      CHECK_ISSUES_QUERY,
+      { ids: issueIds }
+    );
+
+    const completedIds = new Set<string>();
+    for (const node of data.nodes) {
+      if (node.state?.type === 'completed' || node.state?.type === 'canceled') {
+        completedIds.add(node.id);
+      }
+    }
+    return completedIds;
+  } catch (error) {
+    console.error('Failed to check Linear issue status:', error);
+    return new Set();
+  }
+}
+
+// ============================================================================
+// Sync: Transition Issue to Done
+// ============================================================================
+
+interface TeamWorkflowStatesResponse {
+  team: {
+    states: {
+      nodes: Array<{
+        id: string;
+        name: string;
+        type: string;
+      }>;
+    };
+  };
+}
+
+const TEAM_WORKFLOW_STATES_QUERY = `
+  query TeamStates($teamId: String!) {
+    team(id: $teamId) {
+      states {
+        nodes {
+          id
+          name
+          type
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Fetch the "Done" state ID for a team (first state with type "completed").
+ */
+export async function fetchTeamDoneStateId(
+  token: string,
+  teamId: string
+): Promise<string | null> {
+  try {
+    const data = await linearQuery<TeamWorkflowStatesResponse>(
+      token,
+      TEAM_WORKFLOW_STATES_QUERY,
+      { teamId }
+    );
+
+    const doneState = data.team.states.nodes.find(s => s.type === 'completed');
+    return doneState?.id || null;
+  } catch (error) {
+    console.error(`Failed to fetch done state for team ${teamId}:`, error);
+    return null;
+  }
+}
+
+interface IssueUpdateResponse {
+  issueUpdate: {
+    success: boolean;
+  };
+}
+
+const ISSUE_UPDATE_MUTATION = `
+  mutation UpdateIssue($issueId: String!, $stateId: String!) {
+    issueUpdate(id: $issueId, input: { stateId: $stateId }) {
+      success
+    }
+  }
+`;
+
+/**
+ * Transition a Linear issue to Done state.
+ * Looks up the team's "completed" workflow state and applies it.
+ */
+export async function transitionIssueToDone(
+  token: string,
+  issueId: string,
+  teamId: string
+): Promise<boolean> {
+  try {
+    const doneStateId = await fetchTeamDoneStateId(token, teamId);
+    if (!doneStateId) {
+      console.error(`No completed state found for team ${teamId}`);
+      return false;
+    }
+
+    const data = await linearQuery<IssueUpdateResponse>(
+      token,
+      ISSUE_UPDATE_MUTATION,
+      { issueId, stateId: doneStateId }
+    );
+
+    return data.issueUpdate.success;
+  } catch (error) {
+    console.error(`Failed to transition issue ${issueId} to done:`, error);
+    return false;
+  }
 }

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -101,6 +101,13 @@ export type StandupMode = 'today' | 'tomorrow';
  * @param linearIssues - Optional Linear issues to show as checkboxes
  * @param reviewerMap - GitHub login (lowercase) → Slack user ID mapping
  */
+/** Items detected as completed externally (Linear done, GitHub merged) */
+export interface ExternalCompletion {
+  text: string;
+  externalType: string;
+  externalId: string;
+}
+
 export function buildStandupModal(
   dailyName: string,
   yesterday: YesterdayData | null,
@@ -111,7 +118,8 @@ export function buildStandupModal(
   prefill?: SubmissionPrefill,
   linearIssues?: LinearIssue[],
   prData?: UserPRData,
-  reviewerMap?: Map<string, string>
+  reviewerMap?: Map<string, string>,
+  externallyCompleted?: ExternalCompletion[]
 ): ModalView {
   const blocks: Block[] = [];
   const isFirstDay = !yesterday || yesterday.plans.length === 0;
@@ -185,6 +193,14 @@ export function buildStandupModal(
     blocks.push({ type: 'divider' });
   }
 
+  // Build set of yesterday items that were externally completed
+  const externallyDoneTexts = new Set<string>();
+  if (externallyCompleted) {
+    for (const item of externallyCompleted) {
+      externallyDoneTexts.add(item.text);
+    }
+  }
+
   // Yesterday section: plans + unplanned (grouped as "what happened")
   if (!isFirstDay && yesterdayPlans.length > 0) {
     blocks.push({
@@ -197,6 +213,10 @@ export function buildStandupModal(
 
     // Add a dropdown for each yesterday's plan item
     yesterdayPlans.forEach((plan, index) => {
+      // Auto-default to "Done" if externally completed
+      const isDoneExternally = externallyDoneTexts.has(plan);
+      const initialOption = isDoneExternally ? YESTERDAY_ITEM_OPTIONS[2] : YESTERDAY_ITEM_OPTIONS[0]; // [2] = "Done", [0] = "Carry over"
+
       blocks.push({
         type: 'section',
         block_id: `yesterday_item_${index}`,
@@ -208,7 +228,7 @@ export function buildStandupModal(
           type: 'static_select',
           action_id: `item_status_${index}`,
           options: YESTERDAY_ITEM_OPTIONS,
-          initial_option: YESTERDAY_ITEM_OPTIONS[0], // Default to "Carry over"
+          initial_option: initialOption,
         },
       });
     });
@@ -325,7 +345,7 @@ export function buildStandupModal(
               text: issue.state.name,
               emoji: true,
             },
-            value: issue.id,
+            value: issue.teamId ? `${issue.teamId}:${issue.id}` : issue.id,
           }));
           blocks.push({
             type: 'input',

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -117,6 +117,38 @@ export function buildStandupModal(
   const isFirstDay = !yesterday || yesterday.plans.length === 0;
   const yesterdayPlans = yesterday?.plans || [];
 
+  // Deduplicate: extract integration IDs from yesterday's plans so we don't
+  // show the same Linear tickets or GitHub PRs as both "yesterday" items and
+  // fresh integration checkboxes
+  const yesterdayIntegrationIds = new Set<string>();
+  for (const plan of yesterdayPlans) {
+    const match = plan.match(/^\[([^\]]+)\]\s/);
+    if (match) {
+      yesterdayIntegrationIds.add(match[1]);
+    }
+  }
+  if (yesterdayIntegrationIds.size > 0) {
+    if (linearIssues) {
+      linearIssues = linearIssues.filter(
+        issue => !yesterdayIntegrationIds.has(issue.identifier)
+      );
+    }
+    if (prData) {
+      const filterPRs = (prs: GitHubPR[]) => prs.filter(pr => {
+        const repoMatch = pr.url.match(/github\.com\/[^/]+\/([^/]+)/);
+        const repo = repoMatch?.[1] || 'unknown';
+        return !yesterdayIntegrationIds.has(`${repo}#${pr.number}`);
+      });
+      prData = {
+        ...prData,
+        reviewRequests: filterPRs(prData.reviewRequests),
+        awaitingReview: filterPRs(prData.awaitingReview),
+        readyToMerge: filterPRs(prData.readyToMerge),
+        draftPRs: filterPRs(prData.draftPRs),
+      };
+    }
+  }
+
   // Merge field order with defaults
   const order = {
     unplanned: fieldOrder?.unplanned ?? DEFAULT_FIELD_ORDER.unplanned,

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -160,6 +160,16 @@ Items gain a 4th status: **In Progress** (alongside Done, Carry Over, Drop).
 - [ ] Items in-progress for 3+ days flagged as "needs attention" in digest and report
 - [ ] Visual indicator in standup post (e.g., 🔄 Day 3)
 
+### App Home: Today's Tasks Management
+View and manage today's standup items directly from the App Home tab — without reopening the modal.
+
+- [ ] Show today's planned items as an editable list in App Home
+- [ ] Quick-add new items inline
+- [ ] Mark items done / in-progress / drop from App Home
+- [ ] Carry over items to tomorrow
+- [ ] Show integration context (linked PR status, Linear ticket state) alongside each item
+- [ ] Real-time sync: changes in App Home reflect in the standup post (and vice versa)
+
 ### Configurable Digest & Report Cadence
 Digest and full report schedules are set per-daily in config (replacing the hardcoded 2pm UTC / weekly pattern).
 

--- a/schema.sql
+++ b/schema.sql
@@ -63,7 +63,9 @@ CREATE TABLE IF NOT EXISTS work_items (
   carry_count INTEGER NOT NULL DEFAULT 0,
   completed_date DATE,
   snoozed_until DATE,  -- null = not snoozed, date = hidden from bottlenecks until this date
-  submission_id INTEGER REFERENCES submissions(id) ON DELETE SET NULL
+  submission_id INTEGER REFERENCES submissions(id) ON DELETE SET NULL,
+  external_type TEXT,   -- 'linear' | 'github'
+  external_id TEXT      -- Linear: "teamId:issueId", GitHub: "org/repo#123"
 );
 
 -- Channel reminder dedup log
@@ -81,6 +83,9 @@ CREATE TABLE IF NOT EXISTS reminder_log (
 -- ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS github_username TEXT;
 -- ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS linear_user_id TEXT;
 -- ALTER TABLE submissions ADD COLUMN IF NOT EXISTS yesterday_in_progress JSONB;
+-- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS external_type TEXT;
+-- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS external_id TEXT;
+-- CREATE INDEX IF NOT EXISTS idx_work_items_external ON work_items(external_type, external_id) WHERE external_type IS NOT NULL;
 
 -- Out of Office periods
 CREATE TABLE IF NOT EXISTS ooo (
@@ -103,4 +108,5 @@ CREATE INDEX IF NOT EXISTS idx_slack_users_updated ON slack_users(updated_at);
 CREATE INDEX IF NOT EXISTS idx_work_items_user_daily ON work_items(slack_user_id, daily_name);
 CREATE INDEX IF NOT EXISTS idx_work_items_status ON work_items(status);
 CREATE INDEX IF NOT EXISTS idx_work_items_carry ON work_items(carry_count) WHERE carry_count >= 3;
+CREATE INDEX IF NOT EXISTS idx_work_items_external ON work_items(external_type, external_id) WHERE external_type IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_ooo_lookup ON ooo(slack_user_id, daily_name, start_date, end_date);

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -16,6 +16,9 @@ import {
   extractPRSlug,
   formatPRRef,
   GitHubPR,
+  checkPRsMerged,
+  parsePRExternalId,
+  PRRef,
 } from '../lib/github';
 
 describe('github client', () => {
@@ -477,6 +480,214 @@ describe('github client', () => {
       };
 
       expect(formatPRRef(pr)).toBe('#456');
+    });
+  });
+
+  describe('parsePRExternalId', () => {
+    it('parses valid org/repo#number format', () => {
+      const result = parsePRExternalId('myorg/my-repo#123');
+
+      expect(result).toEqual({
+        owner: 'myorg',
+        repo: 'my-repo',
+        number: 123,
+      });
+    });
+
+    it('parses format with numeric repo name', () => {
+      const result = parsePRExternalId('github/2024-project#42');
+
+      expect(result).toEqual({
+        owner: 'github',
+        repo: '2024-project',
+        number: 42,
+      });
+    });
+
+    it('returns null for invalid format missing #', () => {
+      const result = parsePRExternalId('myorg/repo123');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for invalid format missing /', () => {
+      const result = parsePRExternalId('myorg-repo#123');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for invalid format with non-numeric PR number', () => {
+      const result = parsePRExternalId('myorg/repo#abc');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      const result = parsePRExternalId('');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for URL instead of external ID', () => {
+      const result = parsePRExternalId('https://github.com/org/repo/pull/123');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('checkPRsMerged', () => {
+    it('returns external IDs of merged PRs', async () => {
+      const prRefs: PRRef[] = [
+        { owner: 'myorg', repo: 'repo1', number: 123 },
+        { owner: 'myorg', repo: 'repo2', number: 456 },
+      ];
+
+      // Mock first PR as merged
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ merged: true, state: 'closed' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ merged: false, state: 'open' }),
+        });
+
+      const result = await checkPRsMerged('token', prRefs);
+
+      expect(result.size).toBe(1);
+      expect(result.has('myorg/repo1#123')).toBe(true);
+      expect(result.has('myorg/repo2#456')).toBe(false);
+    });
+
+    it('returns external IDs of closed (non-merged) PRs', async () => {
+      const prRefs: PRRef[] = [
+        { owner: 'org', repo: 'repo', number: 100 },
+      ];
+
+      // Mock PR as closed but not merged
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ merged: false, state: 'closed' }),
+      });
+
+      const result = await checkPRsMerged('token', prRefs);
+
+      expect(result.size).toBe(1);
+      expect(result.has('org/repo#100')).toBe(true);
+    });
+
+    it('handles mix of merged and open PRs', async () => {
+      const prRefs: PRRef[] = [
+        { owner: 'org', repo: 'repo', number: 1 },
+        { owner: 'org', repo: 'repo', number: 2 },
+        { owner: 'org', repo: 'repo', number: 3 },
+      ];
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ merged: true, state: 'closed' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ merged: false, state: 'open' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ merged: false, state: 'closed' }),
+        });
+
+      const result = await checkPRsMerged('token', prRefs);
+
+      expect(result.size).toBe(2);
+      expect(result.has('org/repo#1')).toBe(true); // merged
+      expect(result.has('org/repo#2')).toBe(false); // open
+      expect(result.has('org/repo#3')).toBe(true); // closed
+    });
+
+    it('returns empty set for empty input', async () => {
+      const result = await checkPRsMerged('token', []);
+
+      expect(result.size).toBe(0);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('handles API errors gracefully', async () => {
+      const prRefs: PRRef[] = [
+        { owner: 'org', repo: 'repo1', number: 1 },
+        { owner: 'org', repo: 'repo2', number: 2 },
+      ];
+
+      // First call succeeds, second fails
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ merged: true, state: 'closed' }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          text: async () => 'Not Found',
+        });
+
+      const result = await checkPRsMerged('token', prRefs);
+
+      // Should include the successful one, ignore the failed one
+      expect(result.size).toBe(1);
+      expect(result.has('org/repo1#1')).toBe(true);
+      expect(result.has('org/repo2#2')).toBe(false);
+    });
+
+    it('sends correct API requests with headers', async () => {
+      const prRefs: PRRef[] = [
+        { owner: 'myorg', repo: 'my-repo', number: 42 },
+      ];
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ merged: true, state: 'closed' }),
+      });
+
+      await checkPRsMerged('my-token', prRefs);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.github.com/repos/myorg/my-repo/pulls/42',
+        expect.objectContaining({
+          headers: {
+            'Authorization': 'Bearer my-token',
+            'Accept': 'application/vnd.github.v3+json',
+            'User-Agent': 'omdim-bot',
+          },
+        })
+      );
+    });
+
+    it('checks multiple PRs in parallel', async () => {
+      const prRefs: PRRef[] = [
+        { owner: 'org', repo: 'repo', number: 1 },
+        { owner: 'org', repo: 'repo', number: 2 },
+        { owner: 'org', repo: 'repo', number: 3 },
+      ];
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ merged: true, state: 'closed' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ merged: true, state: 'closed' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ merged: true, state: 'closed' }),
+        });
+
+      await checkPRsMerged('token', prRefs);
+
+      // All 3 requests should have been made
+      expect(global.fetch).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -23,6 +23,8 @@ vi.mock('../lib/db', () => ({
   setLinearUserId: vi.fn(),
   getSubmissionForDate: vi.fn(() => Promise.resolve(null)),
   getUserDailies: vi.fn(() => Promise.resolve([])),
+  getPendingExternalItems: vi.fn(() => Promise.resolve([])),
+  getUsersWithGitHubLinks: vi.fn(() => Promise.resolve([])),
 }));
 
 // Mock the config module

--- a/tests/linear.test.ts
+++ b/tests/linear.test.ts
@@ -11,6 +11,9 @@ import {
   calculateCycleProgress,
   fetchUserLinearData,
   fetchTeamCycleData,
+  checkIssuesCompleted,
+  fetchTeamDoneStateId,
+  transitionIssueToDone,
 } from '../lib/linear';
 
 describe('linear client', () => {
@@ -508,6 +511,257 @@ describe('linear client', () => {
       expect(result.teamData).toHaveLength(1);
       expect(result.teamData[0].data.issues).toEqual([]);
       expect(result.cycleProgress).toBeNull();
+    });
+  });
+
+  describe('checkIssuesCompleted', () => {
+    it('returns completed and canceled issue IDs', async () => {
+      const mockResponse = {
+        data: {
+          nodes: [
+            { id: 'issue-1', state: { type: 'completed' } },
+            { id: 'issue-2', state: { type: 'started' } },
+            { id: 'issue-3', state: { type: 'canceled' } },
+            { id: 'issue-4', state: { type: 'unstarted' } },
+          ],
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const { checkIssuesCompleted } = await import('../lib/linear');
+      const result = await checkIssuesCompleted('token', ['issue-1', 'issue-2', 'issue-3', 'issue-4']);
+
+      expect(result.size).toBe(2);
+      expect(result.has('issue-1')).toBe(true); // completed
+      expect(result.has('issue-3')).toBe(true); // canceled
+      expect(result.has('issue-2')).toBe(false); // started
+      expect(result.has('issue-4')).toBe(false); // unstarted
+    });
+
+    it('returns empty set for active issues only', async () => {
+      const mockResponse = {
+        data: {
+          nodes: [
+            { id: 'issue-1', state: { type: 'started' } },
+            { id: 'issue-2', state: { type: 'unstarted' } },
+          ],
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const { checkIssuesCompleted } = await import('../lib/linear');
+      const result = await checkIssuesCompleted('token', ['issue-1', 'issue-2']);
+
+      expect(result.size).toBe(0);
+    });
+
+    it('handles empty input array', async () => {
+      const { checkIssuesCompleted } = await import('../lib/linear');
+      const result = await checkIssuesCompleted('token', []);
+
+      expect(result.size).toBe(0);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns empty set on API error', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      const { checkIssuesCompleted } = await import('../lib/linear');
+      const result = await checkIssuesCompleted('token', ['issue-1']);
+
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('fetchTeamDoneStateId', () => {
+    it('returns the first completed type state ID', async () => {
+      const mockResponse = {
+        data: {
+          team: {
+            states: {
+              nodes: [
+                { id: 'state-1', name: 'Todo', type: 'unstarted' },
+                { id: 'state-2', name: 'In Progress', type: 'started' },
+                { id: 'state-3', name: 'Done', type: 'completed' },
+                { id: 'state-4', name: 'Archive', type: 'completed' },
+              ],
+            },
+          },
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const { fetchTeamDoneStateId } = await import('../lib/linear');
+      const result = await fetchTeamDoneStateId('token', 'team-1');
+
+      expect(result).toBe('state-3'); // First completed type
+    });
+
+    it('returns null when no completed state exists', async () => {
+      const mockResponse = {
+        data: {
+          team: {
+            states: {
+              nodes: [
+                { id: 'state-1', name: 'Todo', type: 'unstarted' },
+                { id: 'state-2', name: 'In Progress', type: 'started' },
+                { id: 'state-3', name: 'Canceled', type: 'canceled' },
+              ],
+            },
+          },
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const { fetchTeamDoneStateId } = await import('../lib/linear');
+      const result = await fetchTeamDoneStateId('token', 'team-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on API error', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () => 'Unauthorized',
+      });
+
+      const { fetchTeamDoneStateId } = await import('../lib/linear');
+      const result = await fetchTeamDoneStateId('token', 'team-1');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('transitionIssueToDone', () => {
+    it('successfully transitions issue to done state', async () => {
+      // Mock fetchTeamDoneStateId response
+      const mockStatesResponse = {
+        data: {
+          team: {
+            states: {
+              nodes: [
+                { id: 'state-done', name: 'Done', type: 'completed' },
+              ],
+            },
+          },
+        },
+      };
+
+      // Mock issueUpdate mutation response
+      const mockUpdateResponse = {
+        data: {
+          issueUpdate: {
+            success: true,
+          },
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockStatesResponse,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockUpdateResponse,
+        });
+
+      const { transitionIssueToDone } = await import('../lib/linear');
+      const result = await transitionIssueToDone('token', 'issue-1', 'team-1');
+
+      expect(result).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns false when no done state found', async () => {
+      // Mock fetchTeamDoneStateId response with no completed state
+      const mockStatesResponse = {
+        data: {
+          team: {
+            states: {
+              nodes: [
+                { id: 'state-1', name: 'Todo', type: 'unstarted' },
+              ],
+            },
+          },
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockStatesResponse,
+      });
+
+      const { transitionIssueToDone } = await import('../lib/linear');
+      const result = await transitionIssueToDone('token', 'issue-1', 'team-1');
+
+      expect(result).toBe(false);
+      expect(global.fetch).toHaveBeenCalledTimes(1); // Only fetched states, didn't try to update
+    });
+
+    it('returns false on API error during state fetch', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      const { transitionIssueToDone } = await import('../lib/linear');
+      const result = await transitionIssueToDone('token', 'issue-1', 'team-1');
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false on API error during issue update', async () => {
+      // Mock successful state fetch
+      const mockStatesResponse = {
+        data: {
+          team: {
+            states: {
+              nodes: [
+                { id: 'state-done', name: 'Done', type: 'completed' },
+              ],
+            },
+          },
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockStatesResponse,
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 403,
+          text: async () => 'Forbidden',
+        });
+
+      const { transitionIssueToDone } = await import('../lib/linear');
+      const result = await transitionIssueToDone('token', 'issue-1', 'team-1');
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -16,7 +16,7 @@ vi.mock('../lib/slack', () => ({
   openModal: vi.fn(),
 }));
 
-import { buildStandupModal, YesterdayData } from '../lib/modal';
+import { buildStandupModal, YesterdayData, ExternalCompletion } from '../lib/modal';
 import type { LinearIssue } from '../lib/linear';
 import type { UserPRData, GitHubPR } from '../lib/github';
 
@@ -607,6 +607,311 @@ describe('modal builder', () => {
       const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
 
       expect(linearBlock).toBeUndefined();
+    });
+
+    describe('externallyCompleted auto-defaulting', () => {
+      it('defaults matched items to "Done" when in externallyCompleted', () => {
+        const yesterday: YesterdayData = {
+          plans: ['[ENG-123] Fix bug', 'Write tests', '[PR-456] Review PR'],
+          completed: [],
+          incomplete: [],
+        };
+
+        const externallyCompleted: ExternalCompletion[] = [
+          { text: '[ENG-123] Fix bug', externalType: 'linear', externalId: 'issue-123' },
+          { text: '[PR-456] Review PR', externalType: 'github', externalId: 'org/repo#456' },
+        ];
+
+        const modal = buildStandupModal(
+          'daily-il',
+          yesterday,
+          [],
+          undefined,
+          undefined,
+          'today',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          externallyCompleted
+        );
+
+        // Find the dropdown blocks for each plan
+        const item0 = modal.blocks.find(b => b.block_id === 'yesterday_item_0');
+        const item1 = modal.blocks.find(b => b.block_id === 'yesterday_item_1');
+        const item2 = modal.blocks.find(b => b.block_id === 'yesterday_item_2');
+
+        // Item 0 matches externallyCompleted, should default to "Done"
+        expect(item0?.accessory?.initial_option?.value).toBe('done');
+        expect(item0?.accessory?.initial_option?.text?.text).toContain('Done');
+
+        // Item 1 doesn't match, should default to "Carry over"
+        expect(item1?.accessory?.initial_option?.value).toBe('continue');
+        expect(item1?.accessory?.initial_option?.text?.text).toContain('Carry over');
+
+        // Item 2 matches externallyCompleted, should default to "Done"
+        expect(item2?.accessory?.initial_option?.value).toBe('done');
+        expect(item2?.accessory?.initial_option?.text?.text).toContain('Done');
+      });
+
+      it('defaults all items to "Carry over" when no externallyCompleted provided', () => {
+        const yesterday: YesterdayData = {
+          plans: ['Task A', 'Task B'],
+          completed: [],
+          incomplete: [],
+        };
+
+        const modal = buildStandupModal('daily-il', yesterday, []);
+
+        const item0 = modal.blocks.find(b => b.block_id === 'yesterday_item_0');
+        const item1 = modal.blocks.find(b => b.block_id === 'yesterday_item_1');
+
+        expect(item0?.accessory?.initial_option?.value).toBe('continue');
+        expect(item1?.accessory?.initial_option?.value).toBe('continue');
+      });
+
+      it('defaults all items to "Carry over" when externallyCompleted is empty array', () => {
+        const yesterday: YesterdayData = {
+          plans: ['Task A', 'Task B'],
+          completed: [],
+          incomplete: [],
+        };
+
+        const modal = buildStandupModal(
+          'daily-il',
+          yesterday,
+          [],
+          undefined,
+          undefined,
+          'today',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          []
+        );
+
+        const item0 = modal.blocks.find(b => b.block_id === 'yesterday_item_0');
+        const item1 = modal.blocks.find(b => b.block_id === 'yesterday_item_1');
+
+        expect(item0?.accessory?.initial_option?.value).toBe('continue');
+        expect(item1?.accessory?.initial_option?.value).toBe('continue');
+      });
+
+      it('matches exactly on text (case-sensitive)', () => {
+        const yesterday: YesterdayData = {
+          plans: ['Fix Bug', 'fix bug'],
+          completed: [],
+          incomplete: [],
+        };
+
+        const externallyCompleted: ExternalCompletion[] = [
+          { text: 'Fix Bug', externalType: 'linear', externalId: 'issue-1' },
+        ];
+
+        const modal = buildStandupModal(
+          'daily-il',
+          yesterday,
+          [],
+          undefined,
+          undefined,
+          'today',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          externallyCompleted
+        );
+
+        const item0 = modal.blocks.find(b => b.block_id === 'yesterday_item_0');
+        const item1 = modal.blocks.find(b => b.block_id === 'yesterday_item_1');
+
+        // Exact match
+        expect(item0?.accessory?.initial_option?.value).toBe('done');
+        // No match (different case)
+        expect(item1?.accessory?.initial_option?.value).toBe('continue');
+      });
+
+      it('handles multiple externally completed items', () => {
+        const yesterday: YesterdayData = {
+          plans: ['Item 1', 'Item 2', 'Item 3', 'Item 4'],
+          completed: [],
+          incomplete: [],
+        };
+
+        const externallyCompleted: ExternalCompletion[] = [
+          { text: 'Item 1', externalType: 'linear', externalId: 'id-1' },
+          { text: 'Item 2', externalType: 'linear', externalId: 'id-2' },
+          { text: 'Item 4', externalType: 'github', externalId: 'id-4' },
+        ];
+
+        const modal = buildStandupModal(
+          'daily-il',
+          yesterday,
+          [],
+          undefined,
+          undefined,
+          'today',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          externallyCompleted
+        );
+
+        const item0 = modal.blocks.find(b => b.block_id === 'yesterday_item_0');
+        const item1 = modal.blocks.find(b => b.block_id === 'yesterday_item_1');
+        const item2 = modal.blocks.find(b => b.block_id === 'yesterday_item_2');
+        const item3 = modal.blocks.find(b => b.block_id === 'yesterday_item_3');
+
+        expect(item0?.accessory?.initial_option?.value).toBe('done');
+        expect(item1?.accessory?.initial_option?.value).toBe('done');
+        expect(item2?.accessory?.initial_option?.value).toBe('continue'); // Item 3 not in list
+        expect(item3?.accessory?.initial_option?.value).toBe('done');
+      });
+    });
+
+    describe('Linear issue teamId encoding', () => {
+      it('encodes value as teamId:issueId when teamId is present', () => {
+        const linearIssues: LinearIssue[] = [
+          {
+            id: 'issue-abc',
+            identifier: 'ENG-123',
+            title: 'Fix bug',
+            state: { name: 'In Progress', type: 'started' },
+            priority: 1,
+            url: 'https://linear.app/issue/ENG-123',
+            teamId: 'team-xyz',
+          },
+        ];
+
+        const modal = buildStandupModal(
+          'daily-il',
+          null,
+          [],
+          undefined,
+          undefined,
+          'today',
+          undefined,
+          linearIssues
+        );
+
+        const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
+        const option = linearBlock?.element?.options?.[0];
+
+        expect(option?.value).toBe('team-xyz:issue-abc');
+      });
+
+      it('encodes value as issueId only when teamId is absent', () => {
+        const linearIssues: LinearIssue[] = [
+          {
+            id: 'issue-abc',
+            identifier: 'ENG-123',
+            title: 'Fix bug',
+            state: { name: 'In Progress', type: 'started' },
+            priority: 1,
+            url: 'https://linear.app/issue/ENG-123',
+            // No teamId
+          },
+        ];
+
+        const modal = buildStandupModal(
+          'daily-il',
+          null,
+          [],
+          undefined,
+          undefined,
+          'today',
+          undefined,
+          linearIssues
+        );
+
+        const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
+        const option = linearBlock?.element?.options?.[0];
+
+        expect(option?.value).toBe('issue-abc');
+      });
+
+      it('handles mix of issues with and without teamId', () => {
+        const linearIssues: LinearIssue[] = [
+          {
+            id: 'issue-1',
+            identifier: 'ENG-100',
+            title: 'With team',
+            state: { name: 'Todo', type: 'unstarted' },
+            priority: 1,
+            url: 'https://linear.app/issue/ENG-100',
+            teamId: 'team-a',
+          },
+          {
+            id: 'issue-2',
+            identifier: 'ENG-101',
+            title: 'Without team',
+            state: { name: 'Todo', type: 'unstarted' },
+            priority: 1,
+            url: 'https://linear.app/issue/ENG-101',
+            // No teamId
+          },
+          {
+            id: 'issue-3',
+            identifier: 'ENG-102',
+            title: 'Another with team',
+            state: { name: 'Todo', type: 'unstarted' },
+            priority: 1,
+            url: 'https://linear.app/issue/ENG-102',
+            teamId: 'team-b',
+          },
+        ];
+
+        const modal = buildStandupModal(
+          'daily-il',
+          null,
+          [],
+          undefined,
+          undefined,
+          'today',
+          undefined,
+          linearIssues
+        );
+
+        const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
+        const options = linearBlock?.element?.options as any[];
+
+        expect(options[0].value).toBe('team-a:issue-1');
+        expect(options[1].value).toBe('issue-2');
+        expect(options[2].value).toBe('team-b:issue-3');
+      });
+
+      it('handles empty string teamId as absent', () => {
+        const linearIssues: LinearIssue[] = [
+          {
+            id: 'issue-1',
+            identifier: 'ENG-100',
+            title: 'Empty team',
+            state: { name: 'Todo', type: 'unstarted' },
+            priority: 1,
+            url: 'https://linear.app/issue/ENG-100',
+            teamId: '',
+          },
+        ];
+
+        const modal = buildStandupModal(
+          'daily-il',
+          null,
+          [],
+          undefined,
+          undefined,
+          'today',
+          undefined,
+          linearIssues
+        );
+
+        const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
+        const option = linearBlock?.element?.options?.[0];
+
+        // Empty string is falsy, so should use issueId only
+        expect(option?.value).toBe('issue-1');
+      });
     });
   });
 });

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -18,6 +18,7 @@ vi.mock('../lib/slack', () => ({
 
 import { buildStandupModal, YesterdayData } from '../lib/modal';
 import type { LinearIssue } from '../lib/linear';
+import type { UserPRData, GitHubPR } from '../lib/github';
 
 describe('modal builder', () => {
   describe('buildStandupModal', () => {
@@ -480,6 +481,115 @@ describe('modal builder', () => {
 
       expect(metadata.linearIssueMap).toBeUndefined();
       expect(metadata.prMap).toBeUndefined();
+    });
+
+    it('filters out Linear issues that already appear in yesterday plans', () => {
+      const yesterday: YesterdayData = {
+        plans: ['[ENG-123] Fix authentication bug', 'Write unit tests'],
+        completed: [],
+        incomplete: [],
+      };
+      const linearIssues: LinearIssue[] = [
+        {
+          id: 'issue-1',
+          identifier: 'ENG-123',
+          title: 'Fix authentication bug',
+          state: { name: 'In Progress', type: 'started' },
+          priority: 1,
+          url: 'https://linear.app/issue/ENG-123',
+        },
+        {
+          id: 'issue-2',
+          identifier: 'ENG-456',
+          title: 'New feature',
+          state: { name: 'Todo', type: 'unstarted' },
+          priority: 2,
+          url: 'https://linear.app/issue/ENG-456',
+        },
+      ];
+
+      const modal = buildStandupModal(
+        'daily-il', yesterday, [], undefined, undefined, 'today', undefined, linearIssues
+      );
+
+      const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
+      expect(linearBlock).toBeDefined();
+      // Only ENG-456 should remain (ENG-123 is in yesterday's plans)
+      expect(linearBlock?.element?.options).toHaveLength(1);
+      expect((linearBlock?.element?.options as any[])[0].value).toBe('issue-2');
+    });
+
+    it('filters out GitHub PRs that already appear in yesterday plans', () => {
+      const yesterday: YesterdayData = {
+        plans: ['[my-repo#42] Fix typo', 'Regular task'],
+        completed: [],
+        incomplete: [],
+      };
+      const prData: UserPRData = {
+        reviewRequests: [{
+          number: 99, title: 'New PR', url: 'https://github.com/org/other-repo/pull/99',
+          author: 'alice', reviewsNeeded: 1, requestedReviewers: [], createdAt: '', updatedAt: '', draft: false,
+        }],
+        awaitingReview: [{
+          number: 42, title: 'Fix typo', url: 'https://github.com/org/my-repo/pull/42',
+          author: 'me', reviewsNeeded: 1, requestedReviewers: [], createdAt: '', updatedAt: '', draft: false,
+        }],
+        readyToMerge: [],
+        draftPRs: [],
+      };
+
+      const modal = buildStandupModal(
+        'daily-il', yesterday, [], undefined, undefined, 'today', undefined, undefined, prData
+      );
+
+      // my-repo#42 should be filtered out of my_prs (awaitingReview)
+      const myPrsBlock = modal.blocks.find(b => b.block_id === 'my_prs');
+      expect(myPrsBlock).toBeUndefined(); // no PRs left after filtering
+
+      // other-repo#99 should still show in review_requests
+      const reviewBlock = modal.blocks.find(b => b.block_id === 'review_requests');
+      expect(reviewBlock).toBeDefined();
+      expect(reviewBlock?.element?.options).toHaveLength(1);
+    });
+
+    it('hides Linear block entirely when all issues are filtered out', () => {
+      const yesterday: YesterdayData = {
+        plans: ['[ENG-100] Only issue'],
+        completed: [],
+        incomplete: [],
+      };
+      const linearIssues: LinearIssue[] = [
+        {
+          id: 'issue-1', identifier: 'ENG-100', title: 'Only issue',
+          state: { name: 'In Progress', type: 'started' }, priority: 1,
+          url: 'https://linear.app/issue/ENG-100',
+        },
+      ];
+
+      const modal = buildStandupModal(
+        'daily-il', yesterday, [], undefined, undefined, 'today', undefined, linearIssues
+      );
+
+      const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
+      expect(linearBlock).toBeUndefined();
+    });
+
+    it('does not filter integration items when there are no yesterday plans', () => {
+      const linearIssues: LinearIssue[] = [
+        {
+          id: 'issue-1', identifier: 'ENG-123', title: 'Fix bug',
+          state: { name: 'In Progress', type: 'started' }, priority: 1,
+          url: 'https://linear.app/issue/ENG-123',
+        },
+      ];
+
+      const modal = buildStandupModal(
+        'daily-il', null, [], undefined, undefined, 'today', undefined, linearIssues
+      );
+
+      const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
+      expect(linearBlock).toBeDefined();
+      expect(linearBlock?.element?.options).toHaveLength(1);
     });
 
     it('does not include Linear block when no issues provided', () => {


### PR DESCRIPTION
## Summary

- **External → Omdim**: On modal open, detect Linear issues completed and GitHub PRs merged since last standup. Auto-default their dropdown to "Done" — no manual status updates for work already finished externally.
- **Omdim → Linear**: When a user marks a Linear-linked item as "Done", write back to Linear by transitioning the issue to the team's completed workflow state (fire-and-forget, non-blocking).
- **Tracking**: `work_items` now stores `external_type` and `external_id` columns to enable round-trip sync without extra API calls.

### Architecture

- All sync checks run **in parallel** with existing Linear/GitHub fetches inside `Promise.all` — no added latency to modal open
- `checkExternalCompletions()` is best-effort: failures are caught and logged, standup always opens normally
- Linear write-back runs inside `processSubmission` (already in `ctx.waitUntil`), never blocks Slack's response
- External IDs encoded in checkbox `value` attributes — no `private_metadata` changes (respects 3000 char limit)

### Files changed

| File | Changes |
|------|---------|
| `schema.sql` | `external_type`, `external_id` columns + index |
| `lib/db.ts` | Updated `WorkItem`, `createWorkItems`; added `getPendingExternalItems` |
| `lib/linear.ts` | `teamId` on `LinearIssue`; `checkIssuesCompleted`, `fetchTeamDoneStateId`, `transitionIssueToDone` |
| `lib/github.ts` | `checkPRsMerged`, `parsePRExternalId` |
| `lib/modal.ts` | `externallyCompleted` param; auto-default dropdown; `teamId:issueId` encoding |
| `lib/handlers/interactions.ts` | `checkExternalCompletions`; parallel fetch; external ref threading; Linear write-back |
| `tests/*` | 34 new tests across linear, github, modal |

## Test plan

- [x] `npm test` — 274 tests pass (240 existing + 34 new), zero regressions
- [ ] Manual: submit standup selecting a Linear ticket → verify `work_items` has `external_type='linear'`, `external_id='teamId:issueId'`
- [ ] Manual: complete that issue in Linear → open next standup → verify dropdown defaults to "Done"
- [ ] Manual: submit with it marked "Done" → verify Linear issue transitions to completed state
- [ ] Manual: same flow for GitHub PRs (merge externally → auto-detected as done)
- [ ] Manual: disable Linear token → verify standup still opens normally (no crash, no external hints)