### PR TITLE
feat: blocker streaks & unplanned overload alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Type check
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test:run

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,7 +3,7 @@
  * Routes requests to appropriate handlers
  */
 
-import { loadConfig, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems } from '../lib/config';
+import { loadConfig, loadConfigOverrides, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems, isDailyEnabled } from '../lib/config';
 import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
 import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate } from '../lib/db';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
@@ -89,6 +89,7 @@ export default {
     if (cronPattern === '*/30 * * * *') {
       console.log('Running prompt cron job');
       const db = getDb(env.DATABASE_URL);
+      await loadConfigOverrides(db);
 
       // Run prompt cron (send DM prompts to users)
       const promptStats = await runPromptCron(db, env.SLACK_BOT_TOKEN);
@@ -168,6 +169,7 @@ async function handleSlackCommands(request: Request, env: Env): Promise<Response
 
   const payload = parseCommandPayload(body);
   const db = getDb(env.DATABASE_URL);
+  await loadConfigOverrides(db);
 
   // Handle /daily command separately
   if (payload.command === '/daily') {
@@ -241,6 +243,7 @@ async function handleSlackInteractions(request: Request, env: Env, ctx: Executio
   console.log('Interaction:', { type: payload.type, user: payload.user.id });
 
   const db = getDb(env.DATABASE_URL);
+  await loadConfigOverrides(db);
   const result = await handleInteraction(payload, {
     db,
     slackToken: env.SLACK_BOT_TOKEN,
@@ -301,6 +304,7 @@ async function handleSlackEvents(request: Request, env: Env): Promise<Response> 
     // Handle app_home_opened event
     if (event.type === 'app_home_opened') {
       const db = getDb(env.DATABASE_URL);
+      await loadConfigOverrides(db);
       await handleAppHomeOpened(event, {
         db,
         slackToken: env.SLACK_BOT_TOKEN,
@@ -325,6 +329,7 @@ async function handlePromptCron(url: URL, env: Env): Promise<Response> {
   const force = url.searchParams.get('force') === 'true';
 
   const db = getDb(env.DATABASE_URL);
+  await loadConfigOverrides(db);
   const stats = await runPromptCron(db, env.SLACK_BOT_TOKEN, force);
 
   return new Response(JSON.stringify({
@@ -395,6 +400,8 @@ async function handleDigestCron(url: URL, env: Env): Promise<Response> {
     return new Response('Invalid period. Use: daily, weekly, 4-week', { status: 400 });
   }
 
+  const db = getDb(env.DATABASE_URL);
+  await loadConfigOverrides(db);
   const result = await runDigestCron(env, period);
 
   return new Response(JSON.stringify({

--- a/api/index.ts
+++ b/api/index.ts
@@ -12,7 +12,7 @@ import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserD
 import { handleCommand, handleDaily } from '../lib/handlers/commands';
 import { handleInteraction, InteractionPayload } from '../lib/handlers/interactions';
 import { handleAppHomeOpened, AppHomeOpenedEvent } from '../lib/handlers/home';
-import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics, OOOInfo } from '../lib/format';
+import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics, OOOInfo, formatTeamSummary } from '../lib/format';
 
 // ============================================================================
 // Types
@@ -499,6 +499,27 @@ async function runDigestCronUnified(env: Env): Promise<{
           await postMessage(env.SLACK_BOT_TOKEN, daily.channel, oooText);
         } catch (err) {
           console.error(`Failed to post OOO notice to channel for "${daily.name}":`, err);
+        }
+      }
+
+      // Post team summary to channel (opt-in per-daily, workdays only)
+      if (isWorkdayToday && daily.team_summary) {
+        try {
+          const todaySubs = await getSubmissionsInRange(db, daily.name, todayStr, todayStr);
+          if (todaySubs.length > 0) {
+            const githubCfg = getGitHubConfig(daily);
+            const summaryText = formatTeamSummary({
+              dailyName: daily.name,
+              channel: daily.channel,
+              submissions: todaySubs,
+              githubOrg: githubCfg?.org,
+            });
+            if (summaryText) {
+              await postMessage(env.SLACK_BOT_TOKEN, daily.channel, summaryText);
+            }
+          }
+        } catch (err) {
+          console.error(`Failed to post team summary for "${daily.name}":`, err);
         }
       }
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -4,15 +4,15 @@
  */
 
 import { loadConfig, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser } from '../lib/config';
-import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks } from '../lib/slack';
-import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks } from '../lib/db';
+import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
+import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate } from '../lib/db';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
 import { fetchTeamCycleData, TeamLinearData, CycleProgress } from '../lib/linear';
 import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate } from '../lib/prompt';
 import { handleCommand, handleDaily } from '../lib/handlers/commands';
 import { handleInteraction, InteractionPayload } from '../lib/handlers/interactions';
 import { handleAppHomeOpened, AppHomeOpenedEvent } from '../lib/handlers/home';
-import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics } from '../lib/format';
+import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics, OOOInfo } from '../lib/format';
 
 // ============================================================================
 // Types
@@ -476,6 +476,28 @@ async function runDigestCronUnified(env: Env): Promise<{
         errors += weeklyResult.errors;
       }
 
+      // Post OOO notice to daily channel for users whose OOO starts today
+      const todayStr = formatDate(new Date());
+      const oooStarting = await getOOOStartingOnDate(db, daily.name, todayStr);
+      if (oooStarting.length > 0) {
+        const formatShortDate = (d: string) => {
+          const date = new Date(d + 'T00:00:00');
+          return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+        };
+        const oooLines = oooStarting.map(r => {
+          const back = r.start_date === r.end_date
+            ? 'back tomorrow'
+            : `back ${formatShortDate(r.end_date)}`;
+          return `<@${r.slack_user_id}> (${back})`;
+        });
+        const oooText = `🏖️ *Out today:* ${oooLines.join(' · ')}`;
+        try {
+          await postMessage(env.SLACK_BOT_TOKEN, daily.channel, oooText);
+        } catch (err) {
+          console.error(`Failed to post OOO notice to channel for "${daily.name}":`, err);
+        }
+      }
+
       processedDailies.push(daily.name);
     } catch (err) {
       console.error(`Failed to process digests for "${daily.name}":`, err);
@@ -663,6 +685,15 @@ async function sendDigestToManagers(
     }
   }
 
+  // Fetch OOO data for daily digest
+  let oooToday: OOOInfo[] | undefined;
+  if (period === 'daily') {
+    const oooRecords = await getActiveOOOForDaily(db, daily.name, endDate);
+    if (oooRecords.length > 0) {
+      oooToday = oooRecords.map(r => ({ slackUserId: r.slack_user_id, endDate: r.end_date }));
+    }
+  }
+
   const digestText = formatManagerDigest({
     dailyName: daily.name,
     period,
@@ -672,6 +703,7 @@ async function sendDigestToManagers(
     stats,
     totalWorkdays,
     missingToday,
+    oooToday,
     bottlenecks,
     dropStats,
     rankings,

--- a/api/index.ts
+++ b/api/index.ts
@@ -8,7 +8,7 @@ import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, po
 import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate } from '../lib/db';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
 import { fetchTeamCycleData, TeamLinearData, CycleProgress } from '../lib/linear';
-import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate } from '../lib/prompt';
+import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate, isWorkday, getDateInTimezone } from '../lib/prompt';
 import { handleCommand, handleDaily } from '../lib/handlers/commands';
 import { handleInteraction, InteractionPayload } from '../lib/handlers/interactions';
 import { handleAppHomeOpened, AppHomeOpenedEvent } from '../lib/handlers/home';
@@ -463,10 +463,14 @@ async function runDigestCronUnified(env: Env): Promise<{
     }
 
     try {
-      // Always send daily digest
-      const dailyResult = await sendDigestToManagers(env, db, daily, managers, schedule, 'daily');
-      dailySent += dailyResult.sent;
-      errors += dailyResult.errors;
+      // Only send daily digest on workdays (check in schedule timezone)
+      const localNow = schedule.timezone ? getDateInTimezone(schedule.timezone) : new Date();
+      const isWorkdayToday = isWorkday(schedule.days, localNow);
+      if (isWorkdayToday) {
+        const dailyResult = await sendDigestToManagers(env, db, daily, managers, schedule, 'daily');
+        dailySent += dailyResult.sent;
+        errors += dailyResult.errors;
+      }
 
       // Check if today is the weekly digest day for this daily
       const weeklyDay = getWeeklyDigestDay(daily);
@@ -476,9 +480,9 @@ async function runDigestCronUnified(env: Env): Promise<{
         errors += weeklyResult.errors;
       }
 
-      // Post OOO notice to daily channel for users whose OOO starts today
+      // Post OOO notice to daily channel for users whose OOO starts today (workdays only)
       const todayStr = formatDate(new Date());
-      const oooStarting = await getOOOStartingOnDate(db, daily.name, todayStr);
+      const oooStarting = isWorkdayToday ? await getOOOStartingOnDate(db, daily.name, todayStr) : [];
       if (oooStarting.length > 0) {
         const formatShortDate = (d: string) => {
           const date = new Date(d + 'T00:00:00');

--- a/api/index.ts
+++ b/api/index.ts
@@ -5,7 +5,7 @@
 
 import { loadConfig, loadConfigOverrides, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems, isDailyEnabled } from '../lib/config';
 import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
-import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate } from '../lib/db';
+import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate, getBlockerStreaks, getUnplannedOverload } from '../lib/db';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
 import { fetchTeamCycleData, TeamLinearData, CycleProgress } from '../lib/linear';
 import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate, isWorkday, getDateInTimezone } from '../lib/prompt';
@@ -582,6 +582,8 @@ async function sendDigestToManagers(
   const threshold = getBottleneckThreshold(daily);
   const bottlenecks = await getBottleneckItems(db, daily.name, threshold);
   const dropStats = await getHighDropUsers(db, daily.name, startDate, endDate, 30);
+  const blockerStreaks = await getBlockerStreaks(db, daily.name, startDate, endDate);
+  const unplannedOverloads = await getUnplannedOverload(db, daily.name, startDate, endDate, 70);
 
   // Get rankings (only for weekly and 4-week)
   let rankings;
@@ -745,6 +747,8 @@ async function sendDigestToManagers(
     teamLinearData,
     cycleProgress,
     maxPlanItems: getMaxPlanItems(daily.name),
+    blockerStreaks,
+    unplannedOverloads,
   });
 
   // Build bottleneck blocks with snooze buttons (only if there are bottlenecks)

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,7 +3,7 @@
  * Routes requests to appropriate handlers
  */
 
-import { loadConfig, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser } from '../lib/config';
+import { loadConfig, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems } from '../lib/config';
 import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
 import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate } from '../lib/db';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
@@ -716,6 +716,7 @@ async function sendDigestToManagers(
     teamPRData,
     teamLinearData,
     cycleProgress,
+    maxPlanItems: getMaxPlanItems(daily.name),
   });
 
   // Build bottleneck blocks with snooze buttons (only if there are bottlenecks)

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -118,6 +118,41 @@ const EMPTY_CONFIG: Config = {
 };
 
 // ============================================================================
+// Config Overrides (DB-backed, takes precedence over YAML)
+// ============================================================================
+
+let overridesCache: Map<string, unknown> | null = null;
+
+function overrideKey(scope: string, key: string): string {
+  return `${scope}::${key}`;
+}
+
+export async function loadConfigOverrides(db: { query: <T>(sql: string, params?: unknown[]) => Promise<T[]> }): Promise<void> {
+  const rows = await db.query<{ scope: string; key: string; value: unknown }>(
+    `SELECT scope, key, value FROM config_overrides`
+  );
+  overridesCache = new Map();
+  for (const row of rows) {
+    overridesCache.set(overrideKey(row.scope, row.key), row.value);
+  }
+}
+
+export function getOverride<T = unknown>(scope: string, key: string): T | undefined {
+  if (!overridesCache) return undefined;
+  return overridesCache.get(overrideKey(scope, key)) as T | undefined;
+}
+
+export function isDailyEnabled(dailyName: string): boolean {
+  const override = getOverride<boolean>(dailyName, 'enabled');
+  if (override !== undefined) return override;
+  return true;
+}
+
+export function clearOverridesCache(): void {
+  overridesCache = null;
+}
+
+// ============================================================================
 // Config Loading
 // ============================================================================
 
@@ -202,6 +237,10 @@ export function isAdmin(userId: string): boolean {
 }
 
 export function getDailies(): Daily[] {
+  return loadConfig().dailies.filter(d => isDailyEnabled(d.name));
+}
+
+export function getAllDailiesIncludingDisabled(): Daily[] {
   return loadConfig().dailies;
 }
 
@@ -272,10 +311,11 @@ export function getMaxPlanItems(dailyName?: string): number {
   return config.max_plan_items ?? 5;
 }
 
-// Clear cache (useful for testing or hot reload)
+// Clear all caches (useful for testing or hot reload)
 export function clearConfigCache(): void {
   cachedConfig = null;
   configError = null;
+  overridesCache = null;
 }
 
 // ============================================================================

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -231,9 +231,21 @@ export function getSchedule(name: string): Schedule | undefined {
   return config.schedules.find((s) => s.name === name);
 }
 
-export function isAdmin(userId: string): boolean {
+export function isSuperAdmin(userId: string): boolean {
   const config = loadConfig();
   return config.admins.includes(userId);
+}
+
+export function isAdmin(userId: string): boolean {
+  if (isSuperAdmin(userId)) return true;
+  const dbAdmins = getOverride<string[]>('global', 'admins');
+  return dbAdmins?.includes(userId) ?? false;
+}
+
+export function getAdmins(): { superAdmins: string[]; dbAdmins: string[] } {
+  const config = loadConfig();
+  const dbAdmins = getOverride<string[]>('global', 'admins') ?? [];
+  return { superAdmins: config.admins, dbAdmins };
 }
 
 export function getDailies(): Daily[] {
@@ -248,17 +260,16 @@ export function getSchedules(): Schedule[] {
   return loadConfig().schedules;
 }
 
-/** Get all managers for a daily (supports both legacy single manager and new managers array) */
+/** Get all managers for a daily (YAML + DB, deduplicated) */
 export function getDailyManagers(daily: Daily): string[] {
-  // New format takes precedence
+  const yamlManagers: string[] = [];
   if (daily.managers && daily.managers.length > 0) {
-    return daily.managers;
+    yamlManagers.push(...daily.managers);
+  } else if (daily.manager) {
+    yamlManagers.push(daily.manager);
   }
-  // Fallback to legacy single manager
-  if (daily.manager) {
-    return [daily.manager];
-  }
-  return [];
+  const dbManagers = getOverride<string[]>(daily.name, 'managers') ?? [];
+  return [...new Set([...yamlManagers, ...dbManagers])];
 }
 
 /** Get all dailies that have at least one manager configured */

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -81,6 +81,8 @@ const DailySchema = z.object({
   integrations: IntegrationsSchema.optional(),
   // Reminder: how many minutes before daily to send channel reminder (0 = disabled, default 90)
   reminder_minutes_before: z.number().min(0).optional(),
+  // Per-daily plan-size warning threshold (overrides global max_plan_items)
+  max_plan_items: z.number().int().min(0).optional(),
 });
 
 const ConfigSchema = z.object({
@@ -258,10 +260,14 @@ export function getDigestTime(): string {
   return loadConfig().digest_time || '14:00';
 }
 
-/** Plan-size soft-warning threshold (0 = disabled, default 5). */
-export function getMaxPlanItems(): number {
-  const value = loadConfig().max_plan_items;
-  return value ?? 5;
+/** Plan-size soft-warning threshold (0 = disabled, default 5). Per-daily overrides global. */
+export function getMaxPlanItems(dailyName?: string): number {
+  const config = loadConfig();
+  if (dailyName) {
+    const daily = config.dailies.find(d => d.name === dailyName);
+    if (daily?.max_plan_items !== undefined) return daily.max_plan_items;
+  }
+  return config.max_plan_items ?? 5;
 }
 
 // Clear cache (useful for testing or hot reload)

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -83,6 +83,8 @@ const DailySchema = z.object({
   reminder_minutes_before: z.number().min(0).optional(),
   // Per-daily plan-size warning threshold (overrides global max_plan_items)
   max_plan_items: z.number().int().min(0).optional(),
+  // Post a consolidated team summary to the daily channel at digest time
+  team_summary: z.boolean().optional(),
 });
 
 const ConfigSchema = z.object({

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -240,6 +240,55 @@ export async function setDmStandupPreference(
 }
 
 // ============================================================================
+// User Settings
+// ============================================================================
+
+export interface UserSettings {
+  dmStandup: boolean;
+  maxItems: number | null;
+  stalePrDays: number | null;
+  linearTeamFilter: string[] | null;
+}
+
+export async function getUserSettings(
+  db: DbClient,
+  slackUserId: string
+): Promise<UserSettings> {
+  const result = await db.query<{
+    dm_standup: boolean | null;
+    max_items: number | null;
+    stale_pr_days: number | null;
+    linear_team_filter: string | null;
+  }>(
+    `SELECT dm_standup, max_items, stale_pr_days, linear_team_filter
+     FROM slack_users WHERE slack_user_id = $1`,
+    [slackUserId]
+  );
+  const row = result[0];
+  return {
+    dmStandup: row?.dm_standup ?? false,
+    maxItems: row?.max_items ?? null,
+    stalePrDays: row?.stale_pr_days ?? null,
+    linearTeamFilter: row?.linear_team_filter ? row.linear_team_filter.split(',').map(s => s.trim()) : null,
+  };
+}
+
+export async function updateUserSetting(
+  db: DbClient,
+  slackUserId: string,
+  key: 'max_items' | 'stale_pr_days' | 'linear_team_filter',
+  value: number | string | null
+): Promise<void> {
+  await db.query(
+    `INSERT INTO slack_users (slack_user_id, ${key}, tz_offset)
+     VALUES ($1, $2, 0)
+     ON CONFLICT (slack_user_id) DO UPDATE SET
+       ${key} = $3`,
+    [slackUserId, value, value]
+  );
+}
+
+// ============================================================================
 // Work Items (for analytics)
 // ============================================================================
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1343,6 +1343,20 @@ export async function getActiveOOOForDaily(
   );
 }
 
+/** Get OOO records starting on a specific date for a daily (for channel notifications) */
+export async function getOOOStartingOnDate(
+  db: DbClient,
+  dailyName: string,
+  date: string
+): Promise<OOORecord[]> {
+  return db.query<OOORecord>(
+    `SELECT * FROM ooo
+     WHERE daily_name = $1
+       AND start_date = $2`,
+    [dailyName, date]
+  );
+}
+
 // ============================================================================
 // Reminder Log (dedup channel reminders)
 // ============================================================================

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1095,6 +1095,7 @@ export interface PeriodStats {
   participation_rate: number;   // % of possible submissions received
   completion_rate: number;      // % of items completed vs dropped/carried
   blocker_rate: number;         // % of submissions with blockers
+  unplanned_rate: number;       // % of completed items that were unplanned
   total_submissions: number;
   total_participants: number;
   total_items_completed: number;
@@ -1118,12 +1119,14 @@ export async function getPeriodStats(
     total_completed: number;
     total_planned: number;
     blocker_count: number;
+    total_unplanned: number;
   }>(
     `SELECT
        COUNT(s.id) as submission_count,
-       COALESCE(SUM(jsonb_array_length(s.yesterday_completed::jsonb) + jsonb_array_length(s.unplanned::jsonb)), 0) as total_completed,
-       COALESCE(SUM(jsonb_array_length(s.today_plans::jsonb)), 0) as total_planned,
-       SUM(CASE WHEN s.blockers IS NOT NULL AND s.blockers != '' THEN 1 ELSE 0 END) as blocker_count
+       COALESCE(SUM(jsonb_array_length(COALESCE(s.yesterday_completed, '[]')::jsonb) + jsonb_array_length(COALESCE(s.unplanned, '[]')::jsonb)), 0) as total_completed,
+       COALESCE(SUM(jsonb_array_length(COALESCE(s.today_plans, '[]')::jsonb)), 0) as total_planned,
+       SUM(CASE WHEN s.blockers IS NOT NULL AND s.blockers != '' THEN 1 ELSE 0 END) as blocker_count,
+       COALESCE(SUM(jsonb_array_length(COALESCE(s.unplanned, '[]')::jsonb)), 0) as total_unplanned
      FROM submissions s
      WHERE s.daily_name = $1 AND s.date >= $2 AND s.date <= $3`,
     [dailyName, startDate, endDate]
@@ -1152,6 +1155,7 @@ export async function getPeriodStats(
   const totalCompleted = Number(submissionResult[0]?.total_completed) || 0;
   const totalPlanned = Number(submissionResult[0]?.total_planned) || 0;
   const blockerCount = Number(submissionResult[0]?.blocker_count) || 0;
+  const totalUnplanned = Number(submissionResult[0]?.total_unplanned) || 0;
   const participantCount = Number(participantResult[0]?.count) || 0;
   const itemsDone = Number(itemResult[0]?.total_done) || 0;
   const itemsDropped = Number(itemResult[0]?.total_dropped) || 0;
@@ -1174,10 +1178,15 @@ export async function getPeriodStats(
     ? Math.round((totalPlanned / submissionCount) * 10) / 10
     : 0;
 
+  const unplannedRate = totalCompleted > 0
+    ? Math.round((totalUnplanned / totalCompleted) * 100)
+    : 0;
+
   return {
     participation_rate: participationRate,
     completion_rate: completionRate,
     blocker_rate: blockerRate,
+    unplanned_rate: unplannedRate,
     total_submissions: submissionCount,
     total_participants: participantCount,
     total_items_completed: itemsDone,
@@ -1479,4 +1488,135 @@ export async function deleteConfigOverride(
     `DELETE FROM config_overrides WHERE scope = $1 AND key = $2`,
     [scope, key]
   );
+}
+
+// ============================================================================
+// Blocker Streak Tracking
+// ============================================================================
+
+export interface BlockerStreak {
+  slack_user_id: string;
+  current_streak: number;
+  max_streak: number;
+  total_blocker_days: number;
+}
+
+/**
+ * Pure function — computes blocker streaks from ordered submission rows.
+ * current_streak: consecutive blocker days up to (and including) the user's last submission.
+ * max_streak: longest consecutive blocker run in the data.
+ * Only users with at least one blocker day are returned.
+ */
+export function computeBlockerStreaks(
+  rows: Array<{ slack_user_id: string; date: string; has_blocker: boolean }>
+): BlockerStreak[] {
+  const byUser = new Map<string, Array<{ date: string; has_blocker: boolean }>>();
+  for (const row of rows) {
+    if (!byUser.has(row.slack_user_id)) byUser.set(row.slack_user_id, []);
+    byUser.get(row.slack_user_id)!.push({ date: row.date, has_blocker: row.has_blocker });
+  }
+
+  const results: BlockerStreak[] = [];
+
+  for (const [userId, entries] of byUser) {
+    // entries are already ordered by date ASC from the query
+    let maxStreak = 0;
+    let runningStreak = 0;
+    let totalBlockerDays = 0;
+
+    for (const entry of entries) {
+      if (entry.has_blocker) {
+        runningStreak++;
+        totalBlockerDays++;
+        if (runningStreak > maxStreak) maxStreak = runningStreak;
+      } else {
+        runningStreak = 0;
+      }
+    }
+
+    // current_streak is the streak at the tail of the sorted entries
+    const currentStreak = runningStreak;
+
+    if (totalBlockerDays > 0) {
+      results.push({
+        slack_user_id: userId,
+        current_streak: currentStreak,
+        max_streak: maxStreak,
+        total_blocker_days: totalBlockerDays,
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Get blocker streaks for all users in a daily within a date range */
+export async function getBlockerStreaks(
+  db: DbClient,
+  dailyName: string,
+  startDate: string,
+  endDate: string
+): Promise<BlockerStreak[]> {
+  const rows = await db.query<{ slack_user_id: string; date: string; has_blocker: boolean }>(
+    `SELECT slack_user_id, date, (blockers IS NOT NULL AND blockers != '') as has_blocker
+     FROM submissions
+     WHERE daily_name = $1 AND date >= $2 AND date <= $3
+     ORDER BY slack_user_id, date`,
+    [dailyName, startDate, endDate]
+  );
+  return computeBlockerStreaks(rows);
+}
+
+// ============================================================================
+// Unplanned Work Overload Detection
+// ============================================================================
+
+export interface UnplannedOverload {
+  slack_user_id: string;
+  unplanned_count: number;
+  completed_count: number;
+  unplanned_pct: number;
+}
+
+/** Get users whose unplanned work exceeds the given percentage threshold */
+export async function getUnplannedOverload(
+  db: DbClient,
+  dailyName: string,
+  startDate: string,
+  endDate: string,
+  threshold: number = 70
+): Promise<UnplannedOverload[]> {
+  const rows = await db.query<{
+    slack_user_id: string;
+    unplanned_count: number;
+    completed_count: number;
+  }>(
+    `SELECT
+       slack_user_id,
+       COALESCE(SUM(jsonb_array_length(COALESCE(unplanned, '[]')::jsonb)), 0) as unplanned_count,
+       COALESCE(SUM(
+         jsonb_array_length(COALESCE(yesterday_completed, '[]')::jsonb) +
+         jsonb_array_length(COALESCE(unplanned, '[]')::jsonb)
+       ), 0) as completed_count
+     FROM submissions
+     WHERE daily_name = $1 AND date >= $2 AND date <= $3
+     GROUP BY slack_user_id`,
+    [dailyName, startDate, endDate]
+  );
+
+  return rows
+    .map(row => {
+      const unplannedCount = Number(row.unplanned_count) || 0;
+      const completedCount = Number(row.completed_count) || 0;
+      const unplannedPct = completedCount > 0
+        ? Math.round((unplannedCount / completedCount) * 100)
+        : 0;
+      return {
+        slack_user_id: row.slack_user_id,
+        unplanned_count: unplannedCount,
+        completed_count: completedCount,
+        unplanned_pct: unplannedPct,
+      };
+    })
+    .filter(row => row.unplanned_pct >= threshold);
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -207,7 +207,7 @@ export async function getUsersWithLinearLinks(
 // DM Standup Preference
 // ============================================================================
 
-/** Get whether user wants DM copies of standup posts (default: true) */
+/** Get whether user wants DM copies of standup posts (default: false — App Home shows plans) */
 export async function getDmStandupPreference(
   db: DbClient,
   slackUserId: string
@@ -217,11 +217,10 @@ export async function getDmStandupPreference(
       `SELECT dm_standup FROM slack_users WHERE slack_user_id = $1`,
       [slackUserId]
     );
-    // Default to true if no row or null
-    return result[0]?.dm_standup ?? true;
+    // Default to false — App Home is the primary place to review your plan
+    return result[0]?.dm_standup ?? false;
   } catch {
-    // Column may not exist yet (pre-migration) — default to true
-    return true;
+    return false;
   }
 }
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1438,3 +1438,45 @@ export async function recordReminderSent(
     [dailyName, date]
   );
 }
+
+// ============================================================================
+// Config Overrides
+// ============================================================================
+
+export interface ConfigOverride {
+  scope: string;
+  key: string;
+  value: unknown;
+}
+
+export async function getAllConfigOverrides(db: DbClient): Promise<ConfigOverride[]> {
+  return db.query<ConfigOverride>(
+    `SELECT scope, key, value FROM config_overrides ORDER BY scope, key`
+  );
+}
+
+export async function setConfigOverride(
+  db: DbClient,
+  scope: string,
+  key: string,
+  value: unknown,
+  updatedBy?: string
+): Promise<void> {
+  await db.query(
+    `INSERT INTO config_overrides (scope, key, value, updated_by, updated_at)
+     VALUES ($1, $2, $3, $4, NOW())
+     ON CONFLICT (scope, key) DO UPDATE SET value = $3, updated_by = $4, updated_at = NOW()`,
+    [scope, key, JSON.stringify(value), updatedBy]
+  );
+}
+
+export async function deleteConfigOverride(
+  db: DbClient,
+  scope: string,
+  key: string
+): Promise<void> {
+  await db.query(
+    `DELETE FROM config_overrides WHERE scope = $1 AND key = $2`,
+    [scope, key]
+  );
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -998,6 +998,7 @@ export interface BottleneckItem {
   carry_count: number;
   days_pending: number;
   type: 'carry' | 'dropped';
+  status: 'pending' | 'carried' | 'in_progress';
 }
 
 /** Get bottleneck items (carried at/above threshold, not snoozed) */
@@ -1012,6 +1013,7 @@ export async function getBottleneckItems(
        text,
        slack_user_id,
        carry_count,
+       status,
        (CURRENT_DATE - created_date) as days_pending,
        'carry' as type
      FROM work_items

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1161,6 +1161,63 @@ export function formatLinearDigestSection(
 }
 
 // ============================================================================
+// Team Summary Post
+// ============================================================================
+
+export interface TeamSummaryOptions {
+  dailyName: string;
+  channel: string;
+  submissions: Submission[];
+  githubOrg?: string;
+}
+
+export function formatTeamSummary(options: TeamSummaryOptions): string {
+  const { dailyName, channel, submissions, githubOrg } = options;
+  if (submissions.length === 0) return '';
+
+  const lines: string[] = [];
+  lines.push(`📋 *${dailyName} — Team Summary*`);
+  lines.push('');
+
+  const blockers: Array<{ userId: string; text: string }> = [];
+
+  for (const sub of submissions) {
+    const topItems: string[] = [];
+
+    // Pick top 1-2 highest-signal items: blockers first, then today's plans
+    const plans = sub.today_plans || [];
+    for (const item of plans.slice(0, 2)) {
+      topItems.push(enrichItemSource(item, githubOrg));
+    }
+
+    // Build line with message link if available
+    const messageLink = sub.slack_message_ts
+      ? ` <https://slack.com/archives/${channel}/p${sub.slack_message_ts.replace('.', '')}|↗>`
+      : '';
+
+    const summary = topItems.length > 0 ? topItems.join(' · ') : '_no plans_';
+    lines.push(`<@${sub.slack_user_id}>${messageLink}: ${summary}`);
+
+    // Collect blockers
+    if (sub.blockers && sub.blockers.trim()) {
+      for (const line of sub.blockers.split('\n').filter(l => l.trim())) {
+        blockers.push({ userId: sub.slack_user_id, text: line.trim() });
+      }
+    }
+  }
+
+  if (blockers.length > 0) {
+    lines.push('');
+    lines.push('🚧 *Blockers*');
+    for (const b of blockers) {
+      lines.push(`<@${b.userId}>: ${b.text}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -372,6 +372,11 @@ export interface IntegrationStatus {
   linear: boolean;
 }
 
+export interface OOOInfo {
+  slackUserId: string;
+  endDate: string;
+}
+
 export interface DigestOptions {
   dailyName: string;
   period: DigestPeriod;
@@ -381,6 +386,7 @@ export interface DigestOptions {
   stats: TeamMemberStats[];
   totalWorkdays: number;
   missingToday?: string[];
+  oooToday?: OOOInfo[]; // Users currently OOO
   bottlenecks?: BottleneckItem[];
   dropStats?: DropStats[];
   rankings?: TeamMemberRanking[];
@@ -475,6 +481,16 @@ export function formatManagerDigest(options: DigestOptions): string {
   if (period === 'daily' && missingToday && missingToday.length > 0) {
     lines.push('');
     lines.push(`*Not submitted:* ${missingToday.map(u => `<@${u}>`).join(' · ')}`);
+  }
+
+  // OOO users (for daily only)
+  if (period === 'daily' && options.oooToday && options.oooToday.length > 0) {
+    const formatShort = (d: string) => {
+      const date = new Date(d + 'T00:00:00');
+      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    };
+    const oooList = options.oooToday.map(o => `<@${o.slackUserId}> (back ${formatShort(o.endDate)})`).join(' · ');
+    lines.push(`*🏖️ Out today:* ${oooList}`);
   }
 
   // Compact team section

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -395,6 +395,7 @@ export interface DigestOptions {
   teamPRData?: TeamPRData[]; // GitHub PR data for team
   teamLinearData?: TeamLinearData[]; // Linear data for team
   cycleProgress?: CycleProgress | null; // Linear cycle progress
+  maxPlanItems?: number; // Plan-size threshold for over-plan flagging
 }
 
 /**
@@ -505,6 +506,21 @@ export function formatManagerDigest(options: DigestOptions): string {
     }
   }
 
+  // Build over-plan lookup (average plan count per user across submissions)
+  const overPlanMap = new Map<string, number>();
+  if (options.maxPlanItems && options.maxPlanItems > 0) {
+    const planCounts = new Map<string, number[]>();
+    for (const sub of submissions) {
+      const plans = (sub.today_plans?.length || 0) + (sub.yesterday_incomplete?.length || 0) + (sub.yesterday_in_progress?.length || 0);
+      if (!planCounts.has(sub.slack_user_id)) planCounts.set(sub.slack_user_id, []);
+      planCounts.get(sub.slack_user_id)!.push(plans);
+    }
+    for (const [userId, counts] of planCounts) {
+      const avg = counts.reduce((a, b) => a + b, 0) / counts.length;
+      if (avg >= options.maxPlanItems) overPlanMap.set(userId, Math.round(avg));
+    }
+  }
+
   for (const member of stats) {
     const rate = totalWorkdays > 0
       ? Math.round((Number(member.submission_count) / totalWorkdays) * 100)
@@ -521,6 +537,12 @@ export function formatManagerDigest(options: DigestOptions): string {
     const dropRate = dropRateMap.get(member.slack_user_id);
     if (dropRate && dropRate > 30) {
       line += ` — ${dropRate}% drops`;
+    }
+
+    // Flag users who routinely over-plan
+    const avgPlan = overPlanMap.get(member.slack_user_id);
+    if (avgPlan) {
+      line += ` — avg ${avgPlan} plans`;
     }
 
     lines.push(line);

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -5,7 +5,7 @@
  * - Generates daily digests and weekly summaries
  */
 
-import { Submission, ParticipationStats, TeamMemberStats, BottleneckItem, DropStats, TeamMemberRanking, PeriodStats } from './db';
+import { Submission, ParticipationStats, TeamMemberStats, BottleneckItem, DropStats, TeamMemberRanking, PeriodStats, BlockerStreak, UnplannedOverload } from './db';
 import { postMessage, sendDM as slackSendDM, sendDMWithBlocks } from './slack';
 import { UserPRData, GitHubPR, formatPRRef, TeamPRData } from './github';
 import { TeamLinearData, CycleProgress } from './linear';
@@ -401,6 +401,8 @@ export interface DigestOptions {
   teamLinearData?: TeamLinearData[]; // Linear data for team
   cycleProgress?: CycleProgress | null; // Linear cycle progress
   maxPlanItems?: number; // Plan-size threshold for over-plan flagging
+  blockerStreaks?: BlockerStreak[];
+  unplannedOverloads?: UnplannedOverload[];
 }
 
 /**
@@ -459,6 +461,24 @@ export function formatManagerDigest(options: DigestOptions): string {
         actionItems.push(`🔄 <@${item.slack_user_id}>: "${truncate(item.text, 35)}" in progress Day ${item.carry_count}`);
       } else {
         actionItems.push(`🔥 <@${item.slack_user_id}>: "${truncate(item.text, 35)}" stuck ${item.days_pending} days`);
+      }
+    }
+  }
+
+  // Blocker streaks (users blocked 3+ consecutive days)
+  if (options.blockerStreaks) {
+    for (const streak of options.blockerStreaks) {
+      if (streak.current_streak >= 3 && actionItems.length < 6) {
+        actionItems.push(`🚧 <@${streak.slack_user_id}>: blocked ${streak.current_streak} consecutive days`);
+      }
+    }
+  }
+
+  // Unplanned overload (pre-filtered by caller to threshold)
+  if (options.unplannedOverloads) {
+    for (const overload of options.unplannedOverloads) {
+      if (actionItems.length < 6) {
+        actionItems.push(`⚡ <@${overload.slack_user_id}>: ${overload.unplanned_pct}% unplanned work (${overload.unplanned_count}/${overload.completed_count} items)`);
       }
     }
   }
@@ -616,6 +636,8 @@ export interface FullReportOptions {
   bottlenecks?: BottleneckItem[];
   dropStats?: DropStats[];
   trends?: TrendData;
+  blockerStreaks?: BlockerStreak[];
+  unplannedOverloads?: UnplannedOverload[];
 }
 
 /**
@@ -623,7 +645,7 @@ export interface FullReportOptions {
  * Used by /standup report command
  */
 export function formatFullReport(options: FullReportOptions): string {
-  const { dailyName, period, startDate, endDate, submissions, stats, totalWorkdays, bottlenecks, dropStats, trends } = options;
+  const { dailyName, period, startDate, endDate, submissions, stats, totalWorkdays, bottlenecks, dropStats, trends, blockerStreaks, unplannedOverloads } = options;
 
   // Format date range
   const formatShortDate = (d: string) => {
@@ -682,6 +704,21 @@ export function formatFullReport(options: FullReportOptions): string {
     completionMap.set(sub.slack_user_id, existing);
   }
 
+  // Build lookup maps for new data
+  const blockerStreakMap = new Map<string, BlockerStreak>();
+  if (blockerStreaks) {
+    for (const streak of blockerStreaks) {
+      blockerStreakMap.set(streak.slack_user_id, streak);
+    }
+  }
+
+  const unplannedOverloadMap = new Map<string, UnplannedOverload>();
+  if (unplannedOverloads) {
+    for (const overload of unplannedOverloads) {
+      unplannedOverloadMap.set(overload.slack_user_id, overload);
+    }
+  }
+
   // Individual member sections
   for (const member of stats) {
     const userId = member.slack_user_id;
@@ -729,6 +766,18 @@ export function formatFullReport(options: FullReportOptions): string {
       lines.push(`Blockers: 0 days`);
     }
 
+    // Blocker streak
+    const streak = blockerStreakMap.get(userId);
+    if (streak && streak.current_streak >= 3) {
+      lines.push(`🚧 Current blocker streak: ${streak.current_streak} days`);
+    }
+
+    // Unplanned overload
+    const overload = unplannedOverloadMap.get(userId);
+    if (overload) {
+      lines.push(`⚡ Unplanned work: ${overload.unplanned_pct}% (${overload.unplanned_count}/${overload.completed_count} items)`);
+    }
+
     // Stuck items — separate in-progress from carried
     const userBottlenecks = bottleneckMap.get(userId);
     if (userBottlenecks && userBottlenecks.length > 0) {
@@ -772,6 +821,10 @@ export function formatFullReport(options: FullReportOptions): string {
     lines.push(`Completion: ${completionTrend}`);
     const blockerTrend = formatTrendCompact(trends.current.blocker_rate, trends.previous.blocker_rate, false);
     lines.push(`Blockers: ${blockerTrend}`);
+    if (trends.current.unplanned_rate !== undefined) {
+      const unplannedTrend = formatTrendCompact(trends.current.unplanned_rate, trends.previous.unplanned_rate, false);
+      lines.push(`Unplanned work: ${unplannedTrend}`);
+    }
   }
 
   return lines.join('\n');

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -42,6 +42,7 @@ export interface StandupData {
   prData?: UserPRData; // GitHub PR data for integration
   reviewerSlackMap?: Map<string, string>; // GitHub login → Slack user ID
   inProgressCarryCounts?: Record<string, number>; // carry counts for attention warnings
+  githubOrg?: string; // GitHub org for building clickable PR links
 }
 
 // Default field order values
@@ -102,19 +103,21 @@ export function formatStandupBlocks(
 
   const sections: OrderedSection[] = [];
 
+  const enrich = (text: string) => enrichItemSource(text, data.githubOrg);
+
   // Yesterday section - completed, unplanned, and dropped items
   sections.push({
     order: yesterdayOrder,
     render: () => {
       const yesterdayItems: string[] = [];
       for (const item of data.yesterdayCompleted) {
-        yesterdayItems.push(`☑️ ${item}`);
+        yesterdayItems.push(`☑️ ${enrich(item)}`);
       }
       for (const item of data.unplanned) {
         yesterdayItems.push(`☑️ ${item} _(unplanned)_`);
       }
       for (const item of data.yesterdayDropped || []) {
-        yesterdayItems.push(`❌ ${item} _(dropped)_`);
+        yesterdayItems.push(`❌ ${enrich(item)} _(dropped)_`);
       }
       if (yesterdayItems.length === 0) return null;
       return {
@@ -133,17 +136,17 @@ export function formatStandupBlocks(
       for (const item of data.yesterdayInProgress || []) {
         const carryCount = data.inProgressCarryCounts?.[item] || 0;
         const emoji = carryCount >= 3 ? '⚠️' : '🔄';
-        todayItems.push(`${emoji} ${item} _(in progress)_`);
+        todayItems.push(`${emoji} ${enrich(item)} _(in progress)_`);
       }
       for (const item of data.yesterdayIncomplete) {
-        todayItems.push(`⬜ ${item} _(carried over)_`);
+        todayItems.push(`⬜ ${enrich(item)} _(carried over)_`);
       }
       const carryForwardCount = (data.yesterdayInProgress || []).length + data.yesterdayIncomplete.length;
       if (carryForwardCount > 0 && data.todayPlans.length > 0) {
         todayItems.push('───');
       }
       for (const item of data.todayPlans) {
-        todayItems.push(`⬜ ${item}`);
+        todayItems.push(`⬜ ${enrich(item)}`);
       }
       if (todayItems.length === 0) return null;
       return {
@@ -1122,6 +1125,28 @@ export function formatLinearDigestSection(
 // ============================================================================
 // Helpers
 // ============================================================================
+
+/**
+ * Enrich a plan item with a clickable source link when it has an [identifier] prefix.
+ * - `[repo#42] title` → `<https://github.com/…|📦 repo#42> title`
+ * - `[ENG-123] title` → `<https://linear.app/issue/ENG-123|🎫 ENG-123> title`
+ * - no prefix → returned as-is
+ */
+function enrichItemSource(text: string, githubOrg?: string): string {
+  const match = text.match(/^\[([^\]]+)\]\s+(.*)/);
+  if (!match) return text;
+  const [, id, title] = match;
+  if (id.includes('#')) {
+    // GitHub PR: "repo#42"
+    const [repo, num] = id.split('#');
+    const url = githubOrg
+      ? `https://github.com/${githubOrg}/${repo}/pull/${num}`
+      : `#`;
+    return `<${url}|📦 ${id}> ${title}`;
+  }
+  // Linear ticket: "ENG-123"
+  return `<https://linear.app/issue/${id}|🎫 ${id}> ${title}`;
+}
 
 /** Parse JSONB arrays from database (handles both array and string formats) */
 function parseJsonArray(value: string[] | null): string[] {

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -111,10 +111,10 @@ export function formatStandupBlocks(
     render: () => {
       const yesterdayItems: string[] = [];
       for (const item of data.yesterdayCompleted) {
-        yesterdayItems.push(`☑️ ${enrich(item)}`);
+        yesterdayItems.push(`✅ ${enrich(item)}`);
       }
       for (const item of data.unplanned) {
-        yesterdayItems.push(`☑️ ${item} _(unplanned)_`);
+        yesterdayItems.push(`⚡ ${item} _(unplanned)_`);
       }
       for (const item of data.yesterdayDropped || []) {
         yesterdayItems.push(`❌ ${enrich(item)} _(dropped)_`);
@@ -139,14 +139,14 @@ export function formatStandupBlocks(
         todayItems.push(`${emoji} ${enrich(item)} _(in progress)_`);
       }
       for (const item of data.yesterdayIncomplete) {
-        todayItems.push(`⬜ ${enrich(item)} _(carried over)_`);
+        todayItems.push(`➡️ ${enrich(item)} _(carried over)_`);
       }
       const carryForwardCount = (data.yesterdayInProgress || []).length + data.yesterdayIncomplete.length;
       if (carryForwardCount > 0 && data.todayPlans.length > 0) {
         todayItems.push('───');
       }
       for (const item of data.todayPlans) {
-        todayItems.push(`⬜ ${enrich(item)}`);
+        todayItems.push(`🎯 ${enrich(item)}`);
       }
       if (todayItems.length === 0) return null;
       return {

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -135,8 +135,13 @@ export function formatStandupBlocks(
       // In-progress items first
       for (const item of data.yesterdayInProgress || []) {
         const carryCount = data.inProgressCarryCounts?.[item] || 0;
-        const emoji = carryCount >= 3 ? '⚠️' : '🔄';
-        todayItems.push(`${emoji} ${enrich(item)} _(in progress)_`);
+        if (carryCount >= 3) {
+          todayItems.push(`⚠️ ${enrich(item)} _(Day ${carryCount} — needs attention)_`);
+        } else if (carryCount >= 1) {
+          todayItems.push(`🔄 ${enrich(item)} _(Day ${carryCount})_`);
+        } else {
+          todayItems.push(`🔄 ${enrich(item)} _(in progress)_`);
+        }
       }
       for (const item of data.yesterdayIncomplete) {
         todayItems.push(`➡️ ${enrich(item)} _(carried over)_`);
@@ -447,10 +452,14 @@ export function formatManagerDigest(options: DigestOptions): string {
   // Collect all action items
   const actionItems: string[] = [];
 
-  // Stuck items (bottlenecks)
+  // Stuck items (bottlenecks) — distinguish in-progress from carried
   if (bottlenecks && bottlenecks.length > 0) {
     for (const item of bottlenecks.slice(0, 3)) {
-      actionItems.push(`🔥 <@${item.slack_user_id}>: "${truncate(item.text, 35)}" stuck ${item.days_pending} days`);
+      if (item.status === 'in_progress') {
+        actionItems.push(`🔄 <@${item.slack_user_id}>: "${truncate(item.text, 35)}" in progress Day ${item.carry_count}`);
+      } else {
+        actionItems.push(`🔥 <@${item.slack_user_id}>: "${truncate(item.text, 35)}" stuck ${item.days_pending} days`);
+      }
     }
   }
 
@@ -720,16 +729,32 @@ export function formatFullReport(options: FullReportOptions): string {
       lines.push(`Blockers: 0 days`);
     }
 
-    // Stuck items
+    // Stuck items — separate in-progress from carried
     const userBottlenecks = bottleneckMap.get(userId);
     if (userBottlenecks && userBottlenecks.length > 0) {
-      lines.push('');
-      lines.push(`Stuck items:`);
-      for (const item of userBottlenecks.slice(0, 3)) {
-        lines.push(`  🔥 "${truncate(item.text, 40)}" (${item.days_pending} days, carried ${item.carry_count}x)`);
+      const inProgressItems = userBottlenecks.filter(b => b.status === 'in_progress');
+      const carriedItems = userBottlenecks.filter(b => b.status !== 'in_progress');
+
+      if (inProgressItems.length > 0) {
+        lines.push('');
+        lines.push(`In progress — needs attention:`);
+        for (const item of inProgressItems.slice(0, 3)) {
+          lines.push(`  🔄 "${truncate(item.text, 40)}" (Day ${item.carry_count})`);
+        }
+        if (inProgressItems.length > 3) {
+          lines.push(`  _...and ${inProgressItems.length - 3} more_`);
+        }
       }
-      if (userBottlenecks.length > 3) {
-        lines.push(`  _...and ${userBottlenecks.length - 3} more_`);
+
+      if (carriedItems.length > 0) {
+        lines.push('');
+        lines.push(`Stuck items:`);
+        for (const item of carriedItems.slice(0, 3)) {
+          lines.push(`  🔥 "${truncate(item.text, 40)}" (${item.days_pending} days, carried ${item.carry_count}x)`);
+        }
+        if (carriedItems.length > 3) {
+          lines.push(`  _...and ${carriedItems.length - 3} more_`);
+        }
       }
     }
 

--- a/lib/handlers/commands.ts
+++ b/lib/handlers/commands.ts
@@ -4,7 +4,7 @@
  */
 
 import { getDailies, getDaily, getSchedule, isAdmin, isSuperAdmin, getAdmins, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser, clearConfigCache, loadConfigOverrides, isDailyEnabled, getAllDailiesIncludingDisabled, getDailyManagers, getOverride } from '../config';
-import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride, getAllConfigOverrides } from '../db';
+import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride, getAllConfigOverrides, getBlockerStreaks, getUnplannedOverload } from '../db';
 import { formatDailyDigest, formatWeeklySummary, formatManagerDigest, formatFullReport, DigestPeriod, TrendData } from '../format';
 import { fetchLinearIssuesForUser, fetchGitHubPRsForUser } from './interactions';
 import { formatDate, getUserDate, getUserTimezone, sendPromptDM } from '../prompt';
@@ -242,6 +242,9 @@ export async function handleDigest(ctx: CommandContext): Promise<CommandResponse
             missingToday = await getMissingSubmissions(ctx.db, daily.name, endDate);
           }
 
+          const blockerStreaks = await getBlockerStreaks(ctx.db, daily.name, startDate, endDate);
+          const unplannedOverloads = await getUnplannedOverload(ctx.db, daily.name, startDate, endDate, 70);
+
           const digestText = formatManagerDigest({
             dailyName: daily.name,
             period,
@@ -251,6 +254,8 @@ export async function handleDigest(ctx: CommandContext): Promise<CommandResponse
             stats,
             totalWorkdays,
             missingToday,
+            blockerStreaks,
+            unplannedOverloads,
           });
           digestParts.push(digestText);
         } catch (err) {
@@ -309,6 +314,9 @@ export async function handleDigest(ctx: CommandContext): Promise<CommandResponse
       missingToday = await getMissingSubmissions(ctx.db, digestDailyName, endDate);
     }
 
+    const blockerStreaks = await getBlockerStreaks(ctx.db, digestDailyName, startDate, endDate);
+    const unplannedOverloads = await getUnplannedOverload(ctx.db, digestDailyName, startDate, endDate, 70);
+
     const digestText = formatManagerDigest({
       dailyName: digestDailyName,
       period,
@@ -318,6 +326,8 @@ export async function handleDigest(ctx: CommandContext): Promise<CommandResponse
       stats,
       totalWorkdays,
       missingToday,
+      blockerStreaks,
+      unplannedOverloads,
     });
 
     await sendDM(ctx.slackToken, ctx.userId, digestText);
@@ -611,6 +621,9 @@ export async function handleReport(ctx: CommandContext): Promise<CommandResponse
             trends = { current: currentStats, previous: previousStats };
           }
 
+          const blockerStreaks = await getBlockerStreaks(ctx.db, daily.name, startDate, endDate);
+          const unplannedOverloads = await getUnplannedOverload(ctx.db, daily.name, startDate, endDate, 70);
+
           const reportText = formatFullReport({
             dailyName: daily.name,
             period,
@@ -622,6 +635,8 @@ export async function handleReport(ctx: CommandContext): Promise<CommandResponse
             bottlenecks,
             dropStats,
             trends,
+            blockerStreaks,
+            unplannedOverloads,
           });
           reportParts.push(reportText);
         } catch (err) {
@@ -698,6 +713,9 @@ export async function handleReport(ctx: CommandContext): Promise<CommandResponse
       };
     }
 
+    const blockerStreaks = await getBlockerStreaks(ctx.db, reportDailyName, startDate, endDate);
+    const unplannedOverloads = await getUnplannedOverload(ctx.db, reportDailyName, startDate, endDate, 70);
+
     const reportText = formatFullReport({
       dailyName: reportDailyName,
       period,
@@ -709,6 +727,8 @@ export async function handleReport(ctx: CommandContext): Promise<CommandResponse
       bottlenecks,
       dropStats,
       trends,
+      blockerStreaks,
+      unplannedOverloads,
     });
 
     await sendDM(ctx.slackToken, ctx.userId, reportText);

--- a/lib/handlers/commands.ts
+++ b/lib/handlers/commands.ts
@@ -3,8 +3,8 @@
  * Handles: help, prompt, add, remove, list, digest, week, daily
  */
 
-import { getDailies, getDaily, getSchedule, isAdmin, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser, clearConfigCache, loadConfigOverrides, isDailyEnabled, getAllDailiesIncludingDisabled } from '../config';
-import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride } from '../db';
+import { getDailies, getDaily, getSchedule, isAdmin, isSuperAdmin, getAdmins, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser, clearConfigCache, loadConfigOverrides, isDailyEnabled, getAllDailiesIncludingDisabled, getDailyManagers, getOverride } from '../config';
+import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride, getAllConfigOverrides } from '../db';
 import { formatDailyDigest, formatWeeklySummary, formatManagerDigest, formatFullReport, DigestPeriod, TrendData } from '../format';
 import { fetchLinearIssuesForUser, fetchGitHubPRsForUser } from './interactions';
 import { formatDate, getUserDate, getUserTimezone, sendPromptDM } from '../prompt';
@@ -58,6 +58,8 @@ export function handleHelp(): CommandResponse {
     '    _period: `day` (default), `week`, `month`_\n' +
     '    _Use `all` to run for all dailies_\n\n' +
     '*Admin*\n' +
+    '`/standup admin [add|remove|list] [@user]` - Manage admins (super-admin only)\n' +
+    '`/standup manager [add|remove|list] <daily> [@user]` - Manage daily managers\n' +
     '`/standup prompt all <daily>` - Send prompts to all participants\n' +
     '`/standup pause <daily>` - Pause a daily (skip prompts, digests)\n' +
     '`/standup resume <daily>` - Resume a paused daily\n' +
@@ -1134,6 +1136,128 @@ export async function handleLinear(ctx: CommandContext): Promise<CommandResponse
 }
 
 // ============================================================================
+// Admin Management
+// ============================================================================
+
+async function handleAdmin(ctx: CommandContext): Promise<CommandResponse> {
+  const action = ctx.args[1]?.toLowerCase();
+
+  if (action === 'list') {
+    const { superAdmins, dbAdmins } = getAdmins();
+    const lines: string[] = ['*Admins*'];
+    lines.push('');
+    lines.push('*Super-admins* (config):');
+    for (const id of superAdmins) lines.push(`  • <@${id}>`);
+    if (dbAdmins.length > 0) {
+      lines.push('');
+      lines.push('*Admins* (added):');
+      for (const id of dbAdmins) lines.push(`  • <@${id}>`);
+    }
+    return ephemeralResponse(lines.join('\n'));
+  }
+
+  if (!isSuperAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only super-admins (defined in config) can manage admins.');
+  }
+
+  if (action === 'add') {
+    const targetId = parseUserId(ctx.args[2] || '');
+    if (!targetId) return ephemeralResponse('Usage: `/standup admin add @user`');
+    if (isAdmin(targetId)) return ephemeralResponse(`ℹ️ <@${targetId}> is already an admin.`);
+
+    const dbAdmins = getOverride<string[]>('global', 'admins') ?? [];
+    await setConfigOverride(ctx.db, 'global', 'admins', [...dbAdmins, targetId], ctx.userId);
+    await loadConfigOverrides(ctx.db);
+    return ephemeralResponse(`✅ <@${targetId}> is now an admin.`);
+  }
+
+  if (action === 'remove') {
+    const targetId = parseUserId(ctx.args[2] || '');
+    if (!targetId) return ephemeralResponse('Usage: `/standup admin remove @user`');
+    if (isSuperAdmin(targetId)) return ephemeralResponse('❌ Cannot remove a super-admin. Edit config.yaml instead.');
+
+    const dbAdmins = getOverride<string[]>('global', 'admins') ?? [];
+    if (!dbAdmins.includes(targetId)) return ephemeralResponse(`ℹ️ <@${targetId}> is not a DB-added admin.`);
+
+    await setConfigOverride(ctx.db, 'global', 'admins', dbAdmins.filter(id => id !== targetId), ctx.userId);
+    await loadConfigOverrides(ctx.db);
+    return ephemeralResponse(`✅ <@${targetId}> is no longer an admin.`);
+  }
+
+  return ephemeralResponse('Usage: `/standup admin [add|remove|list] [@user]`');
+}
+
+// ============================================================================
+// Manager Management
+// ============================================================================
+
+async function handleManager(ctx: CommandContext): Promise<CommandResponse> {
+  if (!isAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only admins can manage daily managers.');
+  }
+
+  const action = ctx.args[1]?.toLowerCase();
+  const dailyName = ctx.args[2];
+
+  if (action === 'list') {
+    if (!dailyName) return ephemeralResponse('Usage: `/standup manager list <daily>`');
+    const daily = getDaily(dailyName);
+    if (!daily) return ephemeralResponse(`❌ Daily "${dailyName}" not found.`);
+
+    const managers = getDailyManagers(daily);
+    if (managers.length === 0) return ephemeralResponse(`*${dailyName}* has no managers.`);
+
+    const list = managers.map(id => `  • <@${id}>`).join('\n');
+    return ephemeralResponse(`*${dailyName}* managers:\n${list}`);
+  }
+
+  if (action === 'add') {
+    const targetId = parseUserId(ctx.args[3] || '') || parseUserId(dailyName || '');
+    const resolvedDaily = parseUserId(dailyName || '') ? ctx.args[3] : dailyName;
+
+    if (!resolvedDaily || !targetId) {
+      return ephemeralResponse('Usage: `/standup manager add <daily> @user`');
+    }
+
+    const daily = getDaily(resolvedDaily);
+    if (!daily) return ephemeralResponse(`❌ Daily "${resolvedDaily}" not found.`);
+
+    const currentManagers = getDailyManagers(daily);
+    if (currentManagers.includes(targetId)) {
+      return ephemeralResponse(`ℹ️ <@${targetId}> is already a manager of *${resolvedDaily}*.`);
+    }
+
+    const dbManagers = getOverride<string[]>(resolvedDaily, 'managers') ?? [];
+    await setConfigOverride(ctx.db, resolvedDaily, 'managers', [...dbManagers, targetId], ctx.userId);
+    await loadConfigOverrides(ctx.db);
+    return ephemeralResponse(`✅ <@${targetId}> is now a manager of *${resolvedDaily}*. They'll receive digests and reports.`);
+  }
+
+  if (action === 'remove') {
+    const targetId = parseUserId(ctx.args[3] || '') || parseUserId(dailyName || '');
+    const resolvedDaily = parseUserId(dailyName || '') ? ctx.args[3] : dailyName;
+
+    if (!resolvedDaily || !targetId) {
+      return ephemeralResponse('Usage: `/standup manager remove <daily> @user`');
+    }
+
+    const daily = getDaily(resolvedDaily);
+    if (!daily) return ephemeralResponse(`❌ Daily "${resolvedDaily}" not found.`);
+
+    const dbManagers = getOverride<string[]>(resolvedDaily, 'managers') ?? [];
+    if (!dbManagers.includes(targetId)) {
+      return ephemeralResponse(`ℹ️ <@${targetId}> is not a DB-added manager of *${resolvedDaily}*. YAML managers must be removed from config.`);
+    }
+
+    await setConfigOverride(ctx.db, resolvedDaily, 'managers', dbManagers.filter(id => id !== targetId), ctx.userId);
+    await loadConfigOverrides(ctx.db);
+    return ephemeralResponse(`✅ <@${targetId}> is no longer a manager of *${resolvedDaily}*.`);
+  }
+
+  return ephemeralResponse('Usage: `/standup manager [add|remove|list] <daily> [@user]`');
+}
+
+// ============================================================================
 // Mass Prompt (Admin)
 // ============================================================================
 
@@ -1298,6 +1422,10 @@ export async function handleCommand(
       return handleLinear(ctx);
     case 'force-prompt':
       return handleForcePrompt(ctx);
+    case 'admin':
+      return handleAdmin(ctx);
+    case 'manager':
+      return handleManager(ctx);
     case 'config':
       return handleConfigReload(ctx);
     case 'pause':

--- a/lib/handlers/commands.ts
+++ b/lib/handlers/commands.ts
@@ -3,8 +3,8 @@
  * Handles: help, prompt, add, remove, list, digest, week, daily
  */
 
-import { getDailies, getDaily, getSchedule, isAdmin, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser } from '../config';
-import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId } from '../db';
+import { getDailies, getDaily, getSchedule, isAdmin, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser, clearConfigCache, loadConfigOverrides, isDailyEnabled, getAllDailiesIncludingDisabled } from '../config';
+import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride } from '../db';
 import { formatDailyDigest, formatWeeklySummary, formatManagerDigest, formatFullReport, DigestPeriod, TrendData } from '../format';
 import { fetchLinearIssuesForUser, fetchGitHubPRsForUser } from './interactions';
 import { formatDate, getUserDate, getUserTimezone, sendPromptDM } from '../prompt';
@@ -56,7 +56,11 @@ export function handleHelp(): CommandResponse {
     '`/standup digest <daily|all> [period]` - Get team summary (DM)\n' +
     '`/standup report <daily|all> [period]` - Get detailed team report (DM)\n' +
     '    _period: `day` (default), `week`, `month`_\n' +
-    '    _Use `all` to run for all dailies_'
+    '    _Use `all` to run for all dailies_\n\n' +
+    '*Admin*\n' +
+    '`/standup pause <daily>` - Pause a daily (skip prompts, digests)\n' +
+    '`/standup resume <daily>` - Resume a paused daily\n' +
+    '`/standup config reload` - Reload configuration'
   );
 }
 
@@ -121,7 +125,7 @@ export async function handleList(ctx: CommandContext): Promise<CommandResponse> 
 
   // No arg or 'all' → show all dailies with participants
   if (!listDailyName || isAllDailies(listDailyName)) {
-    const dailies = getDailies();
+    const dailies = getAllDailiesIncludingDisabled();
     if (dailies.length === 0) {
       return ephemeralResponse('No dailies configured.');
     }
@@ -132,6 +136,7 @@ export async function handleList(ctx: CommandContext): Promise<CommandResponse> 
         const participants = await getParticipants(ctx.db, daily.name);
         const oooRecords = await getActiveOOOForDaily(ctx.db, daily.name, todayStr);
         const oooUserIds = new Set(oooRecords.map(r => r.slack_user_id));
+        const pausedLabel = !isDailyEnabled(daily.name) ? ' ⏸️' : '';
 
         const userList = participants.length > 0
           ? participants.map(p => {
@@ -139,7 +144,7 @@ export async function handleList(ctx: CommandContext): Promise<CommandResponse> 
               return `<@${p.slack_user_id}>${oooLabel}`;
             }).join(', ')
           : '_no participants_';
-        results.push(`*${daily.name}* (${daily.channel}): ${userList}`);
+        results.push(`*${daily.name}*${pausedLabel} (${daily.channel}): ${userList}`);
       }
       return ephemeralResponse(results.join('\n'));
     } catch (err) {
@@ -1122,6 +1127,77 @@ export async function handleLinear(ctx: CommandContext): Promise<CommandResponse
 }
 
 // ============================================================================
+// Dynamic Configuration Commands
+// ============================================================================
+
+async function handleConfigReload(ctx: CommandContext): Promise<CommandResponse> {
+  if (!isAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only admins can reload config.');
+  }
+
+  clearConfigCache();
+  await loadConfigOverrides(ctx.db);
+
+  const dailies = getAllDailiesIncludingDisabled();
+  const enabledCount = dailies.filter(d => isDailyEnabled(d.name)).length;
+  const disabledCount = dailies.length - enabledCount;
+
+  let msg = `✅ Config reloaded. ${enabledCount} dailies active.`;
+  if (disabledCount > 0) {
+    msg += ` ${disabledCount} paused.`;
+  }
+  return ephemeralResponse(msg);
+}
+
+async function handlePause(ctx: CommandContext): Promise<CommandResponse> {
+  if (!isAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only admins can pause dailies.');
+  }
+
+  const dailyName = ctx.args[1];
+  if (!dailyName) {
+    return ephemeralResponse('Usage: `/standup pause <daily>`');
+  }
+
+  const daily = getDaily(dailyName);
+  if (!daily) {
+    return ephemeralResponse(`❌ Unknown daily: \`${dailyName}\``);
+  }
+
+  if (!isDailyEnabled(dailyName)) {
+    return ephemeralResponse(`ℹ️ \`${dailyName}\` is already paused.`);
+  }
+
+  await setConfigOverride(ctx.db, dailyName, 'enabled', false, ctx.userId);
+  await loadConfigOverrides(ctx.db);
+  return ephemeralResponse(`⏸️ \`${dailyName}\` is now paused. Prompts, digests, and reminders will be skipped.\nUse \`/standup resume ${dailyName}\` to re-enable.`);
+}
+
+async function handleResume(ctx: CommandContext): Promise<CommandResponse> {
+  if (!isAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only admins can resume dailies.');
+  }
+
+  const dailyName = ctx.args[1];
+  if (!dailyName) {
+    return ephemeralResponse('Usage: `/standup resume <daily>`');
+  }
+
+  const daily = getDaily(dailyName);
+  if (!daily) {
+    return ephemeralResponse(`❌ Unknown daily: \`${dailyName}\``);
+  }
+
+  if (isDailyEnabled(dailyName)) {
+    return ephemeralResponse(`ℹ️ \`${dailyName}\` is already active.`);
+  }
+
+  await deleteConfigOverride(ctx.db, dailyName, 'enabled');
+  await loadConfigOverrides(ctx.db);
+  return ephemeralResponse(`▶️ \`${dailyName}\` is now active again. Prompts, digests, and reminders will resume.`);
+}
+
+// ============================================================================
 // Main Router
 // ============================================================================
 
@@ -1166,6 +1242,12 @@ export async function handleCommand(
       return handleLinear(ctx);
     case 'force-prompt':
       return handleForcePrompt(ctx);
+    case 'config':
+      return handleConfigReload(ctx);
+    case 'pause':
+      return handlePause(ctx);
+    case 'resume':
+      return handleResume(ctx);
     default:
       return ephemeralResponse(
         `Unknown command: \`${subcommand}\`\nTry \`/standup help\` for usage.`

--- a/lib/handlers/commands.ts
+++ b/lib/handlers/commands.ts
@@ -58,6 +58,7 @@ export function handleHelp(): CommandResponse {
     '    _period: `day` (default), `week`, `month`_\n' +
     '    _Use `all` to run for all dailies_\n\n' +
     '*Admin*\n' +
+    '`/standup prompt all <daily>` - Send prompts to all participants\n' +
     '`/standup pause <daily>` - Pause a daily (skip prompts, digests)\n' +
     '`/standup resume <daily>` - Resume a paused daily\n' +
     '`/standup config reload` - Reload configuration'
@@ -328,6 +329,12 @@ export async function handleDigest(ctx: CommandContext): Promise<CommandResponse
 /** Send prompt DM with "Open Standup" button */
 export async function handlePrompt(ctx: CommandContext): Promise<CommandResponse> {
   const promptDailyName = ctx.args[1];
+  const massPromptDaily = ctx.args[2];
+
+  // Admin mass-prompt: `/standup prompt all <daily>`
+  if (promptDailyName && isAllDailies(promptDailyName) && massPromptDaily) {
+    return handleMassPrompt(ctx, massPromptDaily);
+  }
 
   try {
     // Get user's dailies
@@ -1124,6 +1131,55 @@ export async function handleLinear(ctx: CommandContext): Promise<CommandResponse
     console.error('Failed to manage Linear link:', err);
     return ephemeralResponse('❌ Failed to manage Linear link. Please try again.');
   }
+}
+
+// ============================================================================
+// Mass Prompt (Admin)
+// ============================================================================
+
+async function handleMassPrompt(ctx: CommandContext, dailyName: string): Promise<CommandResponse> {
+  if (!isAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only admins can send mass prompts.');
+  }
+
+  const daily = getDaily(dailyName);
+  if (!daily) {
+    return ephemeralResponse(`❌ Daily "${dailyName}" not found.`);
+  }
+
+  const participants = await getParticipants(ctx.db, dailyName);
+  if (participants.length === 0) {
+    return ephemeralResponse(`❌ No participants in *${dailyName}*.`);
+  }
+
+  if (!ctx.triggerId) {
+    return ephemeralResponse('❌ Cannot open confirmation dialog. Please try again.');
+  }
+
+  const view = {
+    type: 'modal' as const,
+    callback_id: 'mass_prompt_confirm',
+    private_metadata: JSON.stringify({ dailyName }),
+    title: { type: 'plain_text' as const, text: 'Send Mass Prompt' },
+    submit: { type: 'plain_text' as const, text: 'Send Prompts' },
+    close: { type: 'plain_text' as const, text: 'Cancel' },
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `Send standup prompts to *all ${participants.length} participants* in *${dailyName}*?\n\nEach user will receive a DM with a standup prompt.`,
+        },
+      },
+    ],
+  };
+
+  const opened = await openModal(ctx.slackToken, ctx.triggerId, view);
+  if (!opened) {
+    return ephemeralResponse('❌ Failed to open confirmation dialog.');
+  }
+
+  return ephemeralResponse('Opening confirmation...');
 }
 
 // ============================================================================

--- a/lib/handlers/home.ts
+++ b/lib/handlers/home.ts
@@ -182,7 +182,7 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
               planLines.push(`❌ ~${item.text}~${sourceTag}`);
               break;
             default:
-              planLines.push(`⬜ ${item.text}${sourceTag}`);
+              planLines.push(`🎯 ${item.text}${sourceTag}`);
           }
         }
         blocks.push({

--- a/lib/handlers/home.ts
+++ b/lib/handlers/home.ts
@@ -31,12 +31,19 @@ export interface AppHomeOpenedEvent {
 // Home View Builder
 // ============================================================================
 
+interface PlanItem {
+  text: string;
+  status: 'done' | 'in_progress' | 'carried' | 'planned' | 'dropped';
+  source?: string; // e.g. "PR #123", "LIN-456"
+}
+
 interface DailyStatus {
   dailyName: string;
   todaySubmitted: boolean;
   tomorrowScheduled: boolean;
   submission?: Submission; // Today's submission for stats
   droppedCount?: number; // Items dropped from yesterday
+  planItems?: PlanItem[]; // Today's plan items with status
   prData?: UserPRData; // GitHub PR data if integration enabled
   linearData?: UserLinearData; // Linear data if integration enabled
 }
@@ -155,6 +162,37 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
           value: status.dailyName,
         },
       });
+
+      // Today's Plans section — always visible when submitted
+      if (status.planItems && status.planItems.length > 0) {
+        const planLines: string[] = [];
+        for (const item of status.planItems) {
+          const sourceTag = item.source ? ` · _${item.source}_` : '';
+          switch (item.status) {
+            case 'done':
+              planLines.push(`✅ ~${item.text}~${sourceTag}`);
+              break;
+            case 'in_progress':
+              planLines.push(`🔄 ${item.text}${sourceTag}`);
+              break;
+            case 'carried':
+              planLines.push(`➡️ ${item.text} _(carried)_${sourceTag}`);
+              break;
+            case 'dropped':
+              planLines.push(`❌ ~${item.text}~${sourceTag}`);
+              break;
+            default:
+              planLines.push(`⬜ ${item.text}${sourceTag}`);
+          }
+        }
+        blocks.push({
+          type: 'context',
+          elements: [{
+            type: 'mrkdwn',
+            text: planLines.join('\n'),
+          }],
+        });
+      }
     }
   }
 
@@ -245,7 +283,7 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*DM standup copy*\n${dmStatus} — get a private copy of your standup when it posts to the channel`,
+        text: `*DM standup copy*\n${dmStatus} — your plan is shown above; enable this for an extra DM copy`,
       },
       accessory: {
         type: 'button',
@@ -272,6 +310,12 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
     type: 'home',
     blocks,
   };
+}
+
+/** Extract source context from a plan item text (e.g., "[LIN-123] ..." → "LIN-123", "[repo#45] ..." → "repo#45") */
+function extractSource(text: string): string | undefined {
+  const match = text.match(/^\[([^\]]+)\]\s/);
+  return match ? match[1] : undefined;
 }
 
 /** Parse JSONB arrays from database (handles both array and string formats) */
@@ -385,10 +429,14 @@ export async function handleAppHomeOpened(
         }
       }
 
-      // Compute dropped count from previous submission
+      // Build plan items and compute dropped count from previous submission
       let droppedCount: number | undefined;
+      let planItems: PlanItem[] | undefined;
       if (todaySubmission) {
         const prevSubmission = await getPreviousSubmission(ctx.db, userId, dailyName, todayStr);
+
+        // Build dropped set from previous submission
+        const droppedItems: string[] = [];
         if (prevSubmission) {
           const prevPlans = new Set([
             ...parseJsonArray(prevSubmission.today_plans),
@@ -400,7 +448,33 @@ export async function handleAppHomeOpened(
             ...parseJsonArray(todaySubmission.yesterday_incomplete),
             ...parseJsonArray(todaySubmission.yesterday_in_progress),
           ]);
-          droppedCount = [...prevPlans].filter(item => !accountedFor.has(item)).length;
+          for (const item of prevPlans) {
+            if (!accountedFor.has(item)) droppedItems.push(item);
+          }
+          droppedCount = droppedItems.length;
+        }
+
+        // Build plan items list: in-progress, carried, new plans, done yesterday, dropped
+        planItems = [];
+        const completed = parseJsonArray(todaySubmission.yesterday_completed);
+        const incomplete = parseJsonArray(todaySubmission.yesterday_incomplete);
+        const inProgress = parseJsonArray(todaySubmission.yesterday_in_progress);
+        const plans = parseJsonArray(todaySubmission.today_plans);
+
+        for (const item of inProgress) {
+          planItems.push({ text: item, status: 'in_progress', source: extractSource(item) });
+        }
+        for (const item of incomplete) {
+          planItems.push({ text: item, status: 'carried', source: extractSource(item) });
+        }
+        for (const item of plans) {
+          planItems.push({ text: item, status: 'planned', source: extractSource(item) });
+        }
+        for (const item of completed) {
+          planItems.push({ text: item, status: 'done', source: extractSource(item) });
+        }
+        for (const item of droppedItems) {
+          planItems.push({ text: item, status: 'dropped', source: extractSource(item) });
         }
       }
 
@@ -410,6 +484,7 @@ export async function handleAppHomeOpened(
         tomorrowScheduled,
         submission: todaySubmission || undefined,
         droppedCount,
+        planItems,
         prData,
         linearData,
       });

--- a/lib/handlers/home.ts
+++ b/lib/handlers/home.ts
@@ -3,7 +3,7 @@
  * Shows user's dailies with "Start Daily" buttons
  */
 
-import { DbClient, getUserDailies, getSubmissionForDate, getPreviousSubmission, Submission, getGitHubUsername, getLinearUserId, setGitHubUsername, setLinearUserId, getDmStandupPreference } from '../db';
+import { DbClient, getUserDailies, getSubmissionForDate, getPreviousSubmission, Submission, getGitHubUsername, getLinearUserId, setGitHubUsername, setLinearUserId, getDmStandupPreference, getUserSettings, getActiveOOO } from '../db';
 import { getDaily, getGitHubConfig, getGitHubUsernameFromConfig, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser } from '../config';
 import { publishHomeView } from '../slack';
 import { formatDate, getUserDate, getUserTimezone } from '../prompt';
@@ -49,9 +49,13 @@ interface DailyStatus {
 }
 
 export interface LinkedAccounts {
-  github: string | null;  // username or null
-  linear: string | null;  // user ID or null
-  dmStandup: boolean;     // whether DM standup copies are enabled
+  github: string | null;
+  linear: string | null;
+  dmStandup: boolean;
+  maxItems: number | null;
+  stalePrDays: number | null;
+  linearTeamFilter: string[] | null;
+  oooStatus?: { startDate: string; endDate: string } | null;
 }
 
 /**
@@ -267,17 +271,55 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
       });
     }
 
-    // DM preferences
+    // Settings section
     blocks.push({
       type: 'header',
       text: {
         type: 'plain_text',
-        text: '⚙️ Preferences',
+        text: '⚙️ Settings',
         emoji: true,
       },
     });
 
-    const dmStatus = linkedAccounts.dmStandup ? '✅ Enabled' : '❌ Disabled';
+    // OOO management
+    if (linkedAccounts.oooStatus) {
+      const formatShort = (d: string) => {
+        const date = new Date(d + 'T00:00:00');
+        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      };
+      const rangeText = linkedAccounts.oooStatus.startDate === linkedAccounts.oooStatus.endDate
+        ? formatShort(linkedAccounts.oooStatus.startDate)
+        : `${formatShort(linkedAccounts.oooStatus.startDate)} – ${formatShort(linkedAccounts.oooStatus.endDate)}`;
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Out of Office*\n🏖️ ${rangeText}`,
+        },
+        accessory: {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Clear OOO', emoji: true },
+          action_id: 'home_clear_ooo',
+          style: 'danger',
+        },
+      });
+    } else {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '*Out of Office*\nNot set',
+        },
+        accessory: {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Set OOO', emoji: true },
+          action_id: 'home_set_ooo',
+        },
+      });
+    }
+
+    // DM standup copy
+    const dmStatus = linkedAccounts.dmStandup ? '✅ On' : '❌ Off';
     const dmButtonText = linkedAccounts.dmStandup ? 'Disable' : 'Enable';
     blocks.push({
       type: 'section',
@@ -289,6 +331,53 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
         type: 'button',
         text: { type: 'plain_text', text: dmButtonText, emoji: true },
         action_id: 'home_toggle_dm_standup',
+      },
+    });
+
+    // Max items per list
+    const maxItemsLabel = linkedAccounts.maxItems ? `${linkedAccounts.maxItems} items` : 'No limit';
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Max items per list*\n${maxItemsLabel} — PRs and Linear tickets shown in modal and post`,
+      },
+      accessory: {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Change', emoji: true },
+        action_id: 'home_set_max_items',
+      },
+    });
+
+    // Stale PR threshold
+    const stalePrLabel = linkedAccounts.stalePrDays ? `${linkedAccounts.stalePrDays} days` : '3 days (default)';
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Stale PR threshold*\n${stalePrLabel} — reviews older than this are flagged`,
+      },
+      accessory: {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Change', emoji: true },
+        action_id: 'home_set_stale_pr_days',
+      },
+    });
+
+    // Linear team filter
+    const linearFilterLabel = linkedAccounts.linearTeamFilter
+      ? linkedAccounts.linearTeamFilter.join(', ')
+      : 'All teams';
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Linear teams*\n${linearFilterLabel} — which teams' cycles to include`,
+      },
+      accessory: {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Change', emoji: true },
+        action_id: 'home_set_linear_teams',
       },
     });
 
@@ -490,16 +579,30 @@ export async function handleAppHomeOpened(
       });
     }
 
-    // Fetch linked accounts and preferences
-    const [githubUsername, linearUserId, dmStandup] = await Promise.all([
+    // Fetch linked accounts, preferences, and OOO status
+    const [githubUsername, linearUserId, settings] = await Promise.all([
       getGitHubUsername(ctx.db, userId),
       getLinearUserId(ctx.db, userId),
-      getDmStandupPreference(ctx.db, userId),
+      getUserSettings(ctx.db, userId),
     ]);
+
+    // Check OOO for the first daily (shows earliest active OOO)
+    let oooStatus: { startDate: string; endDate: string } | null = null;
+    if (userDailies.length > 0) {
+      const ooo = await getActiveOOO(ctx.db, userId, userDailies[0].daily_name, todayStr);
+      if (ooo) {
+        oooStatus = { startDate: ooo.start_date, endDate: ooo.end_date };
+      }
+    }
+
     const linkedAccounts: LinkedAccounts = {
       github: githubUsername,
       linear: linearUserId,
-      dmStandup,
+      dmStandup: settings.dmStandup,
+      maxItems: settings.maxItems,
+      stalePrDays: settings.stalePrDays,
+      linearTeamFilter: settings.linearTeamFilter,
+      oooStatus,
     };
 
     // Build and publish the home view

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -26,6 +26,10 @@ import {
   getRecentlyDoneLinearItems,
   getDmStandupPreference,
   setDmStandupPreference,
+  updateUserSetting,
+  getUserDailies,
+  setOOO,
+  clearOOO,
 } from '../db';
 import { handleAppHomeOpened, AppHomeOpenedEvent, HomeContext } from './home';
 import { fetchUserPRData, UserPRData } from '../github';
@@ -69,7 +73,8 @@ export interface InteractionPayload {
       values: Record<string, Record<string, {
         value?: string;
         selected_option?: { value: string };
-        selected_options?: Array<{ value: string }>;
+        selected_options?: Array<{ value: string; text?: { type: string; text: string } }>;
+        selected_date?: string;
         rich_text_value?: RichTextBlock;  // Slack uses rich_text_value, not rich_text
       }>>;
     };
@@ -1016,6 +1021,201 @@ export async function handleToggleDmStandup(
 }
 
 // ============================================================================
+// Settings Handlers
+// ============================================================================
+
+async function handleSetOOO(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const view = {
+    type: 'modal',
+    callback_id: 'ooo_set_submission',
+    title: { type: 'plain_text', text: 'Set Out of Office' },
+    submit: { type: 'plain_text', text: 'Set OOO' },
+    blocks: [
+      {
+        type: 'input',
+        block_id: 'ooo_start',
+        element: { type: 'datepicker', action_id: 'start_date' },
+        label: { type: 'plain_text', text: 'Start date' },
+      },
+      {
+        type: 'input',
+        block_id: 'ooo_end',
+        element: { type: 'datepicker', action_id: 'end_date' },
+        label: { type: 'plain_text', text: 'End date' },
+      },
+    ],
+  };
+
+  return openModal(ctx.slackToken, payload.trigger_id, view);
+}
+
+async function handleClearOOO(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const userId = payload.user.id;
+  try {
+    const dailies = await getUserDailies(ctx.db, userId);
+    for (const d of dailies) {
+      await clearOOO(ctx.db, userId, d.daily_name);
+    }
+    await refreshHome(userId, ctx);
+    return true;
+  } catch (error) {
+    console.error('Failed to clear OOO:', error);
+    return false;
+  }
+}
+
+async function handleOOOSetSubmission(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<InteractionResult> {
+  const userId = payload.user.id;
+  const values = payload.view?.state?.values;
+  const startDate = values?.ooo_start?.start_date?.selected_date;
+  const endDate = values?.ooo_end?.end_date?.selected_date;
+
+  if (!startDate || !endDate) {
+    return { response_action: 'errors', errors: { ooo_start: 'Please select both dates' } };
+  }
+  if (endDate < startDate) {
+    return { response_action: 'errors', errors: { ooo_end: 'End date must be on or after start date' } };
+  }
+
+  try {
+    const dailies = await getUserDailies(ctx.db, userId);
+    for (const d of dailies) {
+      await setOOO(ctx.db, userId, d.daily_name, startDate, endDate);
+    }
+    await refreshHome(userId, ctx);
+    return true;
+  } catch (error) {
+    console.error('Failed to set OOO:', error);
+    return false;
+  }
+}
+
+async function handleSetMaxItems(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const view = {
+    type: 'modal',
+    callback_id: 'settings_max_items',
+    title: { type: 'plain_text', text: 'Max Items Per List' },
+    submit: { type: 'plain_text', text: 'Save' },
+    blocks: [
+      {
+        type: 'input',
+        block_id: 'max_items',
+        element: {
+          type: 'static_select',
+          action_id: 'value',
+          placeholder: { type: 'plain_text', text: 'Select limit' },
+          options: [
+            { text: { type: 'plain_text', text: 'No limit' }, value: '0' },
+            { text: { type: 'plain_text', text: '3 items' }, value: '3' },
+            { text: { type: 'plain_text', text: '5 items' }, value: '5' },
+            { text: { type: 'plain_text', text: '10 items' }, value: '10' },
+          ],
+        },
+        label: { type: 'plain_text', text: 'Max PRs and Linear tickets shown' },
+      },
+    ],
+  };
+  return openModal(ctx.slackToken, payload.trigger_id, view);
+}
+
+async function handleSetStalePrDays(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const view = {
+    type: 'modal',
+    callback_id: 'settings_stale_pr_days',
+    title: { type: 'plain_text', text: 'Stale PR Threshold' },
+    submit: { type: 'plain_text', text: 'Save' },
+    blocks: [
+      {
+        type: 'input',
+        block_id: 'stale_pr_days',
+        element: {
+          type: 'static_select',
+          action_id: 'value',
+          placeholder: { type: 'plain_text', text: 'Select threshold' },
+          options: [
+            { text: { type: 'plain_text', text: '1 day' }, value: '1' },
+            { text: { type: 'plain_text', text: '2 days' }, value: '2' },
+            { text: { type: 'plain_text', text: '3 days (default)' }, value: '3' },
+            { text: { type: 'plain_text', text: '5 days' }, value: '5' },
+            { text: { type: 'plain_text', text: '7 days' }, value: '7' },
+          ],
+        },
+        label: { type: 'plain_text', text: 'Flag reviews older than' },
+      },
+    ],
+  };
+  return openModal(ctx.slackToken, payload.trigger_id, view);
+}
+
+async function handleSetLinearTeams(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const view = {
+    type: 'modal',
+    callback_id: 'settings_linear_teams',
+    title: { type: 'plain_text', text: 'Linear Team Filter' },
+    submit: { type: 'plain_text', text: 'Save' },
+    blocks: [
+      {
+        type: 'input',
+        block_id: 'linear_teams',
+        optional: true,
+        element: {
+          type: 'plain_text_input',
+          action_id: 'value',
+          placeholder: { type: 'plain_text', text: 'e.g. ENG,PLATFORM (leave empty for all)' },
+        },
+        label: { type: 'plain_text', text: 'Linear team IDs (comma-separated)' },
+      },
+    ],
+  };
+  return openModal(ctx.slackToken, payload.trigger_id, view);
+}
+
+async function handleSettingsSubmission(
+  payload: InteractionPayload,
+  ctx: InteractionContext,
+  callbackId: string
+): Promise<InteractionResult> {
+  const userId = payload.user.id;
+  const values = payload.view?.state?.values;
+
+  try {
+    if (callbackId === 'settings_max_items') {
+      const val = parseInt(values?.max_items?.value?.selected_option?.value || '0', 10);
+      await updateUserSetting(ctx.db, userId, 'max_items', val === 0 ? null : val);
+    } else if (callbackId === 'settings_stale_pr_days') {
+      const val = parseInt(values?.stale_pr_days?.value?.selected_option?.value || '3', 10);
+      await updateUserSetting(ctx.db, userId, 'stale_pr_days', val === 3 ? null : val);
+    } else if (callbackId === 'settings_linear_teams') {
+      const val = values?.linear_teams?.value?.value?.trim() || '';
+      await updateUserSetting(ctx.db, userId, 'linear_team_filter', val || null);
+    }
+    await refreshHome(userId, ctx);
+    return true;
+  } catch (error) {
+    console.error(`Failed to save setting ${callbackId}:`, error);
+    return false;
+  }
+}
+
+// ============================================================================
 // Main Router
 // ============================================================================
 
@@ -1057,6 +1257,11 @@ export async function handleInteraction(
     if (actionId === 'home_unlink_github') return handleUnlinkGitHub(payload, ctx);
     if (actionId === 'home_unlink_linear') return handleUnlinkLinear(payload, ctx);
     if (actionId === 'home_toggle_dm_standup') return handleToggleDmStandup(payload, ctx);
+    if (actionId === 'home_set_ooo') return handleSetOOO(payload, ctx);
+    if (actionId === 'home_clear_ooo') return handleClearOOO(payload, ctx);
+    if (actionId === 'home_set_max_items') return handleSetMaxItems(payload, ctx);
+    if (actionId === 'home_set_stale_pr_days') return handleSetStalePrDays(payload, ctx);
+    if (actionId === 'home_set_linear_teams') return handleSetLinearTeams(payload, ctx);
   }
 
   // Handle modal submission
@@ -1070,6 +1275,19 @@ export async function handleInteraction(
   }
   if (payload.type === 'view_submission' && payload.view?.callback_id === 'linear_link_submission') {
     return handleLinearLinkSubmission(payload, ctx);
+  }
+
+  // Handle OOO set submission
+  if (payload.type === 'view_submission' && payload.view?.callback_id === 'ooo_set_submission') {
+    return handleOOOSetSubmission(payload, ctx);
+  }
+
+  // Handle settings modal submissions
+  if (payload.type === 'view_submission') {
+    const callbackId = payload.view?.callback_id || '';
+    if (callbackId.startsWith('settings_')) {
+      return handleSettingsSubmission(payload, ctx, callbackId);
+    }
   }
 
   // Unknown interaction type

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -643,6 +643,13 @@ export async function handleStandupSubmission(
         console.error('Failed to send standup DM copy:', error);
       }
     }
+
+    // Refresh App Home so user sees their plan immediately
+    try {
+      await refreshHome(userId, ctx);
+    } catch (error) {
+      console.error('Failed to refresh App Home after submission:', error);
+    }
   };
 
   // Use waitUntil for background processing if available (Cloudflare Workers),

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -513,12 +513,15 @@ export async function handleStandupSubmission(
     // Plan-size soft warning: send a DM if the submitted plan count exceeds the threshold.
     // Counts everything that lands in today's plans: typed items + checked integrations
     // (already merged into todayPlans) + yesterday's carry-over + in-progress.
-    const maxPlanItems = getMaxPlanItems();
+    const maxPlanItems = getMaxPlanItems(dailyName);
     if (maxPlanItems > 0) {
-      const submittedPlanCount = todayPlans.length + yesterdayIncomplete.length + yesterdayInProgress.length;
+      const newPlanCount = todayPlans.length;
+      const carriedCount = yesterdayIncomplete.length + yesterdayInProgress.length;
+      const submittedPlanCount = newPlanCount + carriedCount;
       if (submittedPlanCount >= maxPlanItems) {
         const dayWord = isTomorrowMode ? 'for tomorrow' : 'today';
-        const warningMsg = `⚠️ You're planning ${submittedPlanCount} items ${dayWord}. Teams usually stay under ${maxPlanItems} to keep the day focused.`;
+        const breakdown = carriedCount > 0 ? ` (${newPlanCount} new + ${carriedCount} carried)` : '';
+        const warningMsg = `⚠️ You're planning ${submittedPlanCount} items${breakdown} ${dayWord}. Teams usually stay under ${maxPlanItems} to keep the day focused.`;
         try {
           await sendDM(ctx.slackToken, userId, warningMsg);
         } catch (error) {

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -596,24 +596,28 @@ export async function handleStandupSubmission(
     // are already included in todayPlans — re-fetching would show ALL PRs
     // regardless of what the user selected.
     if (daily?.channel) {
+      const githubConfig = getGitHubConfig(daily);
+      const standupData = {
+        yesterdayCompleted,
+        yesterdayIncomplete,
+        yesterdayInProgress,
+        yesterdayDropped,
+        unplanned,
+        todayPlans,
+        blockers,
+        customAnswers,
+        questions: daily.questions,
+        fieldOrder: daily.field_order,
+        inProgressCarryCounts,
+        githubOrg: githubConfig?.org,
+      };
+
       const messageTs = await postStandupToChannel(
         ctx.slackToken,
         daily.channel,
         userId,
         dailyName,
-        {
-          yesterdayCompleted,
-          yesterdayIncomplete,
-          yesterdayInProgress,
-          yesterdayDropped,
-          unplanned,
-          todayPlans,
-          blockers,
-          customAnswers,
-          questions: daily.questions,
-          fieldOrder: daily.field_order,
-          inProgressCarryCounts,
-        }
+        standupData
       );
 
       // Store message timestamp for future reference
@@ -625,19 +629,7 @@ export async function handleStandupSubmission(
       try {
         const dmEnabled = await getDmStandupPreference(ctx.db, userId);
         if (dmEnabled) {
-          await sendStandupDM(ctx.slackToken, userId, dailyName, daily.channel, {
-            yesterdayCompleted,
-            yesterdayIncomplete,
-            yesterdayInProgress,
-            yesterdayDropped,
-            unplanned,
-            todayPlans,
-            blockers,
-            customAnswers,
-            questions: daily.questions,
-            fieldOrder: daily.field_order,
-            inProgressCarryCounts,
-          });
+          await sendStandupDM(ctx.slackToken, userId, dailyName, daily.channel, standupData);
         }
       } catch (error) {
         console.error('Failed to send standup DM copy:', error);

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -3,7 +3,7 @@
  * Handles: open_standup button, standup_submission modal
  */
 
-import { getDaily, getConfigError, getSchedule, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser, getMaxPlanItems } from '../config';
+import { getDaily, getConfigError, getSchedule, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser, getMaxPlanItems, isAdmin } from '../config';
 import {
   DbClient,
   getPreviousSubmission,
@@ -28,6 +28,7 @@ import {
   setDmStandupPreference,
   updateUserSetting,
   getUserDailies,
+  getParticipants,
   setOOO,
   clearOOO,
 } from '../db';
@@ -36,7 +37,7 @@ import { fetchUserPRData, UserPRData } from '../github';
 import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue, UserLinearData } from '../linear';
 import { postStandupToChannel, sendStandupDM } from '../format';
 import { buildStandupModal, YesterdayData, SubmissionPrefill } from '../modal';
-import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed } from '../prompt';
+import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed, sendPromptDM } from '../prompt';
 import { openModal, parseRichText, RichTextBlock, sendDM } from '../slack';
 import { StandupMode } from '../modal';
 
@@ -1282,6 +1283,11 @@ export async function handleInteraction(
     return handleOOOSetSubmission(payload, ctx);
   }
 
+  // Handle mass prompt confirmation
+  if (payload.type === 'view_submission' && payload.view?.callback_id === 'mass_prompt_confirm') {
+    return handleMassPromptConfirm(payload, ctx);
+  }
+
   // Handle settings modal submissions
   if (payload.type === 'view_submission') {
     const callbackId = payload.view?.callback_id || '';
@@ -1291,5 +1297,41 @@ export async function handleInteraction(
   }
 
   // Unknown interaction type
+  return true;
+}
+
+async function handleMassPromptConfirm(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const userId = payload.user.id;
+  if (!isAdmin(userId)) return false;
+
+  let metadata: { dailyName: string };
+  try {
+    metadata = JSON.parse(payload.view?.private_metadata || '{}');
+  } catch {
+    return false;
+  }
+
+  const { dailyName } = metadata;
+  if (!dailyName) return false;
+
+  const participants = await getParticipants(ctx.db, dailyName);
+  let sent = 0;
+  let failed = 0;
+
+  for (const p of participants) {
+    const ok = await sendPromptDM(ctx.slackToken, p.slack_user_id, dailyName);
+    if (ok) sent++;
+    else failed++;
+  }
+
+  let summary = `📬 Sent prompts to ${sent} user${sent !== 1 ? 's' : ''} in *${dailyName}*.`;
+  if (failed > 0) {
+    summary += `\n⚠️ ${failed} failed.`;
+  }
+
+  await sendDM(ctx.slackToken, userId, summary);
   return true;
 }

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -190,18 +190,19 @@ export function buildStandupModal(
   // pre-checked integration items (currently none), and prefill today-plans (edit mode).
   // Free-text input in the plans textarea can't be observed here — the post-submit DM
   // covers that path.
-  const maxPlanItems = getMaxPlanItems();
+  const maxPlanItems = getMaxPlanItems(dailyName);
   if (maxPlanItems > 0) {
     const carryForwardCount = yesterdayPlans.length - (autoCompletedIds?.size || 0);
     const prefillCount = prefill?.todayPlans?.length || 0;
     const openTimeCount = carryForwardCount + prefillCount;
     if (openTimeCount >= maxPlanItems) {
       const dayWord = mode === 'tomorrow' ? 'for tomorrow' : 'today';
+      const breakdown = carryForwardCount > 0 && prefillCount > 0 ? ` (${prefillCount} new + ${carryForwardCount} carried)` : '';
       blocks.push({
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `⚠️ You're planning ${openTimeCount} items ${dayWord}. Teams usually stay under ${maxPlanItems} to keep the day focused.`,
+          text: `⚠️ You're planning ${openTimeCount} items${breakdown} ${dayWord}. Teams usually stay under ${maxPlanItems} to keep the day focused.`,
         },
       });
       blocks.push({ type: 'divider' });

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -221,6 +221,7 @@ export function buildStandupModal(
   }
 
   // Yesterday section: plans + unplanned (grouped as "what happened")
+  // Items are grouped by source: manual first, then PR items, then Linear items
   if (!isFirstDay && yesterdayPlans.length > 0) {
     blocks.push({
       type: 'section',
@@ -230,8 +231,28 @@ export function buildStandupModal(
       },
     });
 
-    // Add a dropdown for each yesterday's plan item
+    // Classify items by source for grouped display
+    const manualItems: Array<{ plan: string; index: number }> = [];
+    const prItems: Array<{ plan: string; index: number }> = [];
+    const linearItems: Array<{ plan: string; index: number }> = [];
+
     yesterdayPlans.forEach((plan, index) => {
+      const idMatch = plan.match(/^\[([^\]]+)\]\s/);
+      if (idMatch) {
+        if (idMatch[1].includes('#')) {
+          prItems.push({ plan, index });
+        } else {
+          linearItems.push({ plan, index });
+        }
+      } else {
+        manualItems.push({ plan, index });
+      }
+    });
+
+    // Render grouped items with section labels when there are mixed sources
+    const hasMixedSources = [manualItems, prItems, linearItems].filter(g => g.length > 0).length > 1;
+
+    const renderYesterdayItem = (plan: string, index: number) => {
       const isInProgress = yesterday?.inProgressCount != null && index < yesterday.inProgressCount;
       const linearId = plan.match(/^\[([^\]]+)\]\s/)?.[1];
       const isAutoCompleted = linearId && autoCompletedIds?.has(linearId);
@@ -254,7 +275,46 @@ export function buildStandupModal(
             : YESTERDAY_ITEM_OPTIONS[0],  // Carry over
         },
       });
-    });
+    };
+
+    // Manual items first
+    if (manualItems.length > 0) {
+      if (hasMixedSources) {
+        blocks.push({
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: '*✍️ Manual items*' }],
+        });
+      }
+      for (const { plan, index } of manualItems) {
+        renderYesterdayItem(plan, index);
+      }
+    }
+
+    // PR items
+    if (prItems.length > 0) {
+      if (hasMixedSources) {
+        blocks.push({
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: '*📦 PR items*' }],
+        });
+      }
+      for (const { plan, index } of prItems) {
+        renderYesterdayItem(plan, index);
+      }
+    }
+
+    // Linear items
+    if (linearItems.length > 0) {
+      if (hasMixedSources) {
+        blocks.push({
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: '*🎫 Linear items*' }],
+        });
+      }
+      for (const { plan, index } of linearItems) {
+        renderYesterdayItem(plan, index);
+      }
+    }
 
     // Unplanned completions - grouped with yesterday (both are "what happened")
     const unplannedYesterdayElement: Record<string, unknown> = {
@@ -425,7 +485,10 @@ export function buildStandupModal(
 
       case 'review_requests':
         if (prData) {
-          // PRs where others are requesting my review
+          blocks.push({
+            type: 'context',
+            elements: [{ type: 'mrkdwn', text: '_PRs from teammates that need your review_' }],
+          });
           const reviewPRs = prData.reviewRequests.slice(0, 10);
           const reviewOptions = reviewPRs.map((pr) => {
             const repoMatch = pr.url.match(/github\.com\/[^/]+\/([^/]+)/);
@@ -472,6 +535,10 @@ export function buildStandupModal(
 
       case 'my_prs':
         if (prData) {
+          blocks.push({
+            type: 'context',
+            elements: [{ type: 'mrkdwn', text: '_Your authored PRs — select to track in your standup_' }],
+          });
           // PRs I authored: awaiting review, ready to merge, draft
           const myPRsCategorized: Array<{ pr: GitHubPR; category: string; descSuffix?: string }> = [];
           for (const pr of prData.awaitingReview) {

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -622,6 +622,7 @@ async function processScheduledSubmission(
       fieldOrder: daily.field_order,
       prData,
       reviewerSlackMap,
+      githubOrg: githubConfig?.org,
     }
   );
 
@@ -651,6 +652,7 @@ async function processScheduledSubmission(
         fieldOrder: daily.field_order,
         prData,
         reviewerSlackMap,
+        githubOrg: githubConfig?.org,
       });
     }
   } catch (error) {

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -116,15 +116,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
+### Schedule-Aware Prompting ✅
+- [x] Read `schedule` config per-daily to determine working days
+- [x] Skip cron-triggered prompts on off-days (e.g., weekends)
+- [x] OOO and off-day logic combined: neither prompts nor counts as "missing"
+- [x] `/standup force-prompt` still works on off-days (manual override)
+- [x] Daily digest and OOO channel notices skip off-days (timezone-aware)
+
+---
+
 ## Up Next
-
-### Schedule-Aware Prompting
-Respect off-days in the daily schedule — don't prompt on weekends or other non-working days.
-
-- [ ] Read `schedule` config per-daily to determine working days
-- [ ] Skip cron-triggered prompts on off-days (e.g., weekends)
-- [ ] OOO and off-day logic combined: neither prompts nor counts as "missing"
-- [ ] `/standup force-prompt` still works on off-days (manual override)
 
 ### Visual Polish
 - [ ] Use `:white_check_mark:` / `:ballot_box_with_check:` for done items

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -140,16 +140,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
+### Team Summary Post ✅
+- [x] Post channel-level summary at digest time
+- [x] One line per person: name + top 1–2 plan items
+- [x] Blockers called out in a separate section
+- [x] Each line links to the person's full standup post (↗)
+- [x] Opt-in per-daily via `team_summary: true` config
+
+---
+
 ## Up Next
-
-### Team Summary Post
-Post a single consolidated summary to the daily channel with the key items from each team member's standup.
-
-- [ ] After all standups are in (or at digest time), post a channel-level summary
-- [ ] One line per person: name + top 1–2 items (highest-signal plans or blockers)
-- [ ] Blockers called out in a separate section so they're impossible to miss
-- [ ] Linkable: each person's line links to their full standup post in the thread
-- [ ] Configurable per-daily: opt-in via config toggle
 
 ### CI Pipeline
 - [ ] GitHub Actions for automated test runs

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -132,17 +132,15 @@ See `requirements.md` and `architecture.md`
 - [x] 🎯 for new plan items, ⚡ for unplanned items (was ☑️)
 - [x] Consistent emoji across standup post, App Home, and DM
 
+### Plan Size Warning (Follow-on) ✅
+- [x] Per-daily override: `max_plan_items` in daily config
+- [ ] Live validation (deferred — Slack modal limitations)
+- [x] Digest surfacing for users who routinely over-plan (avg plan count in team section)
+- [x] Distinguish net-new vs carried-over items in the count (breakdown in warning DM + modal)
+
 ---
 
 ## Up Next
-
-### Plan Size Warning (Follow-on)
-First Version shipped (see Shipped > Plan Size Warning). Remaining scope:
-
-- [ ] Per-daily override: `max_plan_items` in daily config
-- [ ] Live validation (warning updates as the user types/adds items)
-- [ ] Digest/report surfacing for users who routinely over-plan
-- [ ] Distinguish net-new vs carried-over items in the count
 
 ### Team Summary Post
 Post a single consolidated summary to the daily channel with the key items from each team member's standup.

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -97,17 +97,15 @@ See `requirements.md` and `architecture.md`
 - [x] App Home refreshes after submission so user sees plan immediately
 - [x] Source context per item (PR link, Linear ticket identifier) shown inline
 
+### Standup Modal Reorganization ✅
+- [x] Yesterday items grouped by source: manual → PR → Linear (with section headers when mixed)
+- [x] Clearer section headers: "✍️ Manual items", "📦 PR items", "🎫 Linear items"
+- [x] Context hints on PR and My PR sections explaining what each shows
+- [x] Reduced cognitive load through visual separation between source types
+
 ---
 
 ## Up Next
-
-### Standup Modal Reorganization
-Current modal is cluttered and mixes authored PRs with review requests without clear context.
-
-- [ ] Split "Yesterday" PRs into distinct groups: "My PRs" vs "PRs I reviewed"
-- [ ] Clearer section headers and visual separation between PR / Linear / manual items
-- [ ] Inline source hint per item (e.g., "from PR #123", "from LIN-456")
-- [ ] Reduce cognitive load — consider collapsible sections
 
 ### Readable Standup Post
 Give each line in the posted standup more context and make integration items actionable.

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -176,15 +176,15 @@ See `requirements.md` and `architecture.md`
 - [x] Store config overrides in DB (`config_overrides` table, takes precedence over YAML)
 - [x] Paused dailies shown with ⏸️ in `/standup list`
 
+### Force Prompt Command (Full) ✅
+- [x] `/standup force-prompt <daily>` - force prompt yourself
+- [x] `/standup prompt all <daily>` - admin command to prompt all participants
+- [x] Confirmation modal before mass-prompting (shows participant count)
+- [x] Summary DM: "Sent prompts to 7 users in daily-il"
+
 ---
 
 ## Planned
-
-### Force Prompt Command (Full)
-- [x] `/standup force-prompt <daily>` - force prompt yourself
-- [ ] `/standup prompt all <daily>` - admin command to prompt all participants
-- [ ] Confirmation step before mass-prompting
-- [ ] Show summary: "Sent prompts to 7 users"
 
 ### Admin Management
 - [ ] `/standup admin add @user` - add admin (super-admin only)

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -197,12 +197,15 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Planned
+### Remaining Stats & Analytics ✅
+- [x] Blocker streak tracking: consecutive days with blockers per user, surfaced in digest (🚧) and full report
+- [x] Unplanned overload alert: flag users with >70% unplanned work (⚡) in digest and report
+- [x] Unplanned rate trend comparison in full report Period Trends section
+- ~~Trend visualization (sparklines in Slack?)~~ — Skipped: Slack Block Kit doesn't support sparklines; existing ↑↓→ indicators are sufficient
 
-### Remaining Stats & Analytics
-- [ ] Blocker resolution time tracking
-- [ ] Trend visualization (sparklines in Slack?)
-- [ ] Unplanned overload alert (>70% unplanned work)
+---
+
+## Planned
 
 ### GitHub PR Filtering
 - [ ] Exclude PRs where user has commented and is awaiting author response

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -149,10 +149,8 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Up Next
-
-### CI Pipeline
-- [ ] GitHub Actions for automated test runs
+### CI Pipeline ✅
+- [x] GitHub Actions workflow: type check + test on push/PR to main and dev
 
 ---
 

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -169,13 +169,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Planned
+### Dynamic Configuration ✅
+- [x] Hot-reload config changes without redeploying (DB overrides loaded per-request)
+- [x] Pause/resume dailies: `/standup pause <daily>` / `/standup resume <daily>`
+- [x] Admin command to reload config: `/standup config reload`
+- [x] Store config overrides in DB (`config_overrides` table, takes precedence over YAML)
+- [x] Paused dailies shown with ⏸️ in `/standup list`
 
-### Dynamic Configuration
-- [ ] Hot-reload config changes without redeploying
-- [ ] Pause/resume dailies via config flag (`enabled: false`)
-- [ ] Admin command to reload config: `/standup config reload`
-- [ ] Store config overrides in DB (takes precedence over YAML)
+---
+
+## Planned
 
 ### Force Prompt Command (Full)
 - [x] `/standup force-prompt <daily>` - force prompt yourself

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -90,6 +90,13 @@ See `requirements.md` and `architecture.md`
 - [x] Static warning copy; non-blocking; not dismissible
 - [x] Counts all plan items regardless of source (manual, PR, Linear)
 
+### App Home: Today's Plans ✅
+- [x] Show today's submitted plan items in the App Home tab (done / in-progress / planned / carried / dropped)
+- [x] DM copy defaults to off — App Home is the primary place to review your plan
+- [x] DM copy toggle still available in Preferences for users who prefer it
+- [x] App Home refreshes after submission so user sees plan immediately
+- [x] Source context per item (PR link, Linear ticket identifier) shown inline
+
 ---
 
 ## Up Next
@@ -139,6 +146,15 @@ First Version shipped (see Shipped > Plan Size Warning). Remaining scope:
 - [ ] Live validation (warning updates as the user types/adds items)
 - [ ] Digest/report surfacing for users who routinely over-plan
 - [ ] Distinguish net-new vs carried-over items in the count
+
+### Team Summary Post
+Post a single consolidated summary to the daily channel with the key items from each team member's standup.
+
+- [ ] After all standups are in (or at digest time), post a channel-level summary
+- [ ] One line per person: name + top 1–2 items (highest-signal plans or blockers)
+- [ ] Blockers called out in a separate section so they're impossible to miss
+- [ ] Linkable: each person's line links to their full standup post in the thread
+- [ ] Configurable per-daily: opt-in via config toggle
 
 ### CI Pipeline
 - [ ] GitHub Actions for automated test runs

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -108,17 +108,15 @@ See `requirements.md` and `architecture.md`
 - [x] Source icons: 📦 for PRs, 🎫 for Linear tickets; manual items unchanged
 - [x] Reader can tell at a glance where each item came from
 
+### Report OOO to Daily ✅
+- [x] Post OOO notice to daily channel when a user's OOO period begins (at digest time)
+- [x] Include OOO users in the daily digest (e.g., "Out today: @alice, @bob")
+- [x] Show return date alongside name
+- [ ] Optional per-daily toggle in config (deferred to Dynamic Configuration)
+
 ---
 
 ## Up Next
-
-### Report OOO to Daily
-Surface OOO status in the daily channel so the team sees who's out without checking `/standup list`.
-
-- [ ] Post OOO notice to daily channel when a user's OOO period begins
-- [ ] Include OOO users in the daily digest (e.g., "Out today: @alice, @bob")
-- [ ] Show return date alongside name
-- [ ] Optional per-daily toggle in config
 
 ### Schedule-Aware Prompting
 Respect off-days in the daily schedule — don't prompt on weekends or other non-working days.

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -184,17 +184,20 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Planned
+### Admin Management ✅
+- [x] `/standup admin add @user` - add admin (super-admin only)
+- [x] `/standup admin remove @user` - remove admin
+- [x] `/standup admin list` - show all admins (super-admins + DB admins)
+- [x] Super-admins defined in config (can manage other admins)
+- [x] DB admins stored via `config_overrides` table
+- [x] `/standup manager add <daily> @user` - admin assigns a daily manager
+- [x] `/standup manager remove <daily> @user` - admin removes a daily manager
+- [x] `/standup manager list <daily>` - show managers for a daily
+- [x] Daily managers merged from YAML + DB (deduplicated)
 
-### Admin Management
-- [ ] `/standup admin add @user` - add admin (super-admin only)
-- [ ] `/standup admin remove @user` - remove admin
-- [ ] `/standup admin list` - show all admins
-- [ ] Define super-admins in config (can manage other admins)
-- [ ] `/standup manager add <daily> @user` - admin assigns a daily manager
-- [ ] `/standup manager remove <daily> @user` - admin removes a daily manager
-- [ ] `/standup manager list <daily>` - show managers for a daily
-- [ ] Daily managers receive digest and report without being reporters
+---
+
+## Planned
 
 ### Remaining Stats & Analytics
 - [ ] Blocker resolution time tracking

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -125,13 +125,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Up Next
+### Visual Polish ✅
+- [x] ✅ for completed items (was ☑️)
+- [x] ➡️ for carried-over items (was ⬜)
+- [x] ❌ for dropped items (unchanged)
+- [x] 🎯 for new plan items, ⚡ for unplanned items (was ☑️)
+- [x] Consistent emoji across standup post, App Home, and DM
 
-### Visual Polish
-- [ ] Use `:white_check_mark:` / `:ballot_box_with_check:` for done items
-- [ ] Use `:arrow_right:` for continued items
-- [ ] Use `:x:` for dropped items
-- [ ] Consider emoji prefixes for plan items (🎯 planned, ⚡ unplanned)
+---
+
+## Up Next
 
 ### Plan Size Warning (Follow-on)
 First Version shipped (see Shipped > Plan Size Warning). Remaining scope:

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -103,17 +103,14 @@ See `requirements.md` and `architecture.md`
 - [x] Context hints on PR and My PR sections explaining what each shows
 - [x] Reduced cognitive load through visual separation between source types
 
+### Readable Standup Post ✅
+- [x] Integration items enriched with clickable links: PR items link to GitHub, Linear items to Linear
+- [x] Source icons: 📦 for PRs, 🎫 for Linear tickets; manual items unchanged
+- [x] Reader can tell at a glance where each item came from
+
 ---
 
 ## Up Next
-
-### Readable Standup Post
-Give each line in the posted standup more context and make integration items actionable.
-
-- [ ] Show source per line (e.g., "✅ Fix auth bug — _from PR #123_")
-- [ ] Clickable items: PR/Linear items link to source URL
-- [ ] Consistent source icons (GitHub vs Linear vs manual)
-- [ ] Reader can tell at a glance where each item came from
 
 ### Report OOO to Daily
 Surface OOO status in the daily channel so the team sees who's out without checking `/standup list`.

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -161,17 +161,15 @@ See `requirements.md` and `architecture.md`
 - [x] Stale PR threshold override: `stale_pr_days` setting (default 3)
 - [x] Consolidated all settings under "⚙️ Settings" section in App Home
 
+### In-Progress Item Tracking (Full) ✅
+- [x] In-progress items auto-carry to today (no re-prompting needed)
+- [x] Track consecutive in-progress days per item in DB (`carry_count` increments daily)
+- [x] Items in-progress for 3+ days flagged as "needs attention" in digest (`🔄`) and report
+- [x] Visual indicator in standup post: `🔄 Day X` / `⚠️ Day X — needs attention`
+
 ---
 
 ## Planned
-
-### In-Progress Item Tracking (Full)
-Build on the existing in-progress status to add smart carry-over and attention flagging.
-
-- [ ] In-progress items auto-carry to today (no re-prompting needed)
-- [ ] Track consecutive in-progress days per item in DB
-- [ ] Items in-progress for 3+ days flagged as "needs attention" in digest and report
-- [ ] Visual indicator in standup post (e.g., 🔄 Day 3)
 
 ### Dynamic Configuration
 - [ ] Hot-reload config changes without redeploying

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -154,16 +154,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
+### User Settings Pane ✅
+- [x] Max items shown per list (PRs, Linear tickets) — per-user `max_items` setting
+- [x] OOO management UI (set/clear from App Home via date picker modal)
+- [x] Per-Linear-team filter: `linear_team_filter` setting
+- [x] Stale PR threshold override: `stale_pr_days` setting (default 3)
+- [x] Consolidated all settings under "⚙️ Settings" section in App Home
+
+---
+
 ## Planned
-
-### User Settings Pane
-Per-user self-service configuration in App Home (consolidates existing toggles + new controls).
-
-- [ ] Max items shown per list (PRs, Linear tickets) — in modal and standup post
-- [ ] OOO management UI (set/clear from App Home, currently command-only)
-- [ ] Per-Linear-team filter: which teams' cycles to include
-- [ ] Stale PR threshold override (default 3 days)
-- [ ] Consolidate existing DM-copy opt-out toggle into Settings section
 
 ### In-Progress Item Tracking (Full)
 Build on the existing in-progress status to add smart carry-over and attention flagging.

--- a/schema.sql
+++ b/schema.sql
@@ -50,6 +50,9 @@ CREATE TABLE IF NOT EXISTS slack_users (
   github_username TEXT,  -- Optional: linked GitHub username for PR integration
   linear_user_id TEXT,   -- Optional: linked Linear user ID for ticket integration
   dm_standup BOOLEAN DEFAULT TRUE, -- Whether to send DM copy of standup posts
+  max_items INTEGER,               -- Max PRs/Linear tickets shown in modal & post (NULL = no limit)
+  stale_pr_days INTEGER,           -- Override stale PR threshold in days (NULL = use default 3)
+  linear_team_filter TEXT,         -- Comma-separated Linear team IDs to include (NULL = all)
   updated_at TIMESTAMP DEFAULT NOW()
 );
 

--- a/schema.sql
+++ b/schema.sql
@@ -98,6 +98,17 @@ CREATE TABLE IF NOT EXISTS ooo (
   UNIQUE(slack_user_id, daily_name, start_date, end_date)
 );
 
+-- Config overrides (DB takes precedence over YAML)
+CREATE TABLE IF NOT EXISTS config_overrides (
+  id SERIAL PRIMARY KEY,
+  scope TEXT NOT NULL DEFAULT 'global',
+  key TEXT NOT NULL,
+  value JSONB NOT NULL,
+  updated_at TIMESTAMP DEFAULT NOW(),
+  updated_by TEXT,
+  UNIQUE(scope, key)
+);
+
 -- Indexes for common queries
 CREATE INDEX IF NOT EXISTS idx_participants_daily ON participants(daily_name);
 CREATE INDEX IF NOT EXISTS idx_submissions_date ON submissions(date);

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -10,7 +10,11 @@ vi.mock('../lib/config', () => ({
   getDaily: vi.fn(),
   getSchedule: vi.fn(),
   getDailies: vi.fn(),
+  getAllDailiesIncludingDisabled: vi.fn(),
+  isDailyEnabled: vi.fn(() => true),
   getConfigError: vi.fn(() => null),
+  clearConfigCache: vi.fn(),
+  loadConfigOverrides: vi.fn(() => Promise.resolve()),
 }));
 
 // Mock db module
@@ -29,6 +33,8 @@ vi.mock('../lib/db', () => ({
   setOOO: vi.fn(),
   clearOOO: vi.fn(),
   getUserOOO: vi.fn(() => []),
+  setConfigOverride: vi.fn(),
+  deleteConfigOverride: vi.fn(),
 }));
 
 // Mock slack module
@@ -66,8 +72,8 @@ import {
   CommandContext,
 } from '../lib/handlers/commands';
 
-import { isAdmin, getDaily, getSchedule, getDailies, getConfigError } from '../lib/config';
-import { addParticipant, removeParticipant, getParticipants, getSubmissionsInRange, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, setOOO, clearOOO, getUserOOO } from '../lib/db';
+import { isAdmin, getDaily, getSchedule, getDailies, getConfigError, getAllDailiesIncludingDisabled, isDailyEnabled, clearConfigCache, loadConfigOverrides } from '../lib/config';
+import { addParticipant, removeParticipant, getParticipants, getSubmissionsInRange, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, setOOO, clearOOO, getUserOOO, setConfigOverride, deleteConfigOverride } from '../lib/db';
 import { parseUserId, sendDM } from '../lib/slack';
 import { getUserTimezone, getUserDate, formatDate, sendPromptDM } from '../lib/prompt';
 import { formatManagerDigest } from '../lib/format';
@@ -183,7 +189,7 @@ describe('command handlers', () => {
 
   describe('handleList', () => {
     it('lists all dailies with participants when no name provided', async () => {
-      vi.mocked(getDailies).mockReturnValue([
+      vi.mocked(getAllDailiesIncludingDisabled).mockReturnValue([
         { name: 'daily-il', channel: '#il-standup' },
         { name: 'daily-us', channel: '#us-standup' },
       ] as any);
@@ -200,7 +206,7 @@ describe('command handlers', () => {
     });
 
     it('lists all dailies with participants when "all" provided', async () => {
-      vi.mocked(getDailies).mockReturnValue([
+      vi.mocked(getAllDailiesIncludingDisabled).mockReturnValue([
         { name: 'daily-il', channel: '#il-standup' },
       ] as any);
       vi.mocked(getParticipants).mockResolvedValue([{ slack_user_id: 'U111' }] as any);
@@ -493,7 +499,7 @@ describe('command handlers', () => {
     });
 
     it('routes list command', async () => {
-      vi.mocked(getDailies).mockReturnValue([]);
+      vi.mocked(getAllDailiesIncludingDisabled).mockReturnValue([]);
       const response = await handleCommand('list', createContext(['list']));
       expect(response.text).toContain('dailies');
     });
@@ -512,6 +518,93 @@ describe('command handlers', () => {
     it('routes week command (deprecated)', async () => {
       const response = await handleCommand('week', createContext(['week']));
       expect(response.text).toContain('deprecated');
+    });
+
+    it('routes config reload command', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getAllDailiesIncludingDisabled).mockReturnValue([
+        { name: 'daily-il' },
+      ] as any);
+      const response = await handleCommand('config', createContext(['config', 'reload']));
+      expect(response.text).toContain('Config reloaded');
+    });
+
+    it('routes pause command', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(isDailyEnabled).mockReturnValue(true);
+      const response = await handleCommand('pause', createContext(['pause', 'daily-il']));
+      expect(response.text).toContain('paused');
+      expect(setConfigOverride).toHaveBeenCalled();
+    });
+
+    it('routes resume command', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(isDailyEnabled).mockReturnValue(false);
+      const response = await handleCommand('resume', createContext(['resume', 'daily-il']));
+      expect(response.text).toContain('active');
+      expect(deleteConfigOverride).toHaveBeenCalled();
+    });
+  });
+
+  describe('dynamic configuration commands', () => {
+    it('config reload requires admin', async () => {
+      vi.mocked(isAdmin).mockReturnValue(false);
+      const response = await handleCommand('config', createContext(['config', 'reload']));
+      expect(response.text).toContain('admin');
+    });
+
+    it('pause requires admin', async () => {
+      vi.mocked(isAdmin).mockReturnValue(false);
+      const response = await handleCommand('pause', createContext(['pause', 'daily-il']));
+      expect(response.text).toContain('admin');
+    });
+
+    it('resume requires admin', async () => {
+      vi.mocked(isAdmin).mockReturnValue(false);
+      const response = await handleCommand('resume', createContext(['resume', 'daily-il']));
+      expect(response.text).toContain('admin');
+    });
+
+    it('pause requires daily name', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      const response = await handleCommand('pause', createContext(['pause']));
+      expect(response.text).toContain('Usage');
+    });
+
+    it('pause validates daily exists', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue(undefined);
+      const response = await handleCommand('pause', createContext(['pause', 'nonexistent']));
+      expect(response.text).toContain('Unknown daily');
+    });
+
+    it('pause shows message when already paused', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(isDailyEnabled).mockReturnValue(false);
+      const response = await handleCommand('pause', createContext(['pause', 'daily-il']));
+      expect(response.text).toContain('already paused');
+    });
+
+    it('resume shows message when already active', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(isDailyEnabled).mockReturnValue(true);
+      const response = await handleCommand('resume', createContext(['resume', 'daily-il']));
+      expect(response.text).toContain('already active');
+    });
+
+    it('list shows paused indicator', async () => {
+      vi.mocked(getAllDailiesIncludingDisabled).mockReturnValue([
+        { name: 'daily-il', channel: '#il-standup' },
+      ] as any);
+      vi.mocked(isDailyEnabled).mockReturnValue(false);
+      vi.mocked(getParticipants).mockResolvedValue([{ slack_user_id: 'U111' }] as any);
+
+      const response = await handleList(createContext(['list']));
+      expect(response.text).toContain('⏸️');
     });
   });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -39,6 +39,8 @@ vi.mock('../lib/db', () => ({
   getUserOOO: vi.fn(() => []),
   setConfigOverride: vi.fn(),
   deleteConfigOverride: vi.fn(),
+  getBlockerStreaks: vi.fn(() => []),
+  getUnplannedOverload: vi.fn(() => []),
 }));
 
 // Mock slack module

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -7,9 +7,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock config module
 vi.mock('../lib/config', () => ({
   isAdmin: vi.fn(),
+  isSuperAdmin: vi.fn(),
+  getAdmins: vi.fn(() => ({ superAdmins: [], dbAdmins: [] })),
+  getOverride: vi.fn(() => undefined),
   getDaily: vi.fn(),
   getSchedule: vi.fn(),
   getDailies: vi.fn(),
+  getDailyManagers: vi.fn(() => []),
   getAllDailiesIncludingDisabled: vi.fn(),
   isDailyEnabled: vi.fn(() => true),
   getConfigError: vi.fn(() => null),
@@ -73,7 +77,7 @@ import {
   CommandContext,
 } from '../lib/handlers/commands';
 
-import { isAdmin, getDaily, getSchedule, getDailies, getConfigError, getAllDailiesIncludingDisabled, isDailyEnabled, clearConfigCache, loadConfigOverrides } from '../lib/config';
+import { isAdmin, isSuperAdmin, getAdmins, getOverride, getDaily, getSchedule, getDailies, getDailyManagers, getConfigError, getAllDailiesIncludingDisabled, isDailyEnabled, clearConfigCache, loadConfigOverrides } from '../lib/config';
 import { addParticipant, removeParticipant, getParticipants, getSubmissionsInRange, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, setOOO, clearOOO, getUserOOO, setConfigOverride, deleteConfigOverride } from '../lib/db';
 import { parseUserId, sendDM, openModal } from '../lib/slack';
 import { getUserTimezone, getUserDate, formatDate, sendPromptDM } from '../lib/prompt';
@@ -606,6 +610,182 @@ describe('command handlers', () => {
 
       const response = await handleList(createContext(['list']));
       expect(response.text).toContain('⏸️');
+    });
+  });
+
+  describe('admin management', () => {
+    it('admin list shows super-admins and db admins', async () => {
+      vi.mocked(getAdmins).mockReturnValue({ superAdmins: ['U_SUPER'], dbAdmins: ['U_DB1'] });
+      const response = await handleCommand('admin', createContext(['admin', 'list']));
+      expect(response.text).toContain('U_SUPER');
+      expect(response.text).toContain('U_DB1');
+      expect(response.text).toContain('Super-admins');
+    });
+
+    it('admin list works for non-super-admins', async () => {
+      vi.mocked(getAdmins).mockReturnValue({ superAdmins: ['U_SUPER'], dbAdmins: [] });
+      vi.mocked(isSuperAdmin).mockReturnValue(false);
+      const response = await handleCommand('admin', createContext(['admin', 'list']));
+      expect(response.text).toContain('U_SUPER');
+    });
+
+    it('admin add requires super-admin', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(false);
+      vi.mocked(parseUserId).mockReturnValue('U_NEW');
+      const response = await handleCommand('admin', createContext(['admin', 'add', '<@U_NEW>']));
+      expect(response.text).toContain('super-admin');
+    });
+
+    it('admin add succeeds for super-admin', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue('U_NEW');
+      vi.mocked(isAdmin).mockReturnValue(false);
+      vi.mocked(getOverride).mockReturnValue(undefined);
+      vi.mocked(setConfigOverride).mockResolvedValue();
+      vi.mocked(loadConfigOverrides).mockResolvedValue();
+
+      const response = await handleCommand('admin', createContext(['admin', 'add', '<@U_NEW>']));
+      expect(response.text).toContain('now an admin');
+      expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'global', 'admins', ['U_NEW'], 'U12345');
+    });
+
+    it('admin add rejects if already admin', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue('U_EXISTING');
+      vi.mocked(isAdmin).mockReturnValue(true);
+
+      const response = await handleCommand('admin', createContext(['admin', 'add', '<@U_EXISTING>']));
+      expect(response.text).toContain('already an admin');
+    });
+
+    it('admin add requires user mention', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue(null);
+
+      const response = await handleCommand('admin', createContext(['admin', 'add']));
+      expect(response.text).toContain('Usage');
+    });
+
+    it('admin remove succeeds', async () => {
+      vi.mocked(isSuperAdmin).mockImplementation((id) => id === 'U12345');
+      vi.mocked(parseUserId).mockReturnValue('U_DB1');
+      vi.mocked(getOverride).mockReturnValue(['U_DB1', 'U_DB2']);
+      vi.mocked(setConfigOverride).mockResolvedValue();
+      vi.mocked(loadConfigOverrides).mockResolvedValue();
+
+      const response = await handleCommand('admin', createContext(['admin', 'remove', '<@U_DB1>']));
+      expect(response.text).toContain('no longer an admin');
+      expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'global', 'admins', ['U_DB2'], 'U12345');
+    });
+
+    it('admin remove rejects super-admin removal', async () => {
+      vi.mocked(isSuperAdmin).mockImplementation((id) => id === 'U_SUPER' || id === 'U12345');
+      vi.mocked(parseUserId).mockReturnValue('U_SUPER');
+
+      const response = await handleCommand('admin', createContext(['admin', 'remove', '<@U_SUPER>']));
+      expect(response.text).toContain('Cannot remove a super-admin');
+    });
+
+    it('admin remove rejects if not a DB admin', async () => {
+      vi.mocked(isSuperAdmin).mockImplementation((id) => id === 'U12345');
+      vi.mocked(parseUserId).mockReturnValue('U_UNKNOWN');
+      vi.mocked(getOverride).mockReturnValue([]);
+
+      const response = await handleCommand('admin', createContext(['admin', 'remove', '<@U_UNKNOWN>']));
+      expect(response.text).toContain('not a DB-added admin');
+    });
+  });
+
+  describe('manager management', () => {
+    it('manager commands require admin', async () => {
+      vi.mocked(isAdmin).mockReturnValue(false);
+      const response = await handleCommand('manager', createContext(['manager', 'list', 'daily-il']));
+      expect(response.text).toContain('Only admins');
+    });
+
+    it('manager list shows managers for a daily', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getDailyManagers).mockReturnValue(['U_MGR1', 'U_MGR2']);
+
+      const response = await handleCommand('manager', createContext(['manager', 'list', 'daily-il']));
+      expect(response.text).toContain('U_MGR1');
+      expect(response.text).toContain('U_MGR2');
+    });
+
+    it('manager list shows empty message', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getDailyManagers).mockReturnValue([]);
+
+      const response = await handleCommand('manager', createContext(['manager', 'list', 'daily-il']));
+      expect(response.text).toContain('no managers');
+    });
+
+    it('manager list requires daily name', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      const response = await handleCommand('manager', createContext(['manager', 'list']));
+      expect(response.text).toContain('Usage');
+    });
+
+    it('manager list validates daily exists', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue(undefined);
+      const response = await handleCommand('manager', createContext(['manager', 'list', 'fake']));
+      expect(response.text).toContain('not found');
+    });
+
+    it('manager add succeeds', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockImplementation((text) => text.includes('<@') ? 'U_NEW_MGR' : null);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getDailyManagers).mockReturnValue([]);
+      vi.mocked(getOverride).mockReturnValue(undefined);
+      vi.mocked(setConfigOverride).mockResolvedValue();
+      vi.mocked(loadConfigOverrides).mockResolvedValue();
+
+      const response = await handleCommand('manager', createContext(['manager', 'add', 'daily-il', '<@U_NEW_MGR>']));
+      expect(response.text).toContain('now a manager');
+      expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'daily-il', 'managers', ['U_NEW_MGR'], 'U12345');
+    });
+
+    it('manager add rejects duplicate', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue('U_EXISTING_MGR');
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getDailyManagers).mockReturnValue(['U_EXISTING_MGR']);
+
+      const response = await handleCommand('manager', createContext(['manager', 'add', 'daily-il', '<@U_EXISTING_MGR>']));
+      expect(response.text).toContain('already a manager');
+    });
+
+    it('manager remove succeeds', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockImplementation((text) => text.includes('<@') ? 'U_MGR1' : null);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getOverride).mockReturnValue(['U_MGR1', 'U_MGR2']);
+      vi.mocked(setConfigOverride).mockResolvedValue();
+      vi.mocked(loadConfigOverrides).mockResolvedValue();
+
+      const response = await handleCommand('manager', createContext(['manager', 'remove', 'daily-il', '<@U_MGR1>']));
+      expect(response.text).toContain('no longer a manager');
+      expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'daily-il', 'managers', ['U_MGR2'], 'U12345');
+    });
+
+    it('manager remove rejects if not a DB manager', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue('U_YAML_MGR');
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getOverride).mockReturnValue([]);
+
+      const response = await handleCommand('manager', createContext(['manager', 'remove', 'daily-il', '<@U_YAML_MGR>']));
+      expect(response.text).toContain('not a DB-added manager');
+    });
+
+    it('manager with no action shows usage', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      const response = await handleCommand('manager', createContext(['manager']));
+      expect(response.text).toContain('Usage');
     });
   });
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -42,6 +42,7 @@ vi.mock('../lib/slack', () => ({
   parseUserId: vi.fn(),
   ephemeralResponse: vi.fn((text: string) => ({ response_type: 'ephemeral', text })),
   sendDM: vi.fn(),
+  openModal: vi.fn(() => Promise.resolve(true)),
 }));
 
 // Mock prompt module
@@ -74,7 +75,7 @@ import {
 
 import { isAdmin, getDaily, getSchedule, getDailies, getConfigError, getAllDailiesIncludingDisabled, isDailyEnabled, clearConfigCache, loadConfigOverrides } from '../lib/config';
 import { addParticipant, removeParticipant, getParticipants, getSubmissionsInRange, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, setOOO, clearOOO, getUserOOO, setConfigOverride, deleteConfigOverride } from '../lib/db';
-import { parseUserId, sendDM } from '../lib/slack';
+import { parseUserId, sendDM, openModal } from '../lib/slack';
 import { getUserTimezone, getUserDate, formatDate, sendPromptDM } from '../lib/prompt';
 import { formatManagerDigest } from '../lib/format';
 
@@ -605,6 +606,65 @@ describe('command handlers', () => {
 
       const response = await handleList(createContext(['list']));
       expect(response.text).toContain('⏸️');
+    });
+  });
+
+  describe('mass prompt (prompt all <daily>)', () => {
+    const createContextWithTrigger = (args: string[]): CommandContext => ({
+      userId: 'U12345',
+      args,
+      db: mockDb,
+      slackToken: mockToken,
+      triggerId: 'test-trigger-id',
+    });
+
+    it('requires admin', async () => {
+      vi.mocked(isAdmin).mockReturnValue(false);
+      const response = await handlePrompt(createContextWithTrigger(['prompt', 'all', 'daily-il']));
+      expect(response.text).toContain('admin');
+    });
+
+    it('validates daily exists', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue(undefined);
+      const response = await handlePrompt(createContextWithTrigger(['prompt', 'all', 'nonexistent']));
+      expect(response.text).toContain('not found');
+    });
+
+    it('shows error when no participants', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getParticipants).mockResolvedValue([]);
+      const response = await handlePrompt(createContextWithTrigger(['prompt', 'all', 'daily-il']));
+      expect(response.text).toContain('No participants');
+    });
+
+    it('opens confirmation modal with participant count', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getParticipants).mockResolvedValue([
+        { slack_user_id: 'U111' },
+        { slack_user_id: 'U222' },
+        { slack_user_id: 'U333' },
+      ] as any);
+
+      const response = await handlePrompt(createContextWithTrigger(['prompt', 'all', 'daily-il']));
+
+      expect(openModal).toHaveBeenCalled();
+      const modalCall = vi.mocked(openModal).mock.calls[0];
+      const view = modalCall[2] as any;
+      expect(view.callback_id).toBe('mass_prompt_confirm');
+      expect(view.blocks[0].text.text).toContain('3 participants');
+    });
+
+    it('falls through to self-prompt when only `prompt all` (no daily name)', async () => {
+      vi.mocked(getUserDailies).mockResolvedValue([
+        { daily_name: 'daily-il' },
+      ] as any);
+      vi.mocked(sendPromptDM).mockResolvedValue(true);
+
+      const response = await handlePrompt(createContextWithTrigger(['prompt', 'all']));
+      expect(response.text).toContain('Sent prompts for 1 dailies');
     });
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for lib/config.ts - Config overrides and dynamic configuration
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadConfigOverrides, getOverride, isDailyEnabled, clearConfigCache, clearOverridesCache, getDailies, getAllDailiesIncludingDisabled } from '../lib/config';
+
+describe('config overrides', () => {
+  beforeEach(() => {
+    clearConfigCache();
+  });
+
+  it('returns undefined when overrides not loaded', () => {
+    clearOverridesCache();
+    expect(getOverride('global', 'some_key')).toBeUndefined();
+  });
+
+  it('loads overrides from DB and retrieves them', async () => {
+    const mockDb = {
+      query: async () => [
+        { scope: 'daily-test', key: 'enabled', value: false },
+        { scope: 'global', key: 'digest_time', value: '16:00' },
+      ],
+    };
+
+    await loadConfigOverrides(mockDb);
+
+    expect(getOverride('daily-test', 'enabled')).toBe(false);
+    expect(getOverride('global', 'digest_time')).toBe('16:00');
+    expect(getOverride('global', 'nonexistent')).toBeUndefined();
+  });
+
+  it('isDailyEnabled returns false when override is false', async () => {
+    const mockDb = {
+      query: async () => [
+        { scope: 'daily-test', key: 'enabled', value: false },
+      ],
+    };
+
+    await loadConfigOverrides(mockDb);
+
+    expect(isDailyEnabled('daily-test')).toBe(false);
+    expect(isDailyEnabled('other-daily')).toBe(true);
+  });
+
+  it('isDailyEnabled defaults to true when no override', async () => {
+    const mockDb = { query: async () => [] };
+    await loadConfigOverrides(mockDb);
+
+    expect(isDailyEnabled('daily-test')).toBe(true);
+  });
+
+  it('getDailies filters out disabled dailies', async () => {
+    const all = getAllDailiesIncludingDisabled();
+    expect(all.length).toBeGreaterThanOrEqual(1);
+
+    const dailyToDisable = all[0].name;
+
+    const mockDb = {
+      query: async () => [
+        { scope: dailyToDisable, key: 'enabled', value: false },
+      ],
+    };
+
+    await loadConfigOverrides(mockDb);
+
+    const enabled = getDailies();
+    expect(enabled.length).toBe(all.length - 1);
+    expect(enabled.find(d => d.name === dailyToDisable)).toBeUndefined();
+  });
+
+  it('getAllDailiesIncludingDisabled returns all dailies regardless of enabled state', async () => {
+    const allBefore = getAllDailiesIncludingDisabled();
+
+    const mockDb = {
+      query: async () => [
+        { scope: allBefore[0].name, key: 'enabled', value: false },
+      ],
+    };
+
+    await loadConfigOverrides(mockDb);
+
+    const allAfter = getAllDailiesIncludingDisabled();
+    expect(allAfter.length).toBe(allBefore.length);
+  });
+
+  it('clearConfigCache clears overrides too', async () => {
+    const mockDb = {
+      query: async () => [
+        { scope: 'global', key: 'test', value: 'hello' },
+      ],
+    };
+
+    await loadConfigOverrides(mockDb);
+    expect(getOverride('global', 'test')).toBe('hello');
+
+    clearConfigCache();
+    expect(getOverride('global', 'test')).toBeUndefined();
+  });
+});

--- a/tests/db-stats.test.ts
+++ b/tests/db-stats.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for stats-related pure functions in lib/db.ts
+ * Covers computeBlockerStreaks and the TS filtering logic of getUnplannedOverload
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the neon driver so db.ts can be imported without a real DB connection
+vi.mock('@neondatabase/serverless', () => ({
+  neon: vi.fn(() => vi.fn()),
+}));
+
+import { computeBlockerStreaks } from '../lib/db';
+
+describe('computeBlockerStreaks', () => {
+  it('returns empty array for empty input', () => {
+    expect(computeBlockerStreaks([])).toEqual([]);
+  });
+
+  it('returns empty array when single user has no blockers', () => {
+    const rows = [
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: false },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: false },
+    ];
+    expect(computeBlockerStreaks(rows)).toEqual([]);
+  });
+
+  it('single user, all blockers — current_streak = max_streak = total_blocker_days = N', () => {
+    const rows = [
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-03', has_blocker: true },
+    ];
+    const result = computeBlockerStreaks(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slack_user_id: 'U1',
+      current_streak: 3,
+      max_streak: 3,
+      total_blocker_days: 3,
+    });
+  });
+
+  it('single user, gap in middle — current_streak is trailing run, max_streak is longest', () => {
+    // blocker, clear, blocker, blocker — trailing run is 2, max was also 2... let's make it asymmetric
+    // blocker, blocker, blocker, clear, blocker, blocker
+    const rows = [
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-03', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-04', has_blocker: false },
+      { slack_user_id: 'U1', date: '2025-12-05', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-06', has_blocker: true },
+    ];
+    const result = computeBlockerStreaks(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slack_user_id: 'U1',
+      current_streak: 2,  // trailing run: Dec 5-6
+      max_streak: 3,      // longest run: Dec 1-3
+      total_blocker_days: 5,
+    });
+  });
+
+  it('single user, blockers then clear — current_streak = 0, max_streak is the earlier run', () => {
+    const rows = [
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-03', has_blocker: false },
+    ];
+    const result = computeBlockerStreaks(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slack_user_id: 'U1',
+      current_streak: 0,
+      max_streak: 2,
+      total_blocker_days: 2,
+    });
+  });
+
+  it('single blocker day — current_streak = max_streak = total = 1', () => {
+    const rows = [
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: false },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: true },
+    ];
+    const result = computeBlockerStreaks(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slack_user_id: 'U1',
+      current_streak: 1,
+      max_streak: 1,
+      total_blocker_days: 1,
+    });
+  });
+
+  it('multiple users — each gets independent streaks', () => {
+    const rows = [
+      // U1: 3-day streak then clear
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-03', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-04', has_blocker: false },
+      // U2: no blockers — should be excluded
+      { slack_user_id: 'U2', date: '2025-12-01', has_blocker: false },
+      { slack_user_id: 'U2', date: '2025-12-02', has_blocker: false },
+      // U3: 1 blocker day, trailing
+      { slack_user_id: 'U3', date: '2025-12-01', has_blocker: false },
+      { slack_user_id: 'U3', date: '2025-12-02', has_blocker: true },
+    ];
+
+    const result = computeBlockerStreaks(rows);
+
+    // U2 excluded (no blockers)
+    expect(result).toHaveLength(2);
+
+    const u1 = result.find(r => r.slack_user_id === 'U1');
+    expect(u1).toMatchObject({
+      current_streak: 0,  // last entry is false
+      max_streak: 3,
+      total_blocker_days: 3,
+    });
+
+    const u3 = result.find(r => r.slack_user_id === 'U3');
+    expect(u3).toMatchObject({
+      current_streak: 1,
+      max_streak: 1,
+      total_blocker_days: 1,
+    });
+  });
+
+  it('only returns users with at least one blocker day', () => {
+    const rows = [
+      { slack_user_id: 'U_CLEAN', date: '2025-12-01', has_blocker: false },
+      { slack_user_id: 'U_BLOCKED', date: '2025-12-01', has_blocker: true },
+    ];
+    const result = computeBlockerStreaks(rows);
+    expect(result.map(r => r.slack_user_id)).toEqual(['U_BLOCKED']);
+  });
+});

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -52,8 +52,8 @@ describe('format utilities', () => {
       });
 
       const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
-      expect(yesterdayBlock?.text?.text).toContain('☑️ Finished task A');
-      expect(yesterdayBlock?.text?.text).toContain('☑️ Completed task B');
+      expect(yesterdayBlock?.text?.text).toContain('✅ Finished task A');
+      expect(yesterdayBlock?.text?.text).toContain('✅ Completed task B');
     });
 
     it('marks unplanned items with unplanned label', () => {
@@ -67,7 +67,7 @@ describe('format utilities', () => {
       });
 
       const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
-      expect(yesterdayBlock?.text?.text).toContain('☑️ Fixed urgent bug _(unplanned)_');
+      expect(yesterdayBlock?.text?.text).toContain('⚡ Fixed urgent bug _(unplanned)_');
     });
 
     it('marks dropped items with red X in yesterday section', () => {
@@ -82,7 +82,7 @@ describe('format utilities', () => {
       });
 
       const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
-      expect(yesterdayBlock?.text?.text).toContain('☑️ Finished task');
+      expect(yesterdayBlock?.text?.text).toContain('✅ Finished task');
       expect(yesterdayBlock?.text?.text).toContain('❌ Cancelled task _(dropped)_');
       expect(yesterdayBlock?.text?.text).toContain('❌ No longer needed _(dropped)_');
     });
@@ -100,7 +100,7 @@ describe('format utilities', () => {
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
       expect(todayBlock?.text?.text).toContain('🔄 WIP task _(in progress)_');
-      expect(todayBlock?.text?.text).toContain('⬜ New task');
+      expect(todayBlock?.text?.text).toContain('🎯 New task');
     });
 
     it('shows ⚠️ for in-progress items with carry_count >= 3', () => {
@@ -150,8 +150,8 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('⬜ Ongoing work _(carried over)_');
-      expect(todayBlock?.text?.text).toContain('⬜ New task');
+      expect(todayBlock?.text?.text).toContain('➡️ Ongoing work _(carried over)_');
+      expect(todayBlock?.text?.text).toContain('🎯 New task');
     });
 
     it('adds separator between carried over and new items', () => {
@@ -447,7 +447,7 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('⬜ Ship the feature');
+      expect(todayBlock?.text?.text).toContain('🎯 Ship the feature');
       expect(todayBlock?.text?.text).not.toContain('<http');
     });
   });

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -402,6 +402,54 @@ describe('format utilities', () => {
       expect(footer.type).toBe('context');
       expect(footer.elements?.[0]?.text).toContain('daily-il standup');
     });
+
+    it('enriches PR items with clickable GitHub links', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: ['[my-repo#42] Fix typo'],
+        yesterdayIncomplete: [],
+        unplanned: [],
+        todayPlans: ['[other-repo#99] Add feature'],
+        blockers: '',
+        customAnswers: {},
+        githubOrg: 'thenvoi',
+      });
+
+      const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
+      expect(yesterdayBlock?.text?.text).toContain('<https://github.com/thenvoi/my-repo/pull/42|📦 my-repo#42>');
+
+      const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
+      expect(todayBlock?.text?.text).toContain('<https://github.com/thenvoi/other-repo/pull/99|📦 other-repo#99>');
+    });
+
+    it('enriches Linear items with clickable Linear links', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: [],
+        yesterdayIncomplete: [],
+        unplanned: [],
+        todayPlans: ['[ENG-123] Fix auth bug'],
+        blockers: '',
+        customAnswers: {},
+      });
+
+      const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
+      expect(todayBlock?.text?.text).toContain('<https://linear.app/issue/ENG-123|🎫 ENG-123>');
+      expect(todayBlock?.text?.text).toContain('Fix auth bug');
+    });
+
+    it('leaves manual items unchanged (no enrichment)', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: [],
+        yesterdayIncomplete: [],
+        unplanned: [],
+        todayPlans: ['Ship the feature'],
+        blockers: '',
+        customAnswers: {},
+      });
+
+      const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
+      expect(todayBlock?.text?.text).toContain('⬜ Ship the feature');
+      expect(todayBlock?.text?.text).not.toContain('<http');
+    });
   });
 
   describe('formatDailyDigest', () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1690,6 +1690,221 @@ describe('format utilities', () => {
     });
   });
 
+  describe('formatManagerDigest - blocker streaks and unplanned overload', () => {
+    it('shows 🚧 in Needs Attention when current_streak >= 3', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        blockerStreaks: [
+          { slack_user_id: 'U111', current_streak: 3, max_streak: 3, total_blocker_days: 3 },
+        ],
+      });
+
+      expect(result).toContain('Needs Attention');
+      expect(result).toContain('🚧 <@U111>');
+      expect(result).toContain('blocked 3 consecutive days');
+    });
+
+    it('does NOT show 🚧 streak warning when current_streak < 3', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        blockerStreaks: [
+          { slack_user_id: 'U222', current_streak: 2, max_streak: 4, total_blocker_days: 6 },
+        ],
+      });
+
+      // No 🚧 streak warning in action items (current_streak is only 2)
+      expect(result).not.toContain('consecutive days');
+    });
+
+    it('shows ⚡ in Needs Attention for unplanned overloads with correct percentages', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        unplannedOverloads: [
+          { slack_user_id: 'U333', unplanned_count: 7, completed_count: 10, unplanned_pct: 70 },
+        ],
+      });
+
+      expect(result).toContain('Needs Attention');
+      expect(result).toContain('⚡ <@U333>');
+      expect(result).toContain('70% unplanned work');
+      expect(result).toContain('7/10 items');
+    });
+
+    it('no crash and no Needs Attention section when blockerStreaks and unplannedOverloads are absent', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        // no blockerStreaks, no unplannedOverloads
+      });
+
+      expect(result).not.toContain('Needs Attention');
+    });
+
+    it('no crash and no Needs Attention when arrays are empty', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        blockerStreaks: [],
+        unplannedOverloads: [],
+      });
+
+      expect(result).not.toContain('Needs Attention');
+    });
+  });
+
+  describe('formatFullReport - blocker streaks and unplanned overload', () => {
+    const baseOptions = {
+      dailyName: 'daily-il',
+      period: 'weekly' as const,
+      startDate: '2025-12-12',
+      endDate: '2025-12-18',
+      submissions: [],
+      stats: [
+        { slack_user_id: 'U111', submission_count: 5, total_completed: 10, total_planned: 12, total_blockers: 3, avg_items_per_day: 2.4 },
+      ],
+      totalWorkdays: 5,
+    };
+
+    it('shows per-user blocker streak line when current_streak >= 3', () => {
+      const result = formatFullReport({
+        ...baseOptions,
+        blockerStreaks: [
+          { slack_user_id: 'U111', current_streak: 4, max_streak: 4, total_blocker_days: 4 },
+        ],
+      });
+
+      expect(result).toContain('🚧 Current blocker streak: 4 days');
+    });
+
+    it('does NOT show blocker streak line when current_streak < 3', () => {
+      const result = formatFullReport({
+        ...baseOptions,
+        blockerStreaks: [
+          { slack_user_id: 'U111', current_streak: 2, max_streak: 5, total_blocker_days: 7 },
+        ],
+      });
+
+      expect(result).not.toContain('Current blocker streak');
+    });
+
+    it('shows per-user unplanned overload line', () => {
+      const result = formatFullReport({
+        ...baseOptions,
+        unplannedOverloads: [
+          { slack_user_id: 'U111', unplanned_count: 8, completed_count: 10, unplanned_pct: 80 },
+        ],
+      });
+
+      expect(result).toContain('⚡ Unplanned work: 80%');
+      expect(result).toContain('8/10 items');
+    });
+
+    it('does not show overload line for users not in unplannedOverloads', () => {
+      const result = formatFullReport({
+        ...baseOptions,
+        unplannedOverloads: [], // U111 not in the list
+      });
+
+      expect(result).not.toContain('Unplanned work');
+    });
+
+    it('trend section includes unplanned_rate when present', () => {
+      const result = formatFullReport({
+        ...baseOptions,
+        trends: {
+          current: {
+            participation_rate: 80,
+            completion_rate: 75,
+            blocker_rate: 10,
+            unplanned_rate: 35,
+            total_submissions: 5,
+            total_participants: 1,
+            total_items_completed: 10,
+            total_items_dropped: 3,
+            avg_items_per_day: 2.4,
+          },
+          previous: {
+            participation_rate: 70,
+            completion_rate: 65,
+            blocker_rate: 15,
+            unplanned_rate: 50,
+            total_submissions: 4,
+            total_participants: 1,
+            total_items_completed: 8,
+            total_items_dropped: 4,
+            avg_items_per_day: 2.0,
+          },
+        },
+      });
+
+      expect(result).toContain('Unplanned work');
+      expect(result).toContain('35%');
+    });
+
+    it('trend section omits unplanned_rate when it is 0 / undefined', () => {
+      // unplanned_rate = 0 is falsy, so the condition `!== undefined` matters
+      // The format.ts code checks: if (trends.current.unplanned_rate !== undefined)
+      const result = formatFullReport({
+        ...baseOptions,
+        trends: {
+          current: {
+            participation_rate: 80,
+            completion_rate: 75,
+            blocker_rate: 10,
+            unplanned_rate: 0,
+            total_submissions: 5,
+            total_participants: 1,
+            total_items_completed: 10,
+            total_items_dropped: 3,
+            avg_items_per_day: 2.4,
+          },
+          previous: {
+            participation_rate: 70,
+            completion_rate: 65,
+            blocker_rate: 15,
+            unplanned_rate: 0,
+            total_submissions: 4,
+            total_participants: 1,
+            total_items_completed: 8,
+            total_items_dropped: 4,
+            avg_items_per_day: 2.0,
+          },
+        },
+      });
+
+      // unplanned_rate is 0 (not undefined) so line should appear, showing "0%"
+      expect(result).toContain('Unplanned work');
+    });
+  });
+
   describe('formatFullReport - in-progress flagging', () => {
     it('shows in-progress needs-attention section per user', () => {
       const result = formatFullReport({

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -20,6 +20,7 @@ import {
   formatLinearDigestSection,
   formatMemberPRSummary,
   formatTeamSummary,
+  formatFullReport,
 } from '../lib/format';
 import type { TeamPRData } from '../lib/github';
 import type { TeamLinearData, CycleProgress } from '../lib/linear';
@@ -117,7 +118,23 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('⚠️ Stuck task _(in progress)_');
+      expect(todayBlock?.text?.text).toContain('⚠️ Stuck task _(Day 3 — needs attention)_');
+    });
+
+    it('shows 🔄 Day X for in-progress items with carry_count 1-2', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: [],
+        yesterdayIncomplete: [],
+        yesterdayInProgress: ['WIP task'],
+        unplanned: [],
+        todayPlans: [],
+        blockers: '',
+        customAnswers: {},
+        inProgressCarryCounts: { 'WIP task': 2 },
+      });
+
+      const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
+      expect(todayBlock?.text?.text).toContain('🔄 WIP task _(Day 2)_');
     });
 
     it('renders in-progress items before carried-over items', () => {
@@ -836,8 +853,8 @@ describe('format utilities', () => {
         stats: [],
         totalWorkdays: 5,
         bottlenecks: [
-          { id: 1, text: 'Fix auth timeout issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' },
-          { id: 2, text: 'Update API docs', slack_user_id: 'U67890', carry_count: 3, days_pending: 3, type: 'carry' },
+          { id: 1, text: 'Fix auth timeout issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry', status: 'carried' },
+          { id: 2, text: 'Update API docs', slack_user_id: 'U67890', carry_count: 3, days_pending: 3, type: 'carry', status: 'carried' },
         ],
       });
 
@@ -1130,7 +1147,7 @@ describe('format utilities', () => {
 
     it('creates header section for bottleneck items', () => {
       const bottlenecks = [
-        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const },
+        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const, status: 'carried' as const },
       ];
 
       const blocks = buildBottleneckBlocks(bottlenecks, 'daily-il');
@@ -1143,8 +1160,8 @@ describe('format utilities', () => {
 
     it('creates section for each bottleneck item with snooze button', () => {
       const bottlenecks = [
-        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const },
-        { id: 2, text: 'Update docs', slack_user_id: 'U67890', carry_count: 3, days_pending: 3, type: 'carry' as const },
+        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const, status: 'carried' as const },
+        { id: 2, text: 'Update docs', slack_user_id: 'U67890', carry_count: 3, days_pending: 3, type: 'carry' as const, status: 'carried' as const },
       ];
 
       const blocks = buildBottleneckBlocks(bottlenecks, 'daily-il');
@@ -1156,7 +1173,7 @@ describe('format utilities', () => {
 
     it('includes item text and user mention in section', () => {
       const bottlenecks = [
-        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const },
+        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const, status: 'carried' as const },
       ];
 
       const blocks = buildBottleneckBlocks(bottlenecks, 'daily-il');
@@ -1169,7 +1186,7 @@ describe('format utilities', () => {
 
     it('includes snooze button with correct action_id', () => {
       const bottlenecks = [
-        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const },
+        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const, status: 'carried' as const },
       ];
 
       const blocks = buildBottleneckBlocks(bottlenecks, 'daily-il');
@@ -1182,7 +1199,7 @@ describe('format utilities', () => {
 
     it('includes item id and daily name in button value', () => {
       const bottlenecks = [
-        { id: 42, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const },
+        { id: 42, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const, status: 'carried' as const },
       ];
 
       const blocks = buildBottleneckBlocks(bottlenecks, 'daily-il');
@@ -1627,6 +1644,114 @@ describe('format utilities', () => {
       });
 
       expect(result).toBe('');
+    });
+  });
+
+  describe('in-progress needs-attention in digest', () => {
+    it('shows 🔄 for in-progress bottleneck items in digest', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        bottlenecks: [
+          { id: 1, text: 'Long-running refactor', slack_user_id: 'U111', carry_count: 4, days_pending: 5, type: 'carry', status: 'in_progress' },
+        ],
+      });
+
+      expect(result).toContain('Needs Attention');
+      expect(result).toContain('🔄 <@U111>');
+      expect(result).toContain('in progress Day 4');
+      expect(result).not.toContain('stuck');
+    });
+
+    it('shows 🔥 for carried bottleneck items and 🔄 for in-progress in same digest', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        bottlenecks: [
+          { id: 1, text: 'Stuck task', slack_user_id: 'U111', carry_count: 3, days_pending: 4, type: 'carry', status: 'carried' },
+          { id: 2, text: 'WIP task', slack_user_id: 'U222', carry_count: 5, days_pending: 6, type: 'carry', status: 'in_progress' },
+        ],
+      });
+
+      expect(result).toContain('🔥 <@U111>');
+      expect(result).toContain('stuck 4 days');
+      expect(result).toContain('🔄 <@U222>');
+      expect(result).toContain('in progress Day 5');
+    });
+  });
+
+  describe('formatFullReport - in-progress flagging', () => {
+    it('shows in-progress needs-attention section per user', () => {
+      const result = formatFullReport({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [
+          { slack_user_id: 'U111', submission_count: 4, total_completed: 10, total_planned: 12, total_blockers: 0, avg_items_per_day: 3 },
+        ],
+        totalWorkdays: 5,
+        bottlenecks: [
+          { id: 1, text: 'Long-running migration', slack_user_id: 'U111', carry_count: 4, days_pending: 5, type: 'carry', status: 'in_progress' },
+        ],
+      });
+
+      expect(result).toContain('In progress — needs attention');
+      expect(result).toContain('🔄 "Long-running migration" (Day 4)');
+    });
+
+    it('separates in-progress and carried stuck items in report', () => {
+      const result = formatFullReport({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [
+          { slack_user_id: 'U111', submission_count: 4, total_completed: 10, total_planned: 12, total_blockers: 0, avg_items_per_day: 3 },
+        ],
+        totalWorkdays: 5,
+        bottlenecks: [
+          { id: 1, text: 'WIP refactor', slack_user_id: 'U111', carry_count: 4, days_pending: 5, type: 'carry', status: 'in_progress' },
+          { id: 2, text: 'Abandoned PR', slack_user_id: 'U111', carry_count: 3, days_pending: 4, type: 'carry', status: 'carried' },
+        ],
+      });
+
+      expect(result).toContain('In progress — needs attention');
+      expect(result).toContain('🔄 "WIP refactor" (Day 4)');
+      expect(result).toContain('Stuck items');
+      expect(result).toContain('🔥 "Abandoned PR" (4 days, carried 3x)');
+    });
+
+    it('does not show in-progress section when no in-progress bottlenecks', () => {
+      const result = formatFullReport({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [
+          { slack_user_id: 'U111', submission_count: 4, total_completed: 10, total_planned: 12, total_blockers: 0, avg_items_per_day: 3 },
+        ],
+        totalWorkdays: 5,
+        bottlenecks: [
+          { id: 1, text: 'Old task', slack_user_id: 'U111', carry_count: 3, days_pending: 4, type: 'carry', status: 'carried' },
+        ],
+      });
+
+      expect(result).not.toContain('In progress — needs attention');
+      expect(result).toContain('Stuck items');
     });
   });
 });

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1022,6 +1022,60 @@ describe('format utilities', () => {
 
       expect(result).not.toContain('Work Alignment');
     });
+
+    it('shows OOO users in daily digest', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'daily',
+        startDate: '2025-12-18',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 1,
+        oooToday: [
+          { slackUserId: 'U111', endDate: '2025-12-20' },
+          { slackUserId: 'U222', endDate: '2025-12-25' },
+        ],
+      });
+
+      expect(result).toContain('Out today');
+      expect(result).toContain('<@U111>');
+      expect(result).toContain('<@U222>');
+      expect(result).toContain('Dec 20');
+      expect(result).toContain('Dec 25');
+    });
+
+    it('does not show OOO section in weekly digest', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        oooToday: [
+          { slackUserId: 'U111', endDate: '2025-12-20' },
+        ],
+      });
+
+      expect(result).not.toContain('Out today');
+    });
+
+    it('does not show OOO section when no one is OOO', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'daily',
+        startDate: '2025-12-18',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 1,
+        oooToday: [],
+      });
+
+      expect(result).not.toContain('Out today');
+    });
   });
 
   describe('buildBottleneckBlocks', () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1076,6 +1076,49 @@ describe('format utilities', () => {
 
       expect(result).not.toContain('Out today');
     });
+
+    it('flags users who routinely over-plan when maxPlanItems is set', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'daily',
+        startDate: '2025-12-18',
+        endDate: '2025-12-18',
+        submissions: [
+          { slack_user_id: 'U111', today_plans: ['a', 'b', 'c', 'd', 'e', 'f'], yesterday_incomplete: [], yesterday_in_progress: [] } as any,
+          { slack_user_id: 'U222', today_plans: ['a', 'b'], yesterday_incomplete: [], yesterday_in_progress: [] } as any,
+        ],
+        stats: [
+          { slack_user_id: 'U111', submission_count: 1, total_completed: 2, avg_items_per_day: '6' } as any,
+          { slack_user_id: 'U222', submission_count: 1, total_completed: 1, avg_items_per_day: '2' } as any,
+        ],
+        totalWorkdays: 1,
+        maxPlanItems: 5,
+      });
+
+      expect(result).toContain('avg 6 plans');
+      // U222 appears in team but without over-plan flag
+      expect(result).toContain('<@U222>');
+      const u222Line = result.split('\n').find((l: string) => l.includes('U222'));
+      expect(u222Line).not.toContain('avg');
+    });
+
+    it('does not flag over-plan when maxPlanItems is not set', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'daily',
+        startDate: '2025-12-18',
+        endDate: '2025-12-18',
+        submissions: [
+          { slack_user_id: 'U111', today_plans: ['a', 'b', 'c', 'd', 'e', 'f'], yesterday_incomplete: [], yesterday_in_progress: [] } as any,
+        ],
+        stats: [
+          { slack_user_id: 'U111', submission_count: 1, total_completed: 2, avg_items_per_day: '6' } as any,
+        ],
+        totalWorkdays: 1,
+      });
+
+      expect(result).not.toContain('avg');
+    });
   });
 
   describe('buildBottleneckBlocks', () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -19,6 +19,7 @@ import {
   formatPRDigestSection,
   formatLinearDigestSection,
   formatMemberPRSummary,
+  formatTeamSummary,
 } from '../lib/format';
 import type { TeamPRData } from '../lib/github';
 import type { TeamLinearData, CycleProgress } from '../lib/linear';
@@ -1570,6 +1571,62 @@ describe('format utilities', () => {
       const result = formatMemberPRSummary(prData);
 
       expect(result).toBe('3 draft');
+    });
+  });
+
+  describe('formatTeamSummary', () => {
+    it('shows one line per person with top plan items', () => {
+      const result = formatTeamSummary({
+        dailyName: 'daily-il',
+        channel: 'C123',
+        submissions: [
+          { slack_user_id: 'U111', today_plans: ['Ship auth', 'Fix tests'], blockers: null, slack_message_ts: null } as any,
+          { slack_user_id: 'U222', today_plans: ['Review PR'], blockers: null, slack_message_ts: null } as any,
+        ],
+      });
+
+      expect(result).toContain('daily-il — Team Summary');
+      expect(result).toContain('<@U111>');
+      expect(result).toContain('Ship auth');
+      expect(result).toContain('Fix tests');
+      expect(result).toContain('<@U222>');
+      expect(result).toContain('Review PR');
+    });
+
+    it('shows blockers in a separate section', () => {
+      const result = formatTeamSummary({
+        dailyName: 'daily-il',
+        channel: 'C123',
+        submissions: [
+          { slack_user_id: 'U111', today_plans: ['Ship auth'], blockers: 'Waiting on API key', slack_message_ts: null } as any,
+        ],
+      });
+
+      expect(result).toContain('Blockers');
+      expect(result).toContain('<@U111>: Waiting on API key');
+    });
+
+    it('includes message permalink when slack_message_ts is present', () => {
+      const result = formatTeamSummary({
+        dailyName: 'daily-il',
+        channel: 'C123',
+        submissions: [
+          { slack_user_id: 'U111', today_plans: ['Ship auth'], blockers: null, slack_message_ts: '1234567890.123456' } as any,
+        ],
+      });
+
+      expect(result).toContain('slack.com/archives/C123/p1234567890123456');
+      expect(result).toContain('↗');
+    });
+
+    it('returns empty string when no submissions', () => {
+      const result = formatTeamSummary({
+        dailyName: 'daily-il',
+        channel: 'C123',
+        submissions: [],
+      });
+
+      expect(result).toBe('');
     });
   });
 });

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -154,7 +154,7 @@ describe('buildHomeView - Today\'s Plans section', () => {
     const text = (planBlock as any).elements[0].text;
     expect(text).toContain('✅ ~Fix auth bug~');
     expect(text).toContain('🔄 Refactor DB layer');
-    expect(text).toContain('⬜ Deploy to staging');
+    expect(text).toContain('🎯 Deploy to staging');
     expect(text).toContain('➡️ Old task _(carried)_');
     expect(text).toContain('❌ ~Abandoned idea~');
   });
@@ -192,7 +192,7 @@ describe('buildHomeView - Today\'s Plans section', () => {
 
     // No context block with plan items
     const planBlocks = view.blocks.filter(
-      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('⬜')
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('🎯')
     );
     expect(planBlocks).toHaveLength(0);
   });
@@ -275,7 +275,7 @@ describe('handleAppHomeOpened - Today\'s Plans from submission', () => {
     const text = (planBlock as any).elements[0].text;
     expect(text).toContain('🔄 WIP task');
     expect(text).toContain('➡️ Carried task');
-    expect(text).toContain('⬜ New plan');
+    expect(text).toContain('🎯 New plan');
     expect(text).toContain('✅ ~Done task~');
   });
 });

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -14,6 +14,8 @@ vi.mock('../lib/db', () => ({
   setGitHubUsername: vi.fn(),
   setLinearUserId: vi.fn(),
   getDmStandupPreference: vi.fn(() => Promise.resolve(false)),
+  getUserSettings: vi.fn(() => Promise.resolve({ dmStandup: false, maxItems: null, stalePrDays: null, linearTeamFilter: null })),
+  getActiveOOO: vi.fn(() => Promise.resolve(null)),
 }));
 
 // Mock the config module
@@ -55,7 +57,7 @@ import { publishHomeView } from '../lib/slack';
 
 describe('buildHomeView - linked accounts section', () => {
   it('shows Link buttons when accounts are not linked', () => {
-    const linkedAccounts: LinkedAccounts = { github: null, linear: null, dmStandup: true };
+    const linkedAccounts: LinkedAccounts = { github: null, linear: null, dmStandup: true, maxItems: null, stalePrDays: null, linearTeamFilter: null };
     const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
 
     // Find linked accounts header
@@ -82,7 +84,7 @@ describe('buildHomeView - linked accounts section', () => {
   });
 
   it('shows Unlink buttons when accounts are linked', () => {
-    const linkedAccounts: LinkedAccounts = { github: 'octocat', linear: 'lin-user-123', dmStandup: true };
+    const linkedAccounts: LinkedAccounts = { github: 'octocat', linear: 'lin-user-123', dmStandup: true, maxItems: null, stalePrDays: null, linearTeamFilter: null };
     const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
 
     // Find GitHub linked section
@@ -103,7 +105,7 @@ describe('buildHomeView - linked accounts section', () => {
   });
 
   it('shows mixed state (one linked, one not)', () => {
-    const linkedAccounts: LinkedAccounts = { github: 'myuser', linear: null, dmStandup: true };
+    const linkedAccounts: LinkedAccounts = { github: 'myuser', linear: null, dmStandup: true, maxItems: null, stalePrDays: null, linearTeamFilter: null };
     const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
 
     const githubSection = view.blocks.find(
@@ -126,6 +128,82 @@ describe('buildHomeView - linked accounts section', () => {
       (b: any) => b.type === 'header' && b.text?.text === '🔗 Linked Accounts'
     );
     expect(header).toBeUndefined();
+  });
+});
+
+describe('buildHomeView - Settings section', () => {
+  it('shows OOO status with clear button when OOO is active', () => {
+    const linkedAccounts: LinkedAccounts = {
+      github: null, linear: null, dmStandup: false,
+      maxItems: null, stalePrDays: null, linearTeamFilter: null,
+      oooStatus: { startDate: '2025-12-22', endDate: '2025-12-25' },
+    };
+    const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
+
+    const oooBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Out of Office')
+    );
+    expect(oooBlock).toBeDefined();
+    expect((oooBlock as any).text.text).toContain('Dec 22');
+    expect((oooBlock as any).text.text).toContain('Dec 25');
+    expect((oooBlock as any).accessory.action_id).toBe('home_clear_ooo');
+  });
+
+  it('shows Set OOO button when not OOO', () => {
+    const linkedAccounts: LinkedAccounts = {
+      github: null, linear: null, dmStandup: false,
+      maxItems: null, stalePrDays: null, linearTeamFilter: null,
+    };
+    const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
+
+    const oooBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Out of Office')
+    );
+    expect(oooBlock).toBeDefined();
+    expect((oooBlock as any).text.text).toContain('Not set');
+    expect((oooBlock as any).accessory.action_id).toBe('home_set_ooo');
+  });
+
+  it('shows max items setting with current value', () => {
+    const linkedAccounts: LinkedAccounts = {
+      github: null, linear: null, dmStandup: false,
+      maxItems: 5, stalePrDays: null, linearTeamFilter: null,
+    };
+    const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
+
+    const maxItemsBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Max items')
+    );
+    expect(maxItemsBlock).toBeDefined();
+    expect((maxItemsBlock as any).text.text).toContain('5 items');
+  });
+
+  it('shows stale PR days with custom value', () => {
+    const linkedAccounts: LinkedAccounts = {
+      github: null, linear: null, dmStandup: false,
+      maxItems: null, stalePrDays: 7, linearTeamFilter: null,
+    };
+    const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
+
+    const stalePrBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Stale PR')
+    );
+    expect(stalePrBlock).toBeDefined();
+    expect((stalePrBlock as any).text.text).toContain('7 days');
+  });
+
+  it('shows Linear team filter', () => {
+    const linkedAccounts: LinkedAccounts = {
+      github: null, linear: null, dmStandup: false,
+      maxItems: null, stalePrDays: null, linearTeamFilter: ['ENG', 'PLATFORM'],
+    };
+    const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
+
+    const linearBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Linear teams')
+    );
+    expect(linearBlock).toBeDefined();
+    expect((linearBlock as any).text.text).toContain('ENG, PLATFORM');
   });
 });
 

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -8,11 +8,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../lib/db', () => ({
   getUserDailies: vi.fn(() => Promise.resolve([])),
   getSubmissionForDate: vi.fn(() => Promise.resolve(null)),
+  getPreviousSubmission: vi.fn(() => Promise.resolve(null)),
   getGitHubUsername: vi.fn(() => Promise.resolve(null)),
   getLinearUserId: vi.fn(() => Promise.resolve(null)),
   setGitHubUsername: vi.fn(),
   setLinearUserId: vi.fn(),
-  getDmStandupPreference: vi.fn(() => Promise.resolve(true)),
+  getDmStandupPreference: vi.fn(() => Promise.resolve(false)),
 }));
 
 // Mock the config module
@@ -49,7 +50,7 @@ vi.mock('../lib/linear', () => ({
 }));
 
 import { buildHomeView, LinkedAccounts, handleAppHomeOpened, HomeContext, AppHomeOpenedEvent } from '../lib/handlers/home';
-import { getGitHubUsername, getLinearUserId } from '../lib/db';
+import { getGitHubUsername, getLinearUserId, getUserDailies, getSubmissionForDate, getPreviousSubmission } from '../lib/db';
 import { publishHomeView } from '../lib/slack';
 
 describe('buildHomeView - linked accounts section', () => {
@@ -128,6 +129,75 @@ describe('buildHomeView - linked accounts section', () => {
   });
 });
 
+describe('buildHomeView - Today\'s Plans section', () => {
+  it('shows plan items grouped by status', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: true,
+      tomorrowScheduled: false,
+      planItems: [
+        { text: 'Fix auth bug', status: 'done' as const },
+        { text: 'Refactor DB layer', status: 'in_progress' as const },
+        { text: 'Deploy to staging', status: 'planned' as const },
+        { text: 'Old task', status: 'carried' as const },
+        { text: 'Abandoned idea', status: 'dropped' as const },
+      ],
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    // Find context block with plan items
+    const planBlock = view.blocks.find(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('Fix auth bug')
+    );
+    expect(planBlock).toBeDefined();
+
+    const text = (planBlock as any).elements[0].text;
+    expect(text).toContain('✅ ~Fix auth bug~');
+    expect(text).toContain('🔄 Refactor DB layer');
+    expect(text).toContain('⬜ Deploy to staging');
+    expect(text).toContain('➡️ Old task _(carried)_');
+    expect(text).toContain('❌ ~Abandoned idea~');
+  });
+
+  it('shows source tags for integration items', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: true,
+      tomorrowScheduled: false,
+      planItems: [
+        { text: '[LIN-123] Fix auth', status: 'planned' as const, source: 'LIN-123' },
+        { text: '[repo#45] Add tests', status: 'done' as const, source: 'repo#45' },
+        { text: 'Manual task', status: 'planned' as const },
+      ],
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    const planBlock = view.blocks.find(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('LIN-123')
+    );
+    expect(planBlock).toBeDefined();
+    const text = (planBlock as any).elements[0].text;
+    expect(text).toContain('· _LIN-123_');
+    expect(text).toContain('· _repo#45_');
+    expect(text).not.toContain('Manual task · _');
+  });
+
+  it('does not show plan section when no submission', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: false,
+      tomorrowScheduled: false,
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    // No context block with plan items
+    const planBlocks = view.blocks.filter(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('⬜')
+    );
+    expect(planBlocks).toHaveLength(0);
+  });
+});
+
 describe('handleAppHomeOpened - fetches linked accounts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -155,5 +225,57 @@ describe('handleAppHomeOpened - fetches linked accounts', () => {
       (b: any) => b.type === 'section' && b.text?.text?.includes('@octocat')
     );
     expect(githubSection).toBeDefined();
+  });
+});
+
+describe('handleAppHomeOpened - Today\'s Plans from submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds plan items from today\'s submission', async () => {
+    // User is part of a daily
+    vi.mocked(getUserDailies).mockResolvedValueOnce([
+      { id: 1, slack_user_id: 'U12345', daily_name: 'daily-test', schedule_name: 'il-team', time_override: null, created_at: new Date() },
+    ]);
+    // Today's submission exists
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce({
+      id: 1,
+      slack_user_id: 'U12345',
+      daily_name: 'daily-test',
+      date: '2025-12-22',
+      submitted_at: new Date(),
+      yesterday_completed: ['Done task'],
+      yesterday_incomplete: ['Carried task'],
+      yesterday_in_progress: ['WIP task'],
+      unplanned: null,
+      today_plans: ['New plan'],
+      blockers: null,
+      custom_answers: null,
+      slack_message_ts: null,
+      posted: true,
+    });
+    // No previous submission (so no dropped items)
+    vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+    vi.mocked(publishHomeView).mockResolvedValueOnce(true);
+
+    const event: AppHomeOpenedEvent = { type: 'app_home_opened', user: 'U12345', tab: 'home' };
+    const ctx: HomeContext = { db: {} as any, slackToken: 'xoxb-test' };
+
+    await handleAppHomeOpened(event, ctx);
+
+    const publishCall = vi.mocked(publishHomeView).mock.calls[0];
+    const view = publishCall[2] as { blocks: Array<Record<string, unknown>> };
+
+    // Find the context block with plan items
+    const planBlock = view.blocks.find(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('New plan')
+    );
+    expect(planBlock).toBeDefined();
+    const text = (planBlock as any).elements[0].text;
+    expect(text).toContain('🔄 WIP task');
+    expect(text).toContain('➡️ Carried task');
+    expect(text).toContain('⬜ New plan');
+    expect(text).toContain('✅ ~Done task~');
   });
 });

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -571,12 +571,12 @@ describe('interaction handlers', () => {
       expect(sendDM).toHaveBeenCalledWith(
         'xoxb-test',
         'U12345',
-        expect.stringContaining('planning 5 items today')
+        expect.stringContaining('planning 5 items')
       );
       expect(sendDM).toHaveBeenCalledWith(
         'xoxb-test',
         'U12345',
-        expect.stringContaining('under 5')
+        expect.stringContaining('3 new + 2 carried')
       );
     });
 
@@ -624,7 +624,12 @@ describe('interaction handlers', () => {
       expect(sendDM).toHaveBeenCalledWith(
         'xoxb-test',
         'U12345',
-        expect.stringContaining('planning 3 items today')
+        expect.stringContaining('planning 3 items')
+      );
+      expect(sendDM).toHaveBeenCalledWith(
+        'xoxb-test',
+        'U12345',
+        expect.stringContaining('1 new + 2 carried')
       );
     });
 

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -702,6 +702,66 @@ describe('modal builder', () => {
     });
   });
 
+  describe('yesterday items grouping by source', () => {
+    it('groups items by source when mixed (manual, PR, Linear)', () => {
+      const yesterday: YesterdayData = {
+        plans: [
+          'Manual task',
+          '[repo#42] Fix typo',
+          '[ENG-123] Auth refactor',
+          'Another manual task',
+        ],
+        completed: [],
+        incomplete: [],
+      };
+
+      const modal = buildStandupModal('daily-il', yesterday, []);
+
+      // Should have group header context blocks when mixed
+      const contextBlocks = modal.blocks.filter(
+        (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('items')
+      );
+      expect(contextBlocks.length).toBe(3); // Manual, PR, Linear
+
+      // Verify headers exist
+      const headers = contextBlocks.map((b: any) => b.elements[0].text);
+      expect(headers).toContain('*✍️ Manual items*');
+      expect(headers).toContain('*📦 PR items*');
+      expect(headers).toContain('*🎫 Linear items*');
+    });
+
+    it('does not show group headers when all items are from one source', () => {
+      const yesterday: YesterdayData = {
+        plans: ['Task A', 'Task B', 'Task C'],
+        completed: [],
+        incomplete: [],
+      };
+
+      const modal = buildStandupModal('daily-il', yesterday, []);
+
+      // Should NOT have source group headers
+      const groupHeaders = modal.blocks.filter(
+        (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('items*')
+      );
+      expect(groupHeaders).toHaveLength(0);
+    });
+
+    it('preserves dropdown indices across groups', () => {
+      const yesterday: YesterdayData = {
+        plans: ['Manual task', '[repo#42] PR task', '[ENG-123] Linear task'],
+        completed: [],
+        incomplete: [],
+      };
+
+      const modal = buildStandupModal('daily-il', yesterday, []);
+
+      // All three items should have their original indices
+      expect(modal.blocks.find(b => b.block_id === 'yesterday_item_0')).toBeDefined();
+      expect(modal.blocks.find(b => b.block_id === 'yesterday_item_1')).toBeDefined();
+      expect(modal.blocks.find(b => b.block_id === 'yesterday_item_2')).toBeDefined();
+    });
+  });
+
   describe('plan-size warning banner', () => {
     const findWarning = (blocks: { type: string; text?: { text?: string } }[]) =>
       blocks.find(b => b.type === 'section' && b.text?.text?.includes('Teams usually stay under'));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,20 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, Plugin } from 'vitest/config';
+import { readFileSync } from 'fs';
+
+function yamlTextPlugin(): Plugin {
+  return {
+    name: 'yaml-text',
+    transform(_code: string, id: string) {
+      if (id.endsWith('.yaml') || id.endsWith('.yml')) {
+        const content = readFileSync(id, 'utf-8');
+        return { code: `export default ${JSON.stringify(content)};`, map: null };
+      }
+    },
+  };
+}
 
 export default defineConfig({
+  plugins: [yamlTextPlugin()],
   test: {
     globals: true,
     environment: 'node',
@@ -9,7 +23,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       include: ['lib/**/*.ts'],
-      exclude: ['lib/handlers/**/*.ts'], // Integration tests separately
+      exclude: ['lib/handlers/**/*.ts'],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
- **Blocker streak tracking**: `computeBlockerStreaks()` walks submission data to compute consecutive days with blockers per user. Users blocked 3+ days flagged with 🚧 in digest and report.
- **Unplanned overload alert**: `getUnplannedOverload()` detects users with >70% unplanned work, surfaced with ⚡ in digest and report.
- **Unplanned rate trends**: `PeriodStats.unplanned_rate` enables ↑↓→ trend comparison in full report.
- ~~Sparklines~~ skipped — Slack Block Kit doesn't support them; existing trend indicators are sufficient.
- 19 new tests (361 total), type check clean.

## Test plan
- [x] `npx vitest run` — 361 tests passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: `/standup digest daily-il` with users who have consecutive blockers → 🚧 in action items
- [ ] Manual: `/standup report daily-il week` with high unplanned % → ⚡ in per-user section + trend line