### PR TITLE
feat: GitHub Work Alignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Type check
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test:run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Create config for tests
+        run: cp config.yaml.example config.yaml
+
       - run: npm ci
 
       - name: Type check

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,7 +3,7 @@
  * Routes requests to appropriate handlers
  */
 
-import { loadConfig, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems } from '../lib/config';
+import { loadConfig, loadConfigOverrides, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems, isDailyEnabled } from '../lib/config';
 import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
 import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate } from '../lib/db';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
@@ -89,6 +89,7 @@ export default {
     if (cronPattern === '*/30 * * * *') {
       console.log('Running prompt cron job');
       const db = getDb(env.DATABASE_URL);
+      await loadConfigOverrides(db);
 
       // Run prompt cron (send DM prompts to users)
       const promptStats = await runPromptCron(db, env.SLACK_BOT_TOKEN);
@@ -168,6 +169,7 @@ async function handleSlackCommands(request: Request, env: Env): Promise<Response
 
   const payload = parseCommandPayload(body);
   const db = getDb(env.DATABASE_URL);
+  await loadConfigOverrides(db);
 
   // Handle /daily command separately
   if (payload.command === '/daily') {
@@ -241,6 +243,7 @@ async function handleSlackInteractions(request: Request, env: Env, ctx: Executio
   console.log('Interaction:', { type: payload.type, user: payload.user.id });
 
   const db = getDb(env.DATABASE_URL);
+  await loadConfigOverrides(db);
   const result = await handleInteraction(payload, {
     db,
     slackToken: env.SLACK_BOT_TOKEN,
@@ -301,6 +304,7 @@ async function handleSlackEvents(request: Request, env: Env): Promise<Response> 
     // Handle app_home_opened event
     if (event.type === 'app_home_opened') {
       const db = getDb(env.DATABASE_URL);
+      await loadConfigOverrides(db);
       await handleAppHomeOpened(event, {
         db,
         slackToken: env.SLACK_BOT_TOKEN,
@@ -325,6 +329,7 @@ async function handlePromptCron(url: URL, env: Env): Promise<Response> {
   const force = url.searchParams.get('force') === 'true';
 
   const db = getDb(env.DATABASE_URL);
+  await loadConfigOverrides(db);
   const stats = await runPromptCron(db, env.SLACK_BOT_TOKEN, force);
 
   return new Response(JSON.stringify({
@@ -395,6 +400,8 @@ async function handleDigestCron(url: URL, env: Env): Promise<Response> {
     return new Response('Invalid period. Use: daily, weekly, 4-week', { status: 400 });
   }
 
+  const db = getDb(env.DATABASE_URL);
+  await loadConfigOverrides(db);
   const result = await runDigestCron(env, period);
 
   return new Response(JSON.stringify({

--- a/api/index.ts
+++ b/api/index.ts
@@ -12,7 +12,7 @@ import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserD
 import { handleCommand, handleDaily } from '../lib/handlers/commands';
 import { handleInteraction, InteractionPayload } from '../lib/handlers/interactions';
 import { handleAppHomeOpened, AppHomeOpenedEvent } from '../lib/handlers/home';
-import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics, OOOInfo } from '../lib/format';
+import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics, OOOInfo, formatTeamSummary } from '../lib/format';
 
 // ============================================================================
 // Types
@@ -499,6 +499,27 @@ async function runDigestCronUnified(env: Env): Promise<{
           await postMessage(env.SLACK_BOT_TOKEN, daily.channel, oooText);
         } catch (err) {
           console.error(`Failed to post OOO notice to channel for "${daily.name}":`, err);
+        }
+      }
+
+      // Post team summary to channel (opt-in per-daily, workdays only)
+      if (isWorkdayToday && daily.team_summary) {
+        try {
+          const todaySubs = await getSubmissionsInRange(db, daily.name, todayStr, todayStr);
+          if (todaySubs.length > 0) {
+            const githubCfg = getGitHubConfig(daily);
+            const summaryText = formatTeamSummary({
+              dailyName: daily.name,
+              channel: daily.channel,
+              submissions: todaySubs,
+              githubOrg: githubCfg?.org,
+            });
+            if (summaryText) {
+              await postMessage(env.SLACK_BOT_TOKEN, daily.channel, summaryText);
+            }
+          }
+        } catch (err) {
+          console.error(`Failed to post team summary for "${daily.name}":`, err);
         }
       }
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -4,15 +4,15 @@
  */
 
 import { loadConfig, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser } from '../lib/config';
-import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks } from '../lib/slack';
-import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks } from '../lib/db';
+import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
+import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate } from '../lib/db';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
 import { fetchTeamCycleData, TeamLinearData, CycleProgress } from '../lib/linear';
 import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate } from '../lib/prompt';
 import { handleCommand, handleDaily } from '../lib/handlers/commands';
 import { handleInteraction, InteractionPayload } from '../lib/handlers/interactions';
 import { handleAppHomeOpened, AppHomeOpenedEvent } from '../lib/handlers/home';
-import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics } from '../lib/format';
+import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics, OOOInfo } from '../lib/format';
 
 // ============================================================================
 // Types
@@ -476,6 +476,28 @@ async function runDigestCronUnified(env: Env): Promise<{
         errors += weeklyResult.errors;
       }
 
+      // Post OOO notice to daily channel for users whose OOO starts today
+      const todayStr = formatDate(new Date());
+      const oooStarting = await getOOOStartingOnDate(db, daily.name, todayStr);
+      if (oooStarting.length > 0) {
+        const formatShortDate = (d: string) => {
+          const date = new Date(d + 'T00:00:00');
+          return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+        };
+        const oooLines = oooStarting.map(r => {
+          const back = r.start_date === r.end_date
+            ? 'back tomorrow'
+            : `back ${formatShortDate(r.end_date)}`;
+          return `<@${r.slack_user_id}> (${back})`;
+        });
+        const oooText = `🏖️ *Out today:* ${oooLines.join(' · ')}`;
+        try {
+          await postMessage(env.SLACK_BOT_TOKEN, daily.channel, oooText);
+        } catch (err) {
+          console.error(`Failed to post OOO notice to channel for "${daily.name}":`, err);
+        }
+      }
+
       processedDailies.push(daily.name);
     } catch (err) {
       console.error(`Failed to process digests for "${daily.name}":`, err);
@@ -663,6 +685,15 @@ async function sendDigestToManagers(
     }
   }
 
+  // Fetch OOO data for daily digest
+  let oooToday: OOOInfo[] | undefined;
+  if (period === 'daily') {
+    const oooRecords = await getActiveOOOForDaily(db, daily.name, endDate);
+    if (oooRecords.length > 0) {
+      oooToday = oooRecords.map(r => ({ slackUserId: r.slack_user_id, endDate: r.end_date }));
+    }
+  }
+
   const digestText = formatManagerDigest({
     dailyName: daily.name,
     period,
@@ -672,6 +703,7 @@ async function sendDigestToManagers(
     stats,
     totalWorkdays,
     missingToday,
+    oooToday,
     bottlenecks,
     dropStats,
     rankings,

--- a/api/index.ts
+++ b/api/index.ts
@@ -187,7 +187,7 @@ async function handleSlackCommands(request: Request, env: Env): Promise<Response
   await loadConfigOverrides(db);
 
   // Handle /daily command separately
-  if (payload.command === '/daily') {
+  if (payload.command === '/daily' || (env.DEV_MODE === 'true' && payload.command === '/dailyl')) {
     const args = payload.text.trim().split(/\s+/).filter(a => a);
     console.log('Command: /daily', { user_id: payload.user_id, args });
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -8,7 +8,7 @@ import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, po
 import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate } from '../lib/db';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
 import { fetchTeamCycleData, TeamLinearData, CycleProgress } from '../lib/linear';
-import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate } from '../lib/prompt';
+import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate, isWorkday, getDateInTimezone } from '../lib/prompt';
 import { handleCommand, handleDaily } from '../lib/handlers/commands';
 import { handleInteraction, InteractionPayload } from '../lib/handlers/interactions';
 import { handleAppHomeOpened, AppHomeOpenedEvent } from '../lib/handlers/home';
@@ -463,10 +463,14 @@ async function runDigestCronUnified(env: Env): Promise<{
     }
 
     try {
-      // Always send daily digest
-      const dailyResult = await sendDigestToManagers(env, db, daily, managers, schedule, 'daily');
-      dailySent += dailyResult.sent;
-      errors += dailyResult.errors;
+      // Only send daily digest on workdays (check in schedule timezone)
+      const localNow = schedule.timezone ? getDateInTimezone(schedule.timezone) : new Date();
+      const isWorkdayToday = isWorkday(schedule.days, localNow);
+      if (isWorkdayToday) {
+        const dailyResult = await sendDigestToManagers(env, db, daily, managers, schedule, 'daily');
+        dailySent += dailyResult.sent;
+        errors += dailyResult.errors;
+      }
 
       // Check if today is the weekly digest day for this daily
       const weeklyDay = getWeeklyDigestDay(daily);
@@ -476,9 +480,9 @@ async function runDigestCronUnified(env: Env): Promise<{
         errors += weeklyResult.errors;
       }
 
-      // Post OOO notice to daily channel for users whose OOO starts today
+      // Post OOO notice to daily channel for users whose OOO starts today (workdays only)
       const todayStr = formatDate(new Date());
-      const oooStarting = await getOOOStartingOnDate(db, daily.name, todayStr);
+      const oooStarting = isWorkdayToday ? await getOOOStartingOnDate(db, daily.name, todayStr) : [];
       if (oooStarting.length > 0) {
         const formatShortDate = (d: string) => {
           const date = new Date(d + 'T00:00:00');

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,11 +3,12 @@
  * Routes requests to appropriate handlers
  */
 
-import { loadConfig, loadConfigOverrides, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems, isDailyEnabled, getLinearIntelligenceConfig } from '../lib/config';
+import { loadConfig, loadConfigOverrides, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems, isDailyEnabled, getLinearIntelligenceConfig, getGitHubIntelligenceConfig } from '../lib/config';
 import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
 import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate, getBlockerStreaks, getUnplannedOverload, getActiveWorkItems } from '../lib/db';
 import { computeLinearAlignment, AlignmentResult } from '../lib/linear-intelligence';
-import { fetchTeamPRData, TeamPRData } from '../lib/github';
+import { computeGitHubAlignment, GitHubAlignmentResult } from '../lib/github-intelligence';
+import { fetchTeamPRData, TeamPRData, fetchTeamMergedPRs } from '../lib/github';
 import { fetchTeamCycleData, TeamLinearData, CycleProgress } from '../lib/linear';
 import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate, isWorkday, getDateInTimezone } from '../lib/prompt';
 import { handleCommand, handleDaily } from '../lib/handlers/commands';
@@ -755,6 +756,45 @@ async function sendDigestToManagers(
     }
   }
 
+  // Compute GitHub intelligence alignment (Phase 4 & 5)
+  let githubAlignment: GitHubAlignmentResult[] | undefined;
+  const githubIntelConfig = getGitHubIntelligenceConfig(daily);
+  if (githubIntelConfig?.work_alignment && githubConfig) {
+    const githubToken = env[githubConfig.tokenEnvVar];
+    if (githubToken) {
+      try {
+        // Build combined user list (same logic as team PR data above)
+        const configMappings = getGitHubUserMappings(daily);
+        const participants = await getParticipants(db, daily.name);
+        const dbLinks = await getUsersWithGitHubLinks(db);
+        const dbLinksMap = new Map(dbLinks.map(l => [l.slackUserId, l.githubUsername]));
+        const configUserIds = new Set(configMappings.map(m => m.slackUserId));
+        const githubUsers: Array<{ slackUserId: string; githubUsername: string }> = [...configMappings];
+        for (const p of participants) {
+          if (!configUserIds.has(p.slack_user_id)) {
+            const githubUsername = dbLinksMap.get(p.slack_user_id);
+            if (githubUsername) {
+              githubUsers.push({ slackUserId: p.slack_user_id, githubUsername });
+            }
+          }
+        }
+
+        if (githubUsers.length > 0) {
+          const teamMergedPRs = await fetchTeamMergedPRs(githubToken, githubConfig.org, githubUsers, endDate);
+          githubAlignment = [];
+          for (const member of teamMergedPRs) {
+            const workItems = await getActiveWorkItems(db, member.slackUserId, daily.name, endDate);
+            const result = computeGitHubAlignment(member.slackUserId, workItems, member.mergedPRs);
+            githubAlignment.push(result);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to compute GitHub alignment for digest:', error);
+        githubAlignment = undefined;
+      }
+    }
+  }
+
   const digestText = formatManagerDigest({
     dailyName: daily.name,
     period,
@@ -777,6 +817,7 @@ async function sendDigestToManagers(
     blockerStreaks,
     unplannedOverloads,
     linearAlignment,
+    githubAlignment,
   });
 
   // Build bottleneck blocks with snooze buttons (only if there are bottlenecks)

--- a/api/index.ts
+++ b/api/index.ts
@@ -5,7 +5,7 @@
 
 import { loadConfig, loadConfigOverrides, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems, isDailyEnabled } from '../lib/config';
 import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
-import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate } from '../lib/db';
+import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate, getBlockerStreaks, getUnplannedOverload } from '../lib/db';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
 import { fetchTeamCycleData, TeamLinearData, CycleProgress } from '../lib/linear';
 import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate, isWorkday, getDateInTimezone } from '../lib/prompt';
@@ -582,6 +582,8 @@ async function sendDigestToManagers(
   const threshold = getBottleneckThreshold(daily);
   const bottlenecks = await getBottleneckItems(db, daily.name, threshold);
   const dropStats = await getHighDropUsers(db, daily.name, startDate, endDate, 30);
+  const blockerStreaks = await getBlockerStreaks(db, daily.name, startDate, endDate);
+  const unplannedOverloads = await getUnplannedOverload(db, daily.name, startDate, endDate, 70);
 
   // Get rankings (only for weekly and 4-week)
   let rankings;
@@ -745,6 +747,8 @@ async function sendDigestToManagers(
     teamLinearData,
     cycleProgress,
     maxPlanItems: getMaxPlanItems(daily.name),
+    blockerStreaks,
+    unplannedOverloads,
   });
 
   // Build bottleneck blocks with snooze buttons (only if there are bottlenecks)

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,15 +3,17 @@
  * Routes requests to appropriate handlers
  */
 
-import { loadConfig, loadConfigOverrides, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems, isDailyEnabled } from '../lib/config';
+import { loadConfig, loadConfigOverrides, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems, isDailyEnabled, getLinearIntelligenceConfig } from '../lib/config';
 import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
-import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate, getBlockerStreaks, getUnplannedOverload } from '../lib/db';
+import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate, getBlockerStreaks, getUnplannedOverload, getActiveWorkItems } from '../lib/db';
+import { computeLinearAlignment, AlignmentResult } from '../lib/linear-intelligence';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
 import { fetchTeamCycleData, TeamLinearData, CycleProgress } from '../lib/linear';
 import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate, isWorkday, getDateInTimezone } from '../lib/prompt';
 import { handleCommand, handleDaily } from '../lib/handlers/commands';
 import { handleInteraction, InteractionPayload } from '../lib/handlers/interactions';
 import { handleAppHomeOpened, AppHomeOpenedEvent } from '../lib/handlers/home';
+import { handleLinearWebhook } from '../lib/handlers/webhooks';
 import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics, OOOInfo, formatTeamSummary } from '../lib/format';
 
 // ============================================================================
@@ -26,6 +28,7 @@ export interface Env {
   DEV_MODE?: string;
   GITHUB_TOKEN?: string;
   LINEAR_API_KEY?: string;
+  LINEAR_WEBHOOK_SECRET?: string;
   // Allow additional env vars for custom token names per daily
   [key: string]: string | undefined;
 }
@@ -73,6 +76,13 @@ export default {
       // Cron: send manager digests
       if (path === '/api/cron/digest') {
         return handleDigestCron(url, env);
+      }
+
+      // Linear webhook: issue status changes → auto-update standup items
+      if (path === '/api/webhooks/linear' && request.method === 'POST') {
+        const db = getDb(env.DATABASE_URL);
+        await loadConfigOverrides(db);
+        return handleLinearWebhook(request, env, db, ctx);
       }
 
       return new Response('Not found', { status: 404 });
@@ -728,6 +738,23 @@ async function sendDigestToManagers(
     }
   }
 
+  // Compute Linear intelligence alignment (Phase 1 & 2)
+  let linearAlignment: AlignmentResult[] | undefined;
+  const linearIntelConfig = getLinearIntelligenceConfig(daily);
+  if (linearIntelConfig && teamLinearData && teamLinearData.length > 0) {
+    try {
+      linearAlignment = [];
+      for (const member of teamLinearData) {
+        const workItems = await getActiveWorkItems(db, member.slackUserId, daily.name, endDate);
+        const result = computeLinearAlignment(member.slackUserId, workItems, member.data.issues);
+        linearAlignment.push(result);
+      }
+    } catch (error) {
+      console.error('Failed to compute Linear alignment for digest:', error);
+      linearAlignment = undefined;
+    }
+  }
+
   const digestText = formatManagerDigest({
     dailyName: daily.name,
     period,
@@ -749,6 +776,7 @@ async function sendDigestToManagers(
     maxPlanItems: getMaxPlanItems(daily.name),
     blockerStreaks,
     unplannedOverloads,
+    linearAlignment,
   });
 
   // Build bottleneck blocks with snooze buttons (only if there are bottlenecks)

--- a/api/index.ts
+++ b/api/index.ts
@@ -10,7 +10,7 @@ import { computeLinearAlignment, AlignmentResult } from '../lib/linear-intellige
 import { computeGitHubAlignment, GitHubAlignmentResult } from '../lib/github-intelligence';
 import { fetchTeamPRData, TeamPRData, fetchTeamMergedPRs } from '../lib/github';
 import { fetchTeamCycleData, TeamLinearData, CycleProgress } from '../lib/linear';
-import { runPromptCron, runScheduledPosts, runReminderCron, formatDate, getUserDate, isWorkday, getDateInTimezone } from '../lib/prompt';
+import { runPromptCron, runScheduledPosts, runReminderCron, runNudgeCron, formatDate, getUserDate, isWorkday, getDateInTimezone } from '../lib/prompt';
 import { handleCommand, handleDaily } from '../lib/handlers/commands';
 import { handleInteraction, InteractionPayload } from '../lib/handlers/interactions';
 import { handleAppHomeOpened, AppHomeOpenedEvent } from '../lib/handlers/home';
@@ -113,6 +113,10 @@ export default {
       // Run reminder cron (send channel reminders before daily standups)
       const reminderStats = await runReminderCron(db, env.SLACK_BOT_TOKEN);
       console.log('Reminder cron complete:', reminderStats);
+
+      // Run nudge cron (DM users who haven't submitted before digest)
+      const nudgeStats = await runNudgeCron(db, env.SLACK_BOT_TOKEN);
+      console.log('Nudge cron complete:', nudgeStats);
 
       // Check if it's time to send digests (based on configured digest_time)
       if (isDigestTime()) {

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,7 +3,7 @@
  * Routes requests to appropriate handlers
  */
 
-import { loadConfig, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser } from '../lib/config';
+import { loadConfig, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems } from '../lib/config';
 import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
 import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate } from '../lib/db';
 import { fetchTeamPRData, TeamPRData } from '../lib/github';
@@ -716,6 +716,7 @@ async function sendDigestToManagers(
     teamPRData,
     teamLinearData,
     cycleProgress,
+    maxPlanItems: getMaxPlanItems(daily.name),
   });
 
   // Build bottleneck blocks with snooze buttons (only if there are bottlenecks)

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,7 +3,7 @@
  * Routes requests to appropriate handlers
  */
 
-import { loadConfig, loadConfigOverrides, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems, isDailyEnabled, getLinearIntelligenceConfig, getGitHubIntelligenceConfig } from '../lib/config';
+import { loadConfig, loadConfigOverrides, getDailies, getSchedules, getConfigError, getDailiesWithManagers, getDaily, getSchedule, getDailyManagers, getWeeklyDigestDay, getBottleneckThreshold, getIntegrationStatus, getDigestTime, getGitHubConfig, getGitHubUserMappings, getLinearConfig, getLinearUserMappings, getLinearTeamIdForUser, getMaxPlanItems, isDailyEnabled, getLinearIntelligenceConfig, getGitHubIntelligenceConfig, getWeeklyRecap } from '../lib/config';
 import { verifySlackSignature, parseCommandPayload, sendDM, sendDMWithBlocks, postMessage } from '../lib/slack';
 import { getDb, deleteOldSubmissions, deleteOldPrompts, getSubmissionsInRange, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getTeamRankings, getPeriodStats, getParticipants, getUsersWithGitHubLinks, getUsersWithLinearLinks, getActiveOOOForDaily, getOOOStartingOnDate, getBlockerStreaks, getUnplannedOverload, getActiveWorkItems } from '../lib/db';
 import { computeLinearAlignment, AlignmentResult } from '../lib/linear-intelligence';
@@ -15,7 +15,7 @@ import { handleCommand, handleDaily } from '../lib/handlers/commands';
 import { handleInteraction, InteractionPayload } from '../lib/handlers/interactions';
 import { handleAppHomeOpened, AppHomeOpenedEvent } from '../lib/handlers/home';
 import { handleLinearWebhook } from '../lib/handlers/webhooks';
-import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics, OOOInfo, formatTeamSummary } from '../lib/format';
+import { formatManagerDigest, DigestPeriod, TrendData, buildBottleneckBlocks, formatPRDigestAnalytics, OOOInfo, formatTeamSummary, formatPersonalWeeklyRecap } from '../lib/format';
 
 // ============================================================================
 // Types
@@ -500,6 +500,26 @@ async function runDigestCronUnified(env: Env): Promise<{
         const weeklyResult = await sendDigestToManagers(env, db, daily, managers, schedule, 'weekly');
         weeklySent += weeklyResult.sent;
         errors += weeklyResult.errors;
+
+        // Personal weekly recap DMs
+        if (getWeeklyRecap(daily)) {
+          try {
+            const recapEnd = formatDate(new Date());
+            const recapStartObj = new Date();
+            recapStartObj.setDate(recapStartObj.getDate() - 6);
+            const recapStart = formatDate(recapStartObj);
+            const weeklySubs = await getSubmissionsInRange(db, daily.name, recapStart, recapEnd);
+            const participants = await getParticipants(db, daily.name);
+            for (const p of participants) {
+              const userSubs = weeklySubs.filter(s => s.slack_user_id === p.slack_user_id);
+              const recap = formatPersonalWeeklyRecap(daily.name, userSubs);
+              await sendDM(env.SLACK_BOT_TOKEN, p.slack_user_id, recap);
+            }
+          } catch (err) {
+            console.error(`Failed to send weekly recaps for "${daily.name}":`, err);
+            errors++;
+          }
+        }
       }
 
       // Post OOO notice to daily channel for users whose OOO starts today (workdays only)

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -118,6 +118,41 @@ const EMPTY_CONFIG: Config = {
 };
 
 // ============================================================================
+// Config Overrides (DB-backed, takes precedence over YAML)
+// ============================================================================
+
+let overridesCache: Map<string, unknown> | null = null;
+
+function overrideKey(scope: string, key: string): string {
+  return `${scope}::${key}`;
+}
+
+export async function loadConfigOverrides(db: { query: <T>(sql: string, params?: unknown[]) => Promise<T[]> }): Promise<void> {
+  const rows = await db.query<{ scope: string; key: string; value: unknown }>(
+    `SELECT scope, key, value FROM config_overrides`
+  );
+  overridesCache = new Map();
+  for (const row of rows) {
+    overridesCache.set(overrideKey(row.scope, row.key), row.value);
+  }
+}
+
+export function getOverride<T = unknown>(scope: string, key: string): T | undefined {
+  if (!overridesCache) return undefined;
+  return overridesCache.get(overrideKey(scope, key)) as T | undefined;
+}
+
+export function isDailyEnabled(dailyName: string): boolean {
+  const override = getOverride<boolean>(dailyName, 'enabled');
+  if (override !== undefined) return override;
+  return true;
+}
+
+export function clearOverridesCache(): void {
+  overridesCache = null;
+}
+
+// ============================================================================
 // Config Loading
 // ============================================================================
 
@@ -202,6 +237,10 @@ export function isAdmin(userId: string): boolean {
 }
 
 export function getDailies(): Daily[] {
+  return loadConfig().dailies.filter(d => isDailyEnabled(d.name));
+}
+
+export function getAllDailiesIncludingDisabled(): Daily[] {
   return loadConfig().dailies;
 }
 
@@ -272,10 +311,11 @@ export function getMaxPlanItems(dailyName?: string): number {
   return config.max_plan_items ?? 5;
 }
 
-// Clear cache (useful for testing or hot reload)
+// Clear all caches (useful for testing or hot reload)
 export function clearConfigCache(): void {
   cachedConfig = null;
   configError = null;
+  overridesCache = null;
 }
 
 // ============================================================================

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -107,6 +107,8 @@ const DailySchema = z.object({
     blockers: z.boolean().default(true),
     unplanned: z.boolean().default(true),
   }).optional(),
+  // Send personal weekly recap DM to each participant on weekly digest day (default true)
+  weekly_recap: z.boolean().optional(),
 });
 
 const ConfigSchema = z.object({
@@ -340,6 +342,11 @@ export function getDailySections(daily: Daily): { blockers: boolean; unplanned: 
     blockers: daily.sections?.blockers ?? true,
     unplanned: daily.sections?.unplanned ?? true,
   };
+}
+
+/** Whether to send weekly recap DMs to participants (default true) */
+export function getWeeklyRecap(daily: Daily): boolean {
+  return daily.weekly_recap ?? true;
 }
 
 /** Get the digest time (UTC, HH:MM format, defaults to 14:00) */

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -96,6 +96,8 @@ const DailySchema = z.object({
   integrations: IntegrationsSchema.optional(),
   // Reminder: how many minutes before daily to send channel reminder (0 = disabled, default 90)
   reminder_minutes_before: z.number().min(0).optional(),
+  // Nudge: DM participants who haven't submitted N minutes before digest (0 = disabled, default 0)
+  nudge_minutes_before: z.number().min(0).optional(),
   // Per-daily plan-size warning threshold (overrides global max_plan_items)
   max_plan_items: z.number().int().min(0).optional(),
   // Post a consolidated team summary to the daily channel at digest time
@@ -320,6 +322,11 @@ export function getIntegrationStatus(daily: Daily): { github: boolean; linear: b
 /** Get the reminder minutes before daily (defaults to 90, 0 = disabled) */
 export function getReminderMinutesBefore(daily: Daily): number {
   return daily.reminder_minutes_before ?? 90;
+}
+
+/** Get nudge minutes before digest (defaults to 0 = disabled) */
+export function getNudgeMinutesBefore(daily: Daily): number {
+  return daily.nudge_minutes_before ?? 0;
 }
 
 /** Get the digest time (UTC, HH:MM format, defaults to 14:00) */

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -102,6 +102,11 @@ const DailySchema = z.object({
   max_plan_items: z.number().int().min(0).optional(),
   // Post a consolidated team summary to the daily channel at digest time
   team_summary: z.boolean().optional(),
+  // Which built-in sections to show in the standup modal (all default to true)
+  sections: z.object({
+    blockers: z.boolean().default(true),
+    unplanned: z.boolean().default(true),
+  }).optional(),
 });
 
 const ConfigSchema = z.object({
@@ -327,6 +332,14 @@ export function getReminderMinutesBefore(daily: Daily): number {
 /** Get nudge minutes before digest (defaults to 0 = disabled) */
 export function getNudgeMinutesBefore(daily: Daily): number {
   return daily.nudge_minutes_before ?? 0;
+}
+
+/** Get which sections are enabled for a daily (defaults both to true) */
+export function getDailySections(daily: Daily): { blockers: boolean; unplanned: boolean } {
+  return {
+    blockers: daily.sections?.blockers ?? true,
+    unplanned: daily.sections?.unplanned ?? true,
+  };
 }
 
 /** Get the digest time (UTC, HH:MM format, defaults to 14:00) */

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -231,9 +231,21 @@ export function getSchedule(name: string): Schedule | undefined {
   return config.schedules.find((s) => s.name === name);
 }
 
-export function isAdmin(userId: string): boolean {
+export function isSuperAdmin(userId: string): boolean {
   const config = loadConfig();
   return config.admins.includes(userId);
+}
+
+export function isAdmin(userId: string): boolean {
+  if (isSuperAdmin(userId)) return true;
+  const dbAdmins = getOverride<string[]>('global', 'admins');
+  return dbAdmins?.includes(userId) ?? false;
+}
+
+export function getAdmins(): { superAdmins: string[]; dbAdmins: string[] } {
+  const config = loadConfig();
+  const dbAdmins = getOverride<string[]>('global', 'admins') ?? [];
+  return { superAdmins: config.admins, dbAdmins };
 }
 
 export function getDailies(): Daily[] {
@@ -248,17 +260,16 @@ export function getSchedules(): Schedule[] {
   return loadConfig().schedules;
 }
 
-/** Get all managers for a daily (supports both legacy single manager and new managers array) */
+/** Get all managers for a daily (YAML + DB, deduplicated) */
 export function getDailyManagers(daily: Daily): string[] {
-  // New format takes precedence
+  const yamlManagers: string[] = [];
   if (daily.managers && daily.managers.length > 0) {
-    return daily.managers;
+    yamlManagers.push(...daily.managers);
+  } else if (daily.manager) {
+    yamlManagers.push(daily.manager);
   }
-  // Fallback to legacy single manager
-  if (daily.manager) {
-    return [daily.manager];
-  }
-  return [];
+  const dbManagers = getOverride<string[]>(daily.name, 'managers') ?? [];
+  return [...new Set([...yamlManagers, ...dbManagers])];
 }
 
 /** Get all dailies that have at least one manager configured */

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -52,11 +52,19 @@ const GitHubIntegrationSchema = z.object({
   user_mapping: z.array(IntegrationUserMappingSchema).optional(),
 });
 
+const LinearIntelligenceSchema = z.object({
+  enabled: z.boolean().default(false),
+  cross_reference: z.boolean().default(true),
+  auto_update: z.boolean().default(true),
+  priority_alignment: z.boolean().default(true),
+}).optional();
+
 const LinearIntegrationSchema = z.object({
   enabled: z.boolean().default(false),
   team_id: z.string().optional(),
   token: z.string().optional(), // Optional: env var name for token (defaults to LINEAR_API_KEY)
   user_mapping: z.array(IntegrationUserMappingSchema).optional(),
+  intelligence: LinearIntelligenceSchema,
 });
 
 const IntegrationsSchema = z.object({
@@ -422,6 +430,25 @@ export function getLinearUserIdFromConfig(daily: Daily, slackUserId: string): st
 
   const match = mapping.find((m) => m.slack_user_id === slackUserId);
   return match?.external_username || null;
+}
+
+export interface LinearIntelligenceConfig {
+  enabled: boolean;
+  cross_reference: boolean;
+  auto_update: boolean;
+  priority_alignment: boolean;
+}
+
+/** Get Linear intelligence config for a daily, returns null if not enabled */
+export function getLinearIntelligenceConfig(daily: Daily): LinearIntelligenceConfig | null {
+  const intel = daily.integrations?.linear?.intelligence;
+  if (!intel?.enabled) return null;
+  return {
+    enabled: true,
+    cross_reference: intel.cross_reference ?? true,
+    auto_update: intel.auto_update ?? true,
+    priority_alignment: intel.priority_alignment ?? true,
+  };
 }
 
 /** Get all Linear user mappings for a daily */

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -45,11 +45,18 @@ const IntegrationUserMappingSchema = z.object({
   team_id: z.string().optional(), // Per-user Linear team ID override
 });
 
+const GitHubIntelligenceSchema = z.object({
+  enabled: z.boolean().default(false),
+  work_alignment: z.boolean().default(true),
+  auto_populate: z.boolean().default(true),
+}).optional();
+
 const GitHubIntegrationSchema = z.object({
   enabled: z.boolean().default(false),
   org: z.string().optional(),
   token: z.string().optional(), // Optional: env var name for token (defaults to GITHUB_TOKEN)
   user_mapping: z.array(IntegrationUserMappingSchema).optional(),
+  intelligence: GitHubIntelligenceSchema,
 });
 
 const LinearIntelligenceSchema = z.object({
@@ -448,6 +455,23 @@ export function getLinearIntelligenceConfig(daily: Daily): LinearIntelligenceCon
     cross_reference: intel.cross_reference ?? true,
     auto_update: intel.auto_update ?? true,
     priority_alignment: intel.priority_alignment ?? true,
+  };
+}
+
+export interface GitHubIntelligenceConfig {
+  enabled: boolean;
+  work_alignment: boolean;
+  auto_populate: boolean;
+}
+
+/** Get GitHub intelligence config for a daily, returns null if not enabled */
+export function getGitHubIntelligenceConfig(daily: Daily): GitHubIntelligenceConfig | null {
+  const intel = daily.integrations?.github?.intelligence;
+  if (!intel?.enabled) return null;
+  return {
+    enabled: true,
+    work_alignment: intel.work_alignment ?? true,
+    auto_populate: intel.auto_populate ?? true,
   };
 }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -81,6 +81,8 @@ const DailySchema = z.object({
   integrations: IntegrationsSchema.optional(),
   // Reminder: how many minutes before daily to send channel reminder (0 = disabled, default 90)
   reminder_minutes_before: z.number().min(0).optional(),
+  // Per-daily plan-size warning threshold (overrides global max_plan_items)
+  max_plan_items: z.number().int().min(0).optional(),
 });
 
 const ConfigSchema = z.object({
@@ -258,10 +260,14 @@ export function getDigestTime(): string {
   return loadConfig().digest_time || '14:00';
 }
 
-/** Plan-size soft-warning threshold (0 = disabled, default 5). */
-export function getMaxPlanItems(): number {
-  const value = loadConfig().max_plan_items;
-  return value ?? 5;
+/** Plan-size soft-warning threshold (0 = disabled, default 5). Per-daily overrides global. */
+export function getMaxPlanItems(dailyName?: string): number {
+  const config = loadConfig();
+  if (dailyName) {
+    const daily = config.dailies.find(d => d.name === dailyName);
+    if (daily?.max_plan_items !== undefined) return daily.max_plan_items;
+  }
+  return config.max_plan_items ?? 5;
 }
 
 // Clear cache (useful for testing or hot reload)

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -83,6 +83,8 @@ const DailySchema = z.object({
   reminder_minutes_before: z.number().min(0).optional(),
   // Per-daily plan-size warning threshold (overrides global max_plan_items)
   max_plan_items: z.number().int().min(0).optional(),
+  // Post a consolidated team summary to the daily channel at digest time
+  team_summary: z.boolean().optional(),
 });
 
 const ConfigSchema = z.object({

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -240,6 +240,55 @@ export async function setDmStandupPreference(
 }
 
 // ============================================================================
+// User Settings
+// ============================================================================
+
+export interface UserSettings {
+  dmStandup: boolean;
+  maxItems: number | null;
+  stalePrDays: number | null;
+  linearTeamFilter: string[] | null;
+}
+
+export async function getUserSettings(
+  db: DbClient,
+  slackUserId: string
+): Promise<UserSettings> {
+  const result = await db.query<{
+    dm_standup: boolean | null;
+    max_items: number | null;
+    stale_pr_days: number | null;
+    linear_team_filter: string | null;
+  }>(
+    `SELECT dm_standup, max_items, stale_pr_days, linear_team_filter
+     FROM slack_users WHERE slack_user_id = $1`,
+    [slackUserId]
+  );
+  const row = result[0];
+  return {
+    dmStandup: row?.dm_standup ?? false,
+    maxItems: row?.max_items ?? null,
+    stalePrDays: row?.stale_pr_days ?? null,
+    linearTeamFilter: row?.linear_team_filter ? row.linear_team_filter.split(',').map(s => s.trim()) : null,
+  };
+}
+
+export async function updateUserSetting(
+  db: DbClient,
+  slackUserId: string,
+  key: 'max_items' | 'stale_pr_days' | 'linear_team_filter',
+  value: number | string | null
+): Promise<void> {
+  await db.query(
+    `INSERT INTO slack_users (slack_user_id, ${key}, tz_offset)
+     VALUES ($1, $2, 0)
+     ON CONFLICT (slack_user_id) DO UPDATE SET
+       ${key} = $3`,
+    [slackUserId, value, value]
+  );
+}
+
+// ============================================================================
 // Work Items (for analytics)
 // ============================================================================
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1343,6 +1343,20 @@ export async function getActiveOOOForDaily(
   );
 }
 
+/** Get OOO records starting on a specific date for a daily (for channel notifications) */
+export async function getOOOStartingOnDate(
+  db: DbClient,
+  dailyName: string,
+  date: string
+): Promise<OOORecord[]> {
+  return db.query<OOORecord>(
+    `SELECT * FROM ooo
+     WHERE daily_name = $1
+       AND start_date = $2`,
+    [dailyName, date]
+  );
+}
+
 // ============================================================================
 // Reminder Log (dedup channel reminders)
 // ============================================================================

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -328,6 +328,41 @@ export interface SubmissionItem {
   position: number;
 }
 
+/** Get active Linear-sourced work items for a user/daily on a specific date */
+export async function getActiveLinearWorkItems(
+  db: DbClient,
+  slackUserId: string,
+  dailyName: string,
+  date: string
+): Promise<WorkItem[]> {
+  return db.query<WorkItem>(
+    `SELECT * FROM work_items
+     WHERE slack_user_id = $1 AND daily_name = $2 AND created_date = $3
+       AND source = 'linear_ticket'
+       AND status IN ('pending', 'carried', 'in_progress')
+     ORDER BY id ASC`,
+    [slackUserId, dailyName, date]
+  );
+}
+
+/**
+ * Get active work items across all users/dailies by source_ref (Linear identifier).
+ * Used by the webhook handler to find items that need auto-update.
+ */
+export async function getActiveWorkItemsBySourceRef(
+  db: DbClient,
+  sourceRef: string
+): Promise<WorkItem[]> {
+  return db.query<WorkItem>(
+    `SELECT * FROM work_items
+     WHERE source_ref = $1
+       AND source = 'linear_ticket'
+       AND status IN ('pending', 'carried', 'in_progress')
+     ORDER BY created_date DESC`,
+    [sourceRef]
+  );
+}
+
 /** Get active work items for a user/daily on a specific date, ordered by status priority */
 export async function getActiveWorkItems(
   db: DbClient,

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1095,6 +1095,7 @@ export interface PeriodStats {
   participation_rate: number;   // % of possible submissions received
   completion_rate: number;      // % of items completed vs dropped/carried
   blocker_rate: number;         // % of submissions with blockers
+  unplanned_rate: number;       // % of completed items that were unplanned
   total_submissions: number;
   total_participants: number;
   total_items_completed: number;
@@ -1118,12 +1119,14 @@ export async function getPeriodStats(
     total_completed: number;
     total_planned: number;
     blocker_count: number;
+    total_unplanned: number;
   }>(
     `SELECT
        COUNT(s.id) as submission_count,
-       COALESCE(SUM(jsonb_array_length(s.yesterday_completed::jsonb) + jsonb_array_length(s.unplanned::jsonb)), 0) as total_completed,
-       COALESCE(SUM(jsonb_array_length(s.today_plans::jsonb)), 0) as total_planned,
-       SUM(CASE WHEN s.blockers IS NOT NULL AND s.blockers != '' THEN 1 ELSE 0 END) as blocker_count
+       COALESCE(SUM(jsonb_array_length(COALESCE(s.yesterday_completed, '[]')::jsonb) + jsonb_array_length(COALESCE(s.unplanned, '[]')::jsonb)), 0) as total_completed,
+       COALESCE(SUM(jsonb_array_length(COALESCE(s.today_plans, '[]')::jsonb)), 0) as total_planned,
+       SUM(CASE WHEN s.blockers IS NOT NULL AND s.blockers != '' THEN 1 ELSE 0 END) as blocker_count,
+       COALESCE(SUM(jsonb_array_length(COALESCE(s.unplanned, '[]')::jsonb)), 0) as total_unplanned
      FROM submissions s
      WHERE s.daily_name = $1 AND s.date >= $2 AND s.date <= $3`,
     [dailyName, startDate, endDate]
@@ -1152,6 +1155,7 @@ export async function getPeriodStats(
   const totalCompleted = Number(submissionResult[0]?.total_completed) || 0;
   const totalPlanned = Number(submissionResult[0]?.total_planned) || 0;
   const blockerCount = Number(submissionResult[0]?.blocker_count) || 0;
+  const totalUnplanned = Number(submissionResult[0]?.total_unplanned) || 0;
   const participantCount = Number(participantResult[0]?.count) || 0;
   const itemsDone = Number(itemResult[0]?.total_done) || 0;
   const itemsDropped = Number(itemResult[0]?.total_dropped) || 0;
@@ -1174,10 +1178,15 @@ export async function getPeriodStats(
     ? Math.round((totalPlanned / submissionCount) * 10) / 10
     : 0;
 
+  const unplannedRate = totalCompleted > 0
+    ? Math.round((totalUnplanned / totalCompleted) * 100)
+    : 0;
+
   return {
     participation_rate: participationRate,
     completion_rate: completionRate,
     blocker_rate: blockerRate,
+    unplanned_rate: unplannedRate,
     total_submissions: submissionCount,
     total_participants: participantCount,
     total_items_completed: itemsDone,
@@ -1479,4 +1488,135 @@ export async function deleteConfigOverride(
     `DELETE FROM config_overrides WHERE scope = $1 AND key = $2`,
     [scope, key]
   );
+}
+
+// ============================================================================
+// Blocker Streak Tracking
+// ============================================================================
+
+export interface BlockerStreak {
+  slack_user_id: string;
+  current_streak: number;
+  max_streak: number;
+  total_blocker_days: number;
+}
+
+/**
+ * Pure function — computes blocker streaks from ordered submission rows.
+ * current_streak: consecutive blocker days up to (and including) the user's last submission.
+ * max_streak: longest consecutive blocker run in the data.
+ * Only users with at least one blocker day are returned.
+ */
+export function computeBlockerStreaks(
+  rows: Array<{ slack_user_id: string; date: string; has_blocker: boolean }>
+): BlockerStreak[] {
+  const byUser = new Map<string, Array<{ date: string; has_blocker: boolean }>>();
+  for (const row of rows) {
+    if (!byUser.has(row.slack_user_id)) byUser.set(row.slack_user_id, []);
+    byUser.get(row.slack_user_id)!.push({ date: row.date, has_blocker: row.has_blocker });
+  }
+
+  const results: BlockerStreak[] = [];
+
+  for (const [userId, entries] of byUser) {
+    // entries are already ordered by date ASC from the query
+    let maxStreak = 0;
+    let runningStreak = 0;
+    let totalBlockerDays = 0;
+
+    for (const entry of entries) {
+      if (entry.has_blocker) {
+        runningStreak++;
+        totalBlockerDays++;
+        if (runningStreak > maxStreak) maxStreak = runningStreak;
+      } else {
+        runningStreak = 0;
+      }
+    }
+
+    // current_streak is the streak at the tail of the sorted entries
+    const currentStreak = runningStreak;
+
+    if (totalBlockerDays > 0) {
+      results.push({
+        slack_user_id: userId,
+        current_streak: currentStreak,
+        max_streak: maxStreak,
+        total_blocker_days: totalBlockerDays,
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Get blocker streaks for all users in a daily within a date range */
+export async function getBlockerStreaks(
+  db: DbClient,
+  dailyName: string,
+  startDate: string,
+  endDate: string
+): Promise<BlockerStreak[]> {
+  const rows = await db.query<{ slack_user_id: string; date: string; has_blocker: boolean }>(
+    `SELECT slack_user_id, date, (blockers IS NOT NULL AND blockers != '') as has_blocker
+     FROM submissions
+     WHERE daily_name = $1 AND date >= $2 AND date <= $3
+     ORDER BY slack_user_id, date`,
+    [dailyName, startDate, endDate]
+  );
+  return computeBlockerStreaks(rows);
+}
+
+// ============================================================================
+// Unplanned Work Overload Detection
+// ============================================================================
+
+export interface UnplannedOverload {
+  slack_user_id: string;
+  unplanned_count: number;
+  completed_count: number;
+  unplanned_pct: number;
+}
+
+/** Get users whose unplanned work exceeds the given percentage threshold */
+export async function getUnplannedOverload(
+  db: DbClient,
+  dailyName: string,
+  startDate: string,
+  endDate: string,
+  threshold: number = 70
+): Promise<UnplannedOverload[]> {
+  const rows = await db.query<{
+    slack_user_id: string;
+    unplanned_count: number;
+    completed_count: number;
+  }>(
+    `SELECT
+       slack_user_id,
+       COALESCE(SUM(jsonb_array_length(COALESCE(unplanned, '[]')::jsonb)), 0) as unplanned_count,
+       COALESCE(SUM(
+         jsonb_array_length(COALESCE(yesterday_completed, '[]')::jsonb) +
+         jsonb_array_length(COALESCE(unplanned, '[]')::jsonb)
+       ), 0) as completed_count
+     FROM submissions
+     WHERE daily_name = $1 AND date >= $2 AND date <= $3
+     GROUP BY slack_user_id`,
+    [dailyName, startDate, endDate]
+  );
+
+  return rows
+    .map(row => {
+      const unplannedCount = Number(row.unplanned_count) || 0;
+      const completedCount = Number(row.completed_count) || 0;
+      const unplannedPct = completedCount > 0
+        ? Math.round((unplannedCount / completedCount) * 100)
+        : 0;
+      return {
+        slack_user_id: row.slack_user_id,
+        unplanned_count: unplannedCount,
+        completed_count: completedCount,
+        unplanned_pct: unplannedPct,
+      };
+    })
+    .filter(row => row.unplanned_pct >= threshold);
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -207,7 +207,7 @@ export async function getUsersWithLinearLinks(
 // DM Standup Preference
 // ============================================================================
 
-/** Get whether user wants DM copies of standup posts (default: true) */
+/** Get whether user wants DM copies of standup posts (default: false — App Home shows plans) */
 export async function getDmStandupPreference(
   db: DbClient,
   slackUserId: string
@@ -217,11 +217,10 @@ export async function getDmStandupPreference(
       `SELECT dm_standup FROM slack_users WHERE slack_user_id = $1`,
       [slackUserId]
     );
-    // Default to true if no row or null
-    return result[0]?.dm_standup ?? true;
+    // Default to false — App Home is the primary place to review your plan
+    return result[0]?.dm_standup ?? false;
   } catch {
-    // Column may not exist yet (pre-migration) — default to true
-    return true;
+    return false;
   }
 }
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1438,3 +1438,45 @@ export async function recordReminderSent(
     [dailyName, date]
   );
 }
+
+// ============================================================================
+// Config Overrides
+// ============================================================================
+
+export interface ConfigOverride {
+  scope: string;
+  key: string;
+  value: unknown;
+}
+
+export async function getAllConfigOverrides(db: DbClient): Promise<ConfigOverride[]> {
+  return db.query<ConfigOverride>(
+    `SELECT scope, key, value FROM config_overrides ORDER BY scope, key`
+  );
+}
+
+export async function setConfigOverride(
+  db: DbClient,
+  scope: string,
+  key: string,
+  value: unknown,
+  updatedBy?: string
+): Promise<void> {
+  await db.query(
+    `INSERT INTO config_overrides (scope, key, value, updated_by, updated_at)
+     VALUES ($1, $2, $3, $4, NOW())
+     ON CONFLICT (scope, key) DO UPDATE SET value = $3, updated_by = $4, updated_at = NOW()`,
+    [scope, key, JSON.stringify(value), updatedBy]
+  );
+}
+
+export async function deleteConfigOverride(
+  db: DbClient,
+  scope: string,
+  key: string
+): Promise<void> {
+  await db.query(
+    `DELETE FROM config_overrides WHERE scope = $1 AND key = $2`,
+    [scope, key]
+  );
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -292,6 +292,9 @@ export async function updateUserSetting(
 // Work Items (for analytics)
 // ============================================================================
 
+export type ItemSource = 'manual' | 'github_pr' | 'linear_ticket';
+export type ItemType = 'plan' | 'unplanned';
+
 export interface WorkItem {
   id: number;
   slack_user_id: string;
@@ -303,6 +306,26 @@ export interface WorkItem {
   completed_date: string | null;
   snoozed_until: string | null;
   submission_id: number | null;
+  source: ItemSource;
+  source_ref: string | null;
+  source_url: string | null;
+  item_type: ItemType;
+}
+
+export type SubmissionItemRole =
+  | 'today_plan'
+  | 'unplanned'
+  | 'yesterday_completed'
+  | 'yesterday_incomplete'
+  | 'yesterday_in_progress'
+  | 'yesterday_dropped';
+
+export interface SubmissionItem {
+  id: number;
+  submission_id: number;
+  work_item_id: number;
+  role: SubmissionItemRole;
+  position: number;
 }
 
 /** Create work items from today's plans */
@@ -314,21 +337,63 @@ export async function createWorkItems(
     text: string;
     date: string;
     submissionId: number;
+    source?: ItemSource;
+    sourceRef?: string;
+    sourceUrl?: string;
+    itemType?: ItemType;
   }>
 ): Promise<WorkItem[]> {
   if (items.length === 0) return [];
 
   const results: WorkItem[] = [];
-  for (const item of items) {
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const source = item.source ?? 'manual';
+    const itemType = item.itemType ?? 'plan';
     const result = await db.query<WorkItem>(
-      `INSERT INTO work_items (slack_user_id, daily_name, text, created_date, status, submission_id)
-       VALUES ($1, $2, $3, $4, 'pending', $5)
+      `INSERT INTO work_items (slack_user_id, daily_name, text, created_date, status, submission_id, source, source_ref, source_url, item_type)
+       VALUES ($1, $2, $3, $4, 'pending', $5, $6, $7, $8, $9)
        RETURNING *`,
-      [item.slackUserId, item.dailyName, item.text, item.date, item.submissionId]
+      [item.slackUserId, item.dailyName, item.text, item.date, item.submissionId, source, item.sourceRef ?? null, item.sourceUrl ?? null, itemType]
     );
-    if (result[0]) results.push(result[0]);
+    if (result[0]) {
+      results.push(result[0]);
+      await db.query(
+        `INSERT INTO submission_items (submission_id, work_item_id, role, position)
+         VALUES ($1, $2, $3, $4)`,
+        [item.submissionId, result[0].id, itemType === 'unplanned' ? 'unplanned' : 'today_plan', i + 1]
+      );
+    }
   }
   return results;
+}
+
+/** Link existing work items to a submission with a role (for yesterday status transitions) */
+export async function linkItemsToSubmission(
+  db: DbClient,
+  submissionId: number,
+  slackUserId: string,
+  dailyName: string,
+  itemTexts: string[],
+  role: SubmissionItemRole
+): Promise<void> {
+  for (let i = 0; i < itemTexts.length; i++) {
+    const items = await db.query<{ id: number }>(
+      `SELECT id FROM work_items
+       WHERE slack_user_id = $1 AND daily_name = $2 AND text = $3
+         AND status IN ('pending', 'carried', 'in_progress')
+       ORDER BY created_date DESC LIMIT 1`,
+      [slackUserId, dailyName, itemTexts[i]]
+    );
+    if (items[0]) {
+      await db.query(
+        `INSERT INTO submission_items (submission_id, work_item_id, role, position)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (submission_id, work_item_id, role) DO NOTHING`,
+        [submissionId, items[0].id, role, i + 1]
+      );
+    }
+  }
 }
 
 /** Mark items as done */
@@ -424,7 +489,7 @@ export async function markItemsInProgress(
   return updated;
 }
 
-/** Get recently done Linear items (items with [IDENTIFIER] prefix marked done within N days) */
+/** Get recently done Linear items (uses source column for new items, falls back to text pattern for old) */
 export async function getRecentlyDoneLinearItems(
   db: DbClient,
   slackUserId: string,
@@ -436,7 +501,7 @@ export async function getRecentlyDoneLinearItems(
      WHERE slack_user_id = $1
        AND daily_name = $2
        AND status = 'done'
-       AND text LIKE '[%]%'
+       AND (source = 'linear_ticket' OR (source = 'manual' AND text LIKE '[%]%'))
        AND completed_date >= CURRENT_DATE - ($3 || ' days')::INTERVAL
      ORDER BY completed_date DESC`,
     [slackUserId, dailyName, days]
@@ -678,6 +743,7 @@ export interface Submission {
   custom_answers: Record<string, string> | null;
   slack_message_ts: string | null;
   posted: boolean;
+  items_normalized: boolean;
 }
 
 // Get the most recent previous submission for a user (regardless of how many days ago)
@@ -722,8 +788,8 @@ export async function saveSubmission(
     `INSERT INTO submissions (
        slack_user_id, daily_name, date,
        yesterday_completed, yesterday_incomplete, yesterday_in_progress, unplanned,
-       today_plans, blockers, custom_answers, posted
-     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       today_plans, blockers, custom_answers, posted, items_normalized
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, TRUE)
      ON CONFLICT (slack_user_id, daily_name, date) DO UPDATE SET
        yesterday_completed = $12,
        yesterday_incomplete = $13,
@@ -733,6 +799,7 @@ export async function saveSubmission(
        blockers = $17,
        custom_answers = $18,
        posted = $19,
+       items_normalized = TRUE,
        submitted_at = NOW()
      RETURNING *`,
     [

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -998,6 +998,7 @@ export interface BottleneckItem {
   carry_count: number;
   days_pending: number;
   type: 'carry' | 'dropped';
+  status: 'pending' | 'carried' | 'in_progress';
 }
 
 /** Get bottleneck items (carried at/above threshold, not snoozed) */
@@ -1012,6 +1013,7 @@ export async function getBottleneckItems(
        text,
        slack_user_id,
        carry_count,
+       status,
        (CURRENT_DATE - created_date) as days_pending,
        'carry' as type
      FROM work_items

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -328,6 +328,131 @@ export interface SubmissionItem {
   position: number;
 }
 
+/** Get active work items for a user/daily on a specific date, ordered by status priority */
+export async function getActiveWorkItems(
+  db: DbClient,
+  slackUserId: string,
+  dailyName: string,
+  date: string
+): Promise<WorkItem[]> {
+  return db.query<WorkItem>(
+    `SELECT * FROM work_items
+     WHERE slack_user_id = $1 AND daily_name = $2 AND created_date = $3
+     ORDER BY
+       CASE status
+         WHEN 'in_progress' THEN 1
+         WHEN 'carried'     THEN 2
+         WHEN 'pending'     THEN 3
+         WHEN 'done'        THEN 4
+         WHEN 'dropped'     THEN 5
+         ELSE 6
+       END,
+       id ASC`,
+    [slackUserId, dailyName, date]
+  );
+}
+
+/** Update a single work item's status by ID */
+export async function updateWorkItemStatus(
+  db: DbClient,
+  itemId: number,
+  status: 'done' | 'dropped' | 'in_progress' | 'pending' | 'carried',
+  completedDate?: string
+): Promise<boolean> {
+  let sql: string;
+  let params: unknown[];
+
+  if (status === 'done') {
+    sql = `UPDATE work_items SET status = 'done', completed_date = $1 WHERE id = $2 RETURNING id`;
+    params = [completedDate ?? null, itemId];
+  } else {
+    sql = `UPDATE work_items SET status = $1 WHERE id = $2 RETURNING id`;
+    params = [status, itemId];
+  }
+
+  const result = await db.query<{ id: number }>(sql, params);
+  return result.length > 0;
+}
+
+/** Insert a single work item (source='manual', item_type='plan') */
+export async function addWorkItem(
+  db: DbClient,
+  slackUserId: string,
+  dailyName: string,
+  text: string,
+  date: string,
+  submissionId: number
+): Promise<WorkItem | null> {
+  const result = await db.query<WorkItem>(
+    `INSERT INTO work_items (slack_user_id, daily_name, text, created_date, status, submission_id, source, item_type)
+     VALUES ($1, $2, $3, $4, 'pending', $5, 'manual', 'plan')
+     RETURNING *`,
+    [slackUserId, dailyName, text, date, submissionId]
+  );
+  return result[0] || null;
+}
+
+/**
+ * Rebuild the submission's JSONB arrays from the current work_items state.
+ * Call this after any App Home mutation to keep the submission record in sync.
+ */
+export async function updateSubmissionArrays(
+  db: DbClient,
+  submissionId: number,
+  slackUserId: string,
+  dailyName: string,
+  date: string
+): Promise<void> {
+  const items = await db.query<WorkItem>(
+    `SELECT * FROM work_items
+     WHERE slack_user_id = $1 AND daily_name = $2 AND created_date = $3`,
+    [slackUserId, dailyName, date]
+  );
+
+  const todayPlans: string[] = [];
+  const yesterdayCompleted: string[] = [];
+  const yesterdayIncomplete: string[] = [];
+  const yesterdayInProgress: string[] = [];
+
+  for (const item of items) {
+    if (item.item_type === 'unplanned') continue; // unplanned items managed separately
+    switch (item.status) {
+      case 'pending':
+      case 'carried':
+        // These are "today's plan" items that haven't changed state
+        if (item.carry_count === 0) {
+          todayPlans.push(item.text);
+        } else {
+          yesterdayIncomplete.push(item.text);
+        }
+        break;
+      case 'in_progress':
+        yesterdayInProgress.push(item.text);
+        break;
+      case 'done':
+        yesterdayCompleted.push(item.text);
+        break;
+      // dropped items are omitted from all arrays
+    }
+  }
+
+  await db.query(
+    `UPDATE submissions
+     SET today_plans = $1,
+         yesterday_completed = $2,
+         yesterday_incomplete = $3,
+         yesterday_in_progress = $4
+     WHERE id = $5`,
+    [
+      JSON.stringify(todayPlans),
+      JSON.stringify(yesterdayCompleted),
+      JSON.stringify(yesterdayIncomplete),
+      JSON.stringify(yesterdayInProgress),
+      submissionId,
+    ]
+  );
+}
+
 /** Create work items from today's plans */
 export async function createWorkItems(
   db: DbClient,

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -10,6 +10,7 @@ import { postMessage, sendDM as slackSendDM, sendDMWithBlocks } from './slack';
 import { UserPRData, GitHubPR, formatPRRef, TeamPRData } from './github';
 import { TeamLinearData, CycleProgress } from './linear';
 import { AlignmentResult } from './linear-intelligence';
+import { GitHubAlignmentResult } from './github-intelligence';
 
 // Re-export sendDM for backward compatibility
 export { sendDM as sendDM } from './slack';
@@ -405,6 +406,7 @@ export interface DigestOptions {
   blockerStreaks?: BlockerStreak[];
   unplannedOverloads?: UnplannedOverload[];
   linearAlignment?: AlignmentResult[]; // Phase 1 & 2: plan-vs-Linear alignment
+  githubAlignment?: GitHubAlignmentResult[]; // Phase 4 & 5: plan-vs-GitHub alignment
 }
 
 /**
@@ -604,6 +606,14 @@ export function formatManagerDigest(options: DigestOptions): string {
     const alignmentSection = formatLinearAlignmentSection(options.linearAlignment);
     if (alignmentSection) {
       lines.push(alignmentSection);
+    }
+  }
+
+  // GitHub intelligence: plan-vs-GitHub alignment (Phase 4 & 5)
+  if (options.githubAlignment && options.githubAlignment.length > 0) {
+    const githubAlignmentSection = formatGitHubAlignmentSection(options.githubAlignment);
+    if (githubAlignmentSection) {
+      lines.push(githubAlignmentSection);
     }
   }
 
@@ -1249,6 +1259,47 @@ function formatLinearAlignmentSection(alignment: AlignmentResult[]): string {
     } else {
       const gapText = parts.length > 0 ? parts.join(', ') : 'gaps found';
       lines.push(`  <@${result.slackUserId}>: ${gapText}${prioritySuffix}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ============================================================================
+// GitHub Intelligence Formatting (Phase 4 & 5)
+// ============================================================================
+
+/**
+ * Format plan-vs-GitHub alignment section for manager digest.
+ * Shows per-user cross-reference gaps between plans and merged PRs.
+ *
+ * Example output:
+ *   🔍 *Plan-GitHub Alignment*
+ *     <@U123>: 2 plans without matching PRs, 1 merged PR unplanned
+ *     <@U456>: ✅ aligned
+ */
+function formatGitHubAlignmentSection(alignment: GitHubAlignmentResult[]): string {
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push('🔍 *Plan-GitHub Alignment*');
+
+  for (const result of alignment) {
+    const parts: string[] = [];
+
+    if (result.plansWithoutWork.length > 0) {
+      parts.push(`${result.plansWithoutWork.length} plan${result.plansWithoutWork.length !== 1 ? 's' : ''} without matching PRs`);
+    }
+
+    if (result.workWithoutPlans.length > 0) {
+      parts.push(`${result.workWithoutPlans.length} merged PR${result.workWithoutPlans.length !== 1 ? 's' : ''} unplanned`);
+    }
+
+    if (parts.length === 0 && result.alignmentStatus === 'aligned') {
+      lines.push(`  <@${result.slackUserId}>: ✅ aligned`);
+    } else {
+      const gapText = parts.length > 0 ? parts.join(', ') : 'gaps found';
+      lines.push(`  <@${result.slackUserId}>: ${gapText}`);
     }
   }
 

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1458,3 +1458,72 @@ function parseJsonArray(value: string[] | null): string[] {
     return [];
   }
 }
+
+// ============================================================================
+// Weekly Personal Recap
+// ============================================================================
+
+export function formatPersonalWeeklyRecap(
+  dailyName: string,
+  submissions: Submission[]
+): string {
+  if (submissions.length === 0) {
+    return `📊 *Weekly recap — ${dailyName}*\n\nNo standups submitted this week.`;
+  }
+
+  const completed: string[] = [];
+  const carried: string[] = [];
+  const dropped: string[] = [];
+  const blockerTexts: string[] = [];
+
+  for (const sub of submissions) {
+    for (const item of parseJsonArray(sub.yesterday_completed)) {
+      if (!completed.includes(item)) completed.push(item);
+    }
+    for (const item of parseJsonArray(sub.yesterday_incomplete)) {
+      if (!carried.includes(item)) carried.push(item);
+    }
+    // "dropped" aren't stored on the submission — they're in work_items.
+    // Use today_plans that never appeared as completed in later submissions as a proxy:
+    // actually, we can approximate by collecting items from yesterday_in_progress
+    // that were eventually dropped. For v1 just skip "dropped" — it requires cross-referencing
+    // work_items which is out of scope for the simple recap.
+
+    const blocker = sub.blockers?.trim();
+    if (blocker && !blockerTexts.includes(blocker)) {
+      blockerTexts.push(blocker);
+    }
+  }
+
+  const lines: string[] = [`📊 *Weekly recap — ${dailyName}*`];
+  lines.push(`_${submissions.length} standup${submissions.length !== 1 ? 's' : ''} submitted this week_`);
+  lines.push('');
+
+  if (completed.length > 0) {
+    lines.push(`✅ *Completed* (${completed.length})`);
+    for (const item of completed.slice(0, 10)) {
+      lines.push(`  • ${item}`);
+    }
+    if (completed.length > 10) lines.push(`  _…and ${completed.length - 10} more_`);
+    lines.push('');
+  }
+
+  if (carried.length > 0) {
+    lines.push(`➡️ *Still carrying* (${carried.length})`);
+    for (const item of carried.slice(0, 5)) {
+      lines.push(`  • ${item}`);
+    }
+    if (carried.length > 5) lines.push(`  _…and ${carried.length - 5} more_`);
+    lines.push('');
+  }
+
+  if (blockerTexts.length > 0) {
+    lines.push(`🚧 *Blockers reported* (${blockerTexts.length})`);
+    for (const b of blockerTexts.slice(0, 5)) {
+      lines.push(`  • ${b.length > 80 ? b.slice(0, 77) + '...' : b}`);
+    }
+    if (blockerTexts.length > 5) lines.push(`  _…and ${blockerTexts.length - 5} more_`);
+  }
+
+  return lines.join('\n');
+}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1161,6 +1161,63 @@ export function formatLinearDigestSection(
 }
 
 // ============================================================================
+// Team Summary Post
+// ============================================================================
+
+export interface TeamSummaryOptions {
+  dailyName: string;
+  channel: string;
+  submissions: Submission[];
+  githubOrg?: string;
+}
+
+export function formatTeamSummary(options: TeamSummaryOptions): string {
+  const { dailyName, channel, submissions, githubOrg } = options;
+  if (submissions.length === 0) return '';
+
+  const lines: string[] = [];
+  lines.push(`📋 *${dailyName} — Team Summary*`);
+  lines.push('');
+
+  const blockers: Array<{ userId: string; text: string }> = [];
+
+  for (const sub of submissions) {
+    const topItems: string[] = [];
+
+    // Pick top 1-2 highest-signal items: blockers first, then today's plans
+    const plans = sub.today_plans || [];
+    for (const item of plans.slice(0, 2)) {
+      topItems.push(enrichItemSource(item, githubOrg));
+    }
+
+    // Build line with message link if available
+    const messageLink = sub.slack_message_ts
+      ? ` <https://slack.com/archives/${channel}/p${sub.slack_message_ts.replace('.', '')}|↗>`
+      : '';
+
+    const summary = topItems.length > 0 ? topItems.join(' · ') : '_no plans_';
+    lines.push(`<@${sub.slack_user_id}>${messageLink}: ${summary}`);
+
+    // Collect blockers
+    if (sub.blockers && sub.blockers.trim()) {
+      for (const line of sub.blockers.split('\n').filter(l => l.trim())) {
+        blockers.push({ userId: sub.slack_user_id, text: line.trim() });
+      }
+    }
+  }
+
+  if (blockers.length > 0) {
+    lines.push('');
+    lines.push('🚧 *Blockers*');
+    for (const b of blockers) {
+      lines.push(`<@${b.userId}>: ${b.text}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -136,15 +136,15 @@ export function formatStandupBlocks(
       for (const item of data.yesterdayInProgress || []) {
         const carryCount = data.inProgressCarryCounts?.[item] || 0;
         if (carryCount >= 3) {
-          todayItems.push(`⚠️ ${enrich(item)} _(Day ${carryCount} — needs attention)_`);
+          todayItems.push(`⚠️ ${enrich(item)} _(day ${carryCount})_`);
         } else if (carryCount >= 1) {
-          todayItems.push(`🔄 ${enrich(item)} _(Day ${carryCount})_`);
+          todayItems.push(`🔄 ${enrich(item)} _(day ${carryCount})_`);
         } else {
-          todayItems.push(`🔄 ${enrich(item)} _(in progress)_`);
+          todayItems.push(`🔄 ${enrich(item)}`);
         }
       }
       for (const item of data.yesterdayIncomplete) {
-        todayItems.push(`➡️ ${enrich(item)} _(carried over)_`);
+        todayItems.push(`➡️ ${enrich(item)}`);
       }
       const carryForwardCount = (data.yesterdayInProgress || []).length + data.yesterdayIncomplete.length;
       if (carryForwardCount > 0 && data.todayPlans.length > 0) {

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -372,6 +372,11 @@ export interface IntegrationStatus {
   linear: boolean;
 }
 
+export interface OOOInfo {
+  slackUserId: string;
+  endDate: string;
+}
+
 export interface DigestOptions {
   dailyName: string;
   period: DigestPeriod;
@@ -381,6 +386,7 @@ export interface DigestOptions {
   stats: TeamMemberStats[];
   totalWorkdays: number;
   missingToday?: string[];
+  oooToday?: OOOInfo[]; // Users currently OOO
   bottlenecks?: BottleneckItem[];
   dropStats?: DropStats[];
   rankings?: TeamMemberRanking[];
@@ -475,6 +481,16 @@ export function formatManagerDigest(options: DigestOptions): string {
   if (period === 'daily' && missingToday && missingToday.length > 0) {
     lines.push('');
     lines.push(`*Not submitted:* ${missingToday.map(u => `<@${u}>`).join(' · ')}`);
+  }
+
+  // OOO users (for daily only)
+  if (period === 'daily' && options.oooToday && options.oooToday.length > 0) {
+    const formatShort = (d: string) => {
+      const date = new Date(d + 'T00:00:00');
+      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    };
+    const oooList = options.oooToday.map(o => `<@${o.slackUserId}> (back ${formatShort(o.endDate)})`).join(' · ');
+    lines.push(`*🏖️ Out today:* ${oooList}`);
   }
 
   // Compact team section

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -41,8 +41,6 @@ export interface StandupData {
   customAnswers: Record<string, string>;
   questions?: QuestionConfig[];
   fieldOrder?: FieldOrder;
-  prData?: UserPRData; // GitHub PR data for integration
-  reviewerSlackMap?: Map<string, string>; // GitHub login → Slack user ID
   inProgressCarryCounts?: Record<string, number>; // carry counts for attention warnings
   githubOrg?: string; // GitHub org for building clickable PR links
 }
@@ -195,14 +193,6 @@ export function formatStandupBlocks(
     const block = section.render();
     if (block) {
       blocks.push(block);
-    }
-  }
-
-  // PR section (if data available)
-  if (data.prData) {
-    const prBlock = formatPRSectionBlock(data.prData, data.reviewerSlackMap);
-    if (prBlock) {
-      blocks.push(prBlock);
     }
   }
 

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -49,8 +49,8 @@ export interface StandupData {
 
 // Default field order values
 const DEFAULT_FIELD_ORDER = {
-  yesterday: 10,  // Combined completed + unplanned
-  today: 20,      // Combined carried + new plans
+  yesterday: 20,  // Combined completed + unplanned
+  today: 10,      // Combined carried + new plans
   blockers: 30,
 };
 

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -5,7 +5,7 @@
  * - Generates daily digests and weekly summaries
  */
 
-import { Submission, ParticipationStats, TeamMemberStats, BottleneckItem, DropStats, TeamMemberRanking, PeriodStats, BlockerStreak, UnplannedOverload } from './db';
+import { Submission, ParticipationStats, TeamMemberStats, BottleneckItem, DropStats, TeamMemberRanking, PeriodStats, BlockerStreak, UnplannedOverload, WorkItem } from './db';
 import { postMessage, sendDM as slackSendDM, sendDMWithBlocks } from './slack';
 import { UserPRData, GitHubPR, formatPRRef, TeamPRData } from './github';
 import { TeamLinearData, CycleProgress } from './linear';
@@ -1319,6 +1319,21 @@ function enrichItemSource(text: string, githubOrg?: string): string {
   }
   // Linear ticket: "ENG-123"
   return `<https://linear.app/issue/${id}|🎫 ${id}> ${title}`;
+}
+
+/**
+ * Enrich a work item entity using its structured source fields (no regex needed).
+ * Falls back to enrichItemSource for items without source metadata.
+ */
+export function enrichItemFromEntity(item: WorkItem, githubOrg?: string): string {
+  if (item.source === 'manual' || !item.source_ref) {
+    return enrichItemSource(item.text, githubOrg);
+  }
+  const icon = item.source === 'github_pr' ? '📦' : '🎫';
+  const url = item.source_url || '#';
+  const ref = item.source_ref;
+  const title = item.text.replace(/^\[[^\]]+\]\s*/, '');
+  return `<${url}|${icon} ${ref}> ${title}`;
 }
 
 /** Parse JSONB arrays from database (handles both array and string formats) */

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -395,6 +395,7 @@ export interface DigestOptions {
   teamPRData?: TeamPRData[]; // GitHub PR data for team
   teamLinearData?: TeamLinearData[]; // Linear data for team
   cycleProgress?: CycleProgress | null; // Linear cycle progress
+  maxPlanItems?: number; // Plan-size threshold for over-plan flagging
 }
 
 /**
@@ -505,6 +506,21 @@ export function formatManagerDigest(options: DigestOptions): string {
     }
   }
 
+  // Build over-plan lookup (average plan count per user across submissions)
+  const overPlanMap = new Map<string, number>();
+  if (options.maxPlanItems && options.maxPlanItems > 0) {
+    const planCounts = new Map<string, number[]>();
+    for (const sub of submissions) {
+      const plans = (sub.today_plans?.length || 0) + (sub.yesterday_incomplete?.length || 0) + (sub.yesterday_in_progress?.length || 0);
+      if (!planCounts.has(sub.slack_user_id)) planCounts.set(sub.slack_user_id, []);
+      planCounts.get(sub.slack_user_id)!.push(plans);
+    }
+    for (const [userId, counts] of planCounts) {
+      const avg = counts.reduce((a, b) => a + b, 0) / counts.length;
+      if (avg >= options.maxPlanItems) overPlanMap.set(userId, Math.round(avg));
+    }
+  }
+
   for (const member of stats) {
     const rate = totalWorkdays > 0
       ? Math.round((Number(member.submission_count) / totalWorkdays) * 100)
@@ -521,6 +537,12 @@ export function formatManagerDigest(options: DigestOptions): string {
     const dropRate = dropRateMap.get(member.slack_user_id);
     if (dropRate && dropRate > 30) {
       line += ` — ${dropRate}% drops`;
+    }
+
+    // Flag users who routinely over-plan
+    const avgPlan = overPlanMap.get(member.slack_user_id);
+    if (avgPlan) {
+      line += ` — avg ${avgPlan} plans`;
     }
 
     lines.push(line);

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -111,20 +111,20 @@ export function formatStandupBlocks(
   sections.push({
     order: yesterdayOrder,
     render: () => {
-      const yesterdayItems: string[] = [];
-      for (const item of data.yesterdayCompleted) {
-        yesterdayItems.push(`✅ ${enrich(item)}`);
-      }
-      for (const item of data.unplanned) {
-        yesterdayItems.push(`⚡ ${item} _(unplanned)_`);
-      }
-      for (const item of data.yesterdayDropped || []) {
-        yesterdayItems.push(`❌ ${enrich(item)} _(dropped)_`);
-      }
-      if (yesterdayItems.length === 0) return null;
+      const doneCount = data.yesterdayCompleted.length;
+      const unplannedCount = data.unplanned.length;
+      const droppedCount = (data.yesterdayDropped || []).length;
+
+      if (doneCount + unplannedCount + droppedCount === 0) return null;
+
+      const parts: string[] = [];
+      if (doneCount > 0) parts.push(`${doneCount} done`);
+      if (unplannedCount > 0) parts.push(`${unplannedCount} unplanned`);
+      if (droppedCount > 0) parts.push(`${droppedCount} dropped`);
+
       return {
         type: 'section',
-        text: { type: 'mrkdwn', text: '*Yesterday:*\n' + yesterdayItems.join('\n') },
+        text: { type: 'mrkdwn', text: `*Yesterday* — ${parts.join(' · ')}` },
       };
     },
   });

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -5,7 +5,7 @@
  * - Generates daily digests and weekly summaries
  */
 
-import { Submission, ParticipationStats, TeamMemberStats, BottleneckItem, DropStats, TeamMemberRanking, PeriodStats } from './db';
+import { Submission, ParticipationStats, TeamMemberStats, BottleneckItem, DropStats, TeamMemberRanking, PeriodStats, BlockerStreak, UnplannedOverload } from './db';
 import { postMessage, sendDM as slackSendDM, sendDMWithBlocks } from './slack';
 import { UserPRData, GitHubPR, formatPRRef, TeamPRData } from './github';
 import { TeamLinearData, CycleProgress } from './linear';
@@ -401,6 +401,8 @@ export interface DigestOptions {
   teamLinearData?: TeamLinearData[]; // Linear data for team
   cycleProgress?: CycleProgress | null; // Linear cycle progress
   maxPlanItems?: number; // Plan-size threshold for over-plan flagging
+  blockerStreaks?: BlockerStreak[];
+  unplannedOverloads?: UnplannedOverload[];
 }
 
 /**
@@ -459,6 +461,24 @@ export function formatManagerDigest(options: DigestOptions): string {
         actionItems.push(`🔄 <@${item.slack_user_id}>: "${truncate(item.text, 35)}" in progress Day ${item.carry_count}`);
       } else {
         actionItems.push(`🔥 <@${item.slack_user_id}>: "${truncate(item.text, 35)}" stuck ${item.days_pending} days`);
+      }
+    }
+  }
+
+  // Blocker streaks (users blocked 3+ consecutive days)
+  if (options.blockerStreaks) {
+    for (const streak of options.blockerStreaks) {
+      if (streak.current_streak >= 3 && actionItems.length < 6) {
+        actionItems.push(`🚧 <@${streak.slack_user_id}>: blocked ${streak.current_streak} consecutive days`);
+      }
+    }
+  }
+
+  // Unplanned overload (pre-filtered by caller to threshold)
+  if (options.unplannedOverloads) {
+    for (const overload of options.unplannedOverloads) {
+      if (actionItems.length < 6) {
+        actionItems.push(`⚡ <@${overload.slack_user_id}>: ${overload.unplanned_pct}% unplanned work (${overload.unplanned_count}/${overload.completed_count} items)`);
       }
     }
   }
@@ -616,6 +636,8 @@ export interface FullReportOptions {
   bottlenecks?: BottleneckItem[];
   dropStats?: DropStats[];
   trends?: TrendData;
+  blockerStreaks?: BlockerStreak[];
+  unplannedOverloads?: UnplannedOverload[];
 }
 
 /**
@@ -623,7 +645,7 @@ export interface FullReportOptions {
  * Used by /standup report command
  */
 export function formatFullReport(options: FullReportOptions): string {
-  const { dailyName, period, startDate, endDate, submissions, stats, totalWorkdays, bottlenecks, dropStats, trends } = options;
+  const { dailyName, period, startDate, endDate, submissions, stats, totalWorkdays, bottlenecks, dropStats, trends, blockerStreaks, unplannedOverloads } = options;
 
   // Format date range
   const formatShortDate = (d: string) => {
@@ -682,6 +704,21 @@ export function formatFullReport(options: FullReportOptions): string {
     completionMap.set(sub.slack_user_id, existing);
   }
 
+  // Build lookup maps for new data
+  const blockerStreakMap = new Map<string, BlockerStreak>();
+  if (blockerStreaks) {
+    for (const streak of blockerStreaks) {
+      blockerStreakMap.set(streak.slack_user_id, streak);
+    }
+  }
+
+  const unplannedOverloadMap = new Map<string, UnplannedOverload>();
+  if (unplannedOverloads) {
+    for (const overload of unplannedOverloads) {
+      unplannedOverloadMap.set(overload.slack_user_id, overload);
+    }
+  }
+
   // Individual member sections
   for (const member of stats) {
     const userId = member.slack_user_id;
@@ -729,6 +766,18 @@ export function formatFullReport(options: FullReportOptions): string {
       lines.push(`Blockers: 0 days`);
     }
 
+    // Blocker streak
+    const streak = blockerStreakMap.get(userId);
+    if (streak && streak.current_streak >= 3) {
+      lines.push(`🚧 Current blocker streak: ${streak.current_streak} days`);
+    }
+
+    // Unplanned overload
+    const overload = unplannedOverloadMap.get(userId);
+    if (overload) {
+      lines.push(`⚡ Unplanned work: ${overload.unplanned_pct}% (${overload.unplanned_count}/${overload.completed_count} items)`);
+    }
+
     // Stuck items — separate in-progress from carried
     const userBottlenecks = bottleneckMap.get(userId);
     if (userBottlenecks && userBottlenecks.length > 0) {
@@ -772,6 +821,10 @@ export function formatFullReport(options: FullReportOptions): string {
     lines.push(`Completion: ${completionTrend}`);
     const blockerTrend = formatTrendCompact(trends.current.blocker_rate, trends.previous.blocker_rate, false);
     lines.push(`Blockers: ${blockerTrend}`);
+    if (trends.current.unplanned_rate !== undefined) {
+      const unplannedTrend = formatTrendCompact(trends.current.unplanned_rate, trends.previous.unplanned_rate, false);
+      lines.push(`Unplanned work: ${unplannedTrend}`);
+    }
   }
 
   return lines.join('\n');

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -42,6 +42,7 @@ export interface StandupData {
   prData?: UserPRData; // GitHub PR data for integration
   reviewerSlackMap?: Map<string, string>; // GitHub login → Slack user ID
   inProgressCarryCounts?: Record<string, number>; // carry counts for attention warnings
+  githubOrg?: string; // GitHub org for building clickable PR links
 }
 
 // Default field order values
@@ -102,19 +103,21 @@ export function formatStandupBlocks(
 
   const sections: OrderedSection[] = [];
 
+  const enrich = (text: string) => enrichItemSource(text, data.githubOrg);
+
   // Yesterday section - completed, unplanned, and dropped items
   sections.push({
     order: yesterdayOrder,
     render: () => {
       const yesterdayItems: string[] = [];
       for (const item of data.yesterdayCompleted) {
-        yesterdayItems.push(`☑️ ${item}`);
+        yesterdayItems.push(`☑️ ${enrich(item)}`);
       }
       for (const item of data.unplanned) {
         yesterdayItems.push(`☑️ ${item} _(unplanned)_`);
       }
       for (const item of data.yesterdayDropped || []) {
-        yesterdayItems.push(`❌ ${item} _(dropped)_`);
+        yesterdayItems.push(`❌ ${enrich(item)} _(dropped)_`);
       }
       if (yesterdayItems.length === 0) return null;
       return {
@@ -133,17 +136,17 @@ export function formatStandupBlocks(
       for (const item of data.yesterdayInProgress || []) {
         const carryCount = data.inProgressCarryCounts?.[item] || 0;
         const emoji = carryCount >= 3 ? '⚠️' : '🔄';
-        todayItems.push(`${emoji} ${item} _(in progress)_`);
+        todayItems.push(`${emoji} ${enrich(item)} _(in progress)_`);
       }
       for (const item of data.yesterdayIncomplete) {
-        todayItems.push(`⬜ ${item} _(carried over)_`);
+        todayItems.push(`⬜ ${enrich(item)} _(carried over)_`);
       }
       const carryForwardCount = (data.yesterdayInProgress || []).length + data.yesterdayIncomplete.length;
       if (carryForwardCount > 0 && data.todayPlans.length > 0) {
         todayItems.push('───');
       }
       for (const item of data.todayPlans) {
-        todayItems.push(`⬜ ${item}`);
+        todayItems.push(`⬜ ${enrich(item)}`);
       }
       if (todayItems.length === 0) return null;
       return {
@@ -1122,6 +1125,28 @@ export function formatLinearDigestSection(
 // ============================================================================
 // Helpers
 // ============================================================================
+
+/**
+ * Enrich a plan item with a clickable source link when it has an [identifier] prefix.
+ * - `[repo#42] title` → `<https://github.com/…|📦 repo#42> title`
+ * - `[ENG-123] title` → `<https://linear.app/issue/ENG-123|🎫 ENG-123> title`
+ * - no prefix → returned as-is
+ */
+function enrichItemSource(text: string, githubOrg?: string): string {
+  const match = text.match(/^\[([^\]]+)\]\s+(.*)/);
+  if (!match) return text;
+  const [, id, title] = match;
+  if (id.includes('#')) {
+    // GitHub PR: "repo#42"
+    const [repo, num] = id.split('#');
+    const url = githubOrg
+      ? `https://github.com/${githubOrg}/${repo}/pull/${num}`
+      : `#`;
+    return `<${url}|📦 ${id}> ${title}`;
+  }
+  // Linear ticket: "ENG-123"
+  return `<https://linear.app/issue/${id}|🎫 ${id}> ${title}`;
+}
 
 /** Parse JSONB arrays from database (handles both array and string formats) */
 function parseJsonArray(value: string[] | null): string[] {

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -111,10 +111,10 @@ export function formatStandupBlocks(
     render: () => {
       const yesterdayItems: string[] = [];
       for (const item of data.yesterdayCompleted) {
-        yesterdayItems.push(`☑️ ${enrich(item)}`);
+        yesterdayItems.push(`✅ ${enrich(item)}`);
       }
       for (const item of data.unplanned) {
-        yesterdayItems.push(`☑️ ${item} _(unplanned)_`);
+        yesterdayItems.push(`⚡ ${item} _(unplanned)_`);
       }
       for (const item of data.yesterdayDropped || []) {
         yesterdayItems.push(`❌ ${enrich(item)} _(dropped)_`);
@@ -139,14 +139,14 @@ export function formatStandupBlocks(
         todayItems.push(`${emoji} ${enrich(item)} _(in progress)_`);
       }
       for (const item of data.yesterdayIncomplete) {
-        todayItems.push(`⬜ ${enrich(item)} _(carried over)_`);
+        todayItems.push(`➡️ ${enrich(item)} _(carried over)_`);
       }
       const carryForwardCount = (data.yesterdayInProgress || []).length + data.yesterdayIncomplete.length;
       if (carryForwardCount > 0 && data.todayPlans.length > 0) {
         todayItems.push('───');
       }
       for (const item of data.todayPlans) {
-        todayItems.push(`⬜ ${enrich(item)}`);
+        todayItems.push(`🎯 ${enrich(item)}`);
       }
       if (todayItems.length === 0) return null;
       return {

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -9,6 +9,7 @@ import { Submission, ParticipationStats, TeamMemberStats, BottleneckItem, DropSt
 import { postMessage, sendDM as slackSendDM, sendDMWithBlocks } from './slack';
 import { UserPRData, GitHubPR, formatPRRef, TeamPRData } from './github';
 import { TeamLinearData, CycleProgress } from './linear';
+import { AlignmentResult } from './linear-intelligence';
 
 // Re-export sendDM for backward compatibility
 export { sendDM as sendDM } from './slack';
@@ -403,6 +404,7 @@ export interface DigestOptions {
   maxPlanItems?: number; // Plan-size threshold for over-plan flagging
   blockerStreaks?: BlockerStreak[];
   unplannedOverloads?: UnplannedOverload[];
+  linearAlignment?: AlignmentResult[]; // Phase 1 & 2: plan-vs-Linear alignment
 }
 
 /**
@@ -594,6 +596,14 @@ export function formatManagerDigest(options: DigestOptions): string {
     const linearSection = formatLinearDigestSection(options.teamLinearData || [], options.cycleProgress);
     if (linearSection) {
       lines.push(linearSection);
+    }
+  }
+
+  // Linear intelligence: plan-vs-Linear alignment (Phase 1 & 2)
+  if (options.linearAlignment && options.linearAlignment.length > 0) {
+    const alignmentSection = formatLinearAlignmentSection(options.linearAlignment);
+    if (alignmentSection) {
+      lines.push(alignmentSection);
     }
   }
 
@@ -1192,6 +1202,57 @@ export function formatMemberPRSummary(prData: UserPRData): string {
   }
 
   return parts.join(' · ');
+}
+
+// ============================================================================
+// Linear Intelligence Formatting (Phase 1 & 2)
+// ============================================================================
+
+/**
+ * Format plan-vs-Linear alignment section for manager digest.
+ * Shows per-user cross-reference gaps and priority alignment status.
+ *
+ * Example output:
+ *   🔍 *Plan-Linear Alignment*
+ *     <@U123>: 2 plans not in Linear, 1 ticket unplanned ⚠️ 1 urgent unplanned
+ *     <@U456>: ✅ aligned
+ */
+function formatLinearAlignmentSection(alignment: AlignmentResult[]): string {
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push('🔍 *Plan-Linear Alignment*');
+
+  for (const result of alignment) {
+    const parts: string[] = [];
+
+    if (result.plansNotInLinear.length > 0) {
+      parts.push(`${result.plansNotInLinear.length} plan${result.plansNotInLinear.length !== 1 ? 's' : ''} not in Linear`);
+    }
+
+    if (result.linearNotInPlans.length > 0) {
+      parts.push(`${result.linearNotInPlans.length} ticket${result.linearNotInPlans.length !== 1 ? 's' : ''} unplanned`);
+    }
+
+    let prioritySuffix = '';
+    if (result.priorityAlignment === 'off-track' && result.missedHighPriority.length > 0) {
+      const urgentCount = result.missedHighPriority.filter(i => i.priority === 1).length;
+      const highCount = result.missedHighPriority.filter(i => i.priority === 2).length;
+      const priorityParts: string[] = [];
+      if (urgentCount > 0) priorityParts.push(`${urgentCount} urgent`);
+      if (highCount > 0) priorityParts.push(`${highCount} high-priority`);
+      prioritySuffix = ` ⚠️ ${priorityParts.join(', ')} unplanned`;
+    }
+
+    if (parts.length === 0 && result.priorityAlignment === 'on-track') {
+      lines.push(`  <@${result.slackUserId}>: ✅ aligned`);
+    } else {
+      const gapText = parts.length > 0 ? parts.join(', ') : 'gaps found';
+      lines.push(`  <@${result.slackUserId}>: ${gapText}${prioritySuffix}`);
+    }
+  }
+
+  return lines.join('\n');
 }
 
 // ============================================================================

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -163,9 +163,14 @@ export function formatStandupBlocks(
     order: blockersOrder,
     render: () => {
       if (!data.blockers || !data.blockers.trim()) return null;
+      const prefixed = data.blockers
+        .split('\n')
+        .filter(line => line.trim())
+        .map(line => `🚧 ${line.trim()}`)
+        .join('\n');
       return {
         type: 'section',
-        text: { type: 'mrkdwn', text: `*🚧 Blockers:*\n${data.blockers}` },
+        text: { type: 'mrkdwn', text: prefixed },
       };
     },
   });

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -135,8 +135,13 @@ export function formatStandupBlocks(
       // In-progress items first
       for (const item of data.yesterdayInProgress || []) {
         const carryCount = data.inProgressCarryCounts?.[item] || 0;
-        const emoji = carryCount >= 3 ? '⚠️' : '🔄';
-        todayItems.push(`${emoji} ${enrich(item)} _(in progress)_`);
+        if (carryCount >= 3) {
+          todayItems.push(`⚠️ ${enrich(item)} _(Day ${carryCount} — needs attention)_`);
+        } else if (carryCount >= 1) {
+          todayItems.push(`🔄 ${enrich(item)} _(Day ${carryCount})_`);
+        } else {
+          todayItems.push(`🔄 ${enrich(item)} _(in progress)_`);
+        }
       }
       for (const item of data.yesterdayIncomplete) {
         todayItems.push(`➡️ ${enrich(item)} _(carried over)_`);
@@ -447,10 +452,14 @@ export function formatManagerDigest(options: DigestOptions): string {
   // Collect all action items
   const actionItems: string[] = [];
 
-  // Stuck items (bottlenecks)
+  // Stuck items (bottlenecks) — distinguish in-progress from carried
   if (bottlenecks && bottlenecks.length > 0) {
     for (const item of bottlenecks.slice(0, 3)) {
-      actionItems.push(`🔥 <@${item.slack_user_id}>: "${truncate(item.text, 35)}" stuck ${item.days_pending} days`);
+      if (item.status === 'in_progress') {
+        actionItems.push(`🔄 <@${item.slack_user_id}>: "${truncate(item.text, 35)}" in progress Day ${item.carry_count}`);
+      } else {
+        actionItems.push(`🔥 <@${item.slack_user_id}>: "${truncate(item.text, 35)}" stuck ${item.days_pending} days`);
+      }
     }
   }
 
@@ -720,16 +729,32 @@ export function formatFullReport(options: FullReportOptions): string {
       lines.push(`Blockers: 0 days`);
     }
 
-    // Stuck items
+    // Stuck items — separate in-progress from carried
     const userBottlenecks = bottleneckMap.get(userId);
     if (userBottlenecks && userBottlenecks.length > 0) {
-      lines.push('');
-      lines.push(`Stuck items:`);
-      for (const item of userBottlenecks.slice(0, 3)) {
-        lines.push(`  🔥 "${truncate(item.text, 40)}" (${item.days_pending} days, carried ${item.carry_count}x)`);
+      const inProgressItems = userBottlenecks.filter(b => b.status === 'in_progress');
+      const carriedItems = userBottlenecks.filter(b => b.status !== 'in_progress');
+
+      if (inProgressItems.length > 0) {
+        lines.push('');
+        lines.push(`In progress — needs attention:`);
+        for (const item of inProgressItems.slice(0, 3)) {
+          lines.push(`  🔄 "${truncate(item.text, 40)}" (Day ${item.carry_count})`);
+        }
+        if (inProgressItems.length > 3) {
+          lines.push(`  _...and ${inProgressItems.length - 3} more_`);
+        }
       }
-      if (userBottlenecks.length > 3) {
-        lines.push(`  _...and ${userBottlenecks.length - 3} more_`);
+
+      if (carriedItems.length > 0) {
+        lines.push('');
+        lines.push(`Stuck items:`);
+        for (const item of carriedItems.slice(0, 3)) {
+          lines.push(`  🔥 "${truncate(item.text, 40)}" (${item.days_pending} days, carried ${item.carry_count}x)`);
+        }
+        if (carriedItems.length > 3) {
+          lines.push(`  _...and ${carriedItems.length - 3} more_`);
+        }
       }
     }
 

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -85,7 +85,7 @@ export function formatStandupBlocks(
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text: `*<@${userId}>* submitted their standup`,
+      text: `*<@${userId}>*`,
     },
   });
 
@@ -147,9 +147,6 @@ export function formatStandupBlocks(
         todayItems.push(`➡️ ${enrich(item)}`);
       }
       const carryForwardCount = (data.yesterdayInProgress || []).length + data.yesterdayIncomplete.length;
-      if (carryForwardCount > 0 && data.todayPlans.length > 0) {
-        todayItems.push('───');
-      }
       for (const item of data.todayPlans) {
         todayItems.push(`🎯 ${enrich(item)}`);
       }
@@ -195,17 +192,6 @@ export function formatStandupBlocks(
       blocks.push(block);
     }
   }
-
-  // Context footer
-  blocks.push({
-    type: 'context',
-    elements: [
-      {
-        type: 'mrkdwn',
-        text: `_${dailyName} standup_`,
-      },
-    ],
-  });
 
   return blocks;
 }

--- a/lib/github-intelligence.ts
+++ b/lib/github-intelligence.ts
@@ -1,0 +1,153 @@
+/**
+ * GitHub Intelligence — Phase 2
+ * Pure data transformation: plan-vs-merged-PR cross-reference.
+ * No Slack, DB, or HTTP dependencies.
+ */
+
+import { WorkItem } from './db';
+import { MergedPR } from './github';
+
+export type { MergedPR };
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface GitHubAlignmentResult {
+  slackUserId: string;
+  plansWithoutWork: string[];     // plan item texts with no matching merged PR
+  workWithoutPlans: MergedPR[];   // merged PRs not covered by any plan item
+  alignmentStatus: 'aligned' | 'misaligned';
+}
+
+// ============================================================================
+// Text Normalization
+// ============================================================================
+
+const STOP_WORDS = new Set([
+  'the', 'a', 'an', 'is', 'in', 'on', 'for', 'to', 'and', 'or', 'of',
+  'with', 'from', 'by', 'at', 'as', 'it', 'fix', 'add', 'update',
+  'implement', 'feat', 'chore', 'refactor',
+]);
+
+/**
+ * Extract meaningful keywords from text for substring matching.
+ * Lowercases, strips punctuation, splits on whitespace, removes stop words
+ * and short words, and returns unique terms.
+ */
+export function normalizeForMatching(text: string): string[] {
+  const cleaned = text
+    .toLowerCase()
+    .replace(/[[\](){}<>*#@!?,;:'"\\|/]/g, ' ') // strip punctuation/special chars
+    .replace(/[^\w\s-]/g, ' ')                    // catch anything left
+    .replace(/-/g, ' ');                           // treat hyphens as spaces
+
+  const words = cleaned.split(/\s+/).filter(Boolean);
+
+  const unique = new Set<string>();
+  for (const word of words) {
+    if (word.length >= 3 && !STOP_WORDS.has(word)) {
+      unique.add(word);
+    }
+  }
+
+  return Array.from(unique);
+}
+
+// ============================================================================
+// Core Matching
+// ============================================================================
+
+/**
+ * Match a work item to a merged PR.
+ *
+ * Priority order:
+ *   1. Exact source_ref match: item.source === 'github_pr' AND source_ref === '{repo}#{number}'
+ *   2. Keyword match: ≥50% of normalized plan keywords appear in the PR title
+ *   3. linear_ticket items are excluded (handled by Linear intelligence)
+ *
+ * Returns the best-matching PR, or null if none found.
+ */
+export function matchPlanToMergedPR(
+  item: WorkItem,
+  mergedPRs: MergedPR[]
+): MergedPR | null {
+  // linear_ticket items are not matched here
+  if (item.source === 'linear_ticket') return null;
+
+  // Rule 1: exact source_ref match for github_pr items
+  if (item.source === 'github_pr' && item.source_ref) {
+    const exact = mergedPRs.find(
+      pr => `${pr.repo}#${pr.number}` === item.source_ref
+    );
+    if (exact) return exact;
+  }
+
+  // Rule 2: keyword overlap match (applies to manual and github_pr items)
+  const itemKeywords = normalizeForMatching(item.text);
+  if (itemKeywords.length === 0) return null;
+
+  let bestMatch: MergedPR | null = null;
+  let bestOverlap = 0;
+
+  for (const pr of mergedPRs) {
+    const prKeywords = new Set(normalizeForMatching(pr.title));
+    const matchCount = itemKeywords.filter(kw => prKeywords.has(kw)).length;
+    const overlapRatio = matchCount / itemKeywords.length;
+
+    if (overlapRatio >= 0.5 && matchCount > bestOverlap) {
+      bestOverlap = matchCount;
+      bestMatch = pr;
+    }
+  }
+
+  return bestMatch;
+}
+
+// ============================================================================
+// Main Alignment Computation
+// ============================================================================
+
+/**
+ * Compute full plan-vs-GitHub alignment for a single user.
+ *
+ * - plansWithoutWork: manual items that don't match any merged PR
+ * - workWithoutPlans: merged PRs that no work item matches
+ * - alignmentStatus: 'misaligned' if either list is non-empty
+ *
+ * linear_ticket items are excluded from "plans without work" — they're
+ * tracked by Linear intelligence.
+ */
+export function computeGitHubAlignment(
+  slackUserId: string,
+  workItems: WorkItem[],
+  mergedPRs: MergedPR[]
+): GitHubAlignmentResult {
+  // ---- plans without work ----
+  // Only manual items can be "unmatched plans"
+  const plansWithoutWork: string[] = workItems
+    .filter(item => item.source === 'manual')
+    .filter(item => matchPlanToMergedPR(item, mergedPRs) === null)
+    .map(item => item.text);
+
+  // ---- work without plans ----
+  // PRs that no work item (of any source) maps to
+  const workWithoutPlans: MergedPR[] = mergedPRs.filter(pr => {
+    return !workItems.some(item => {
+      const matched = matchPlanToMergedPR(item, [pr]);
+      return matched !== null;
+    });
+  });
+
+  const alignmentStatus =
+    plansWithoutWork.length > 0 || workWithoutPlans.length > 0
+      ? 'misaligned'
+      : 'aligned';
+
+  return {
+    slackUserId,
+    plansWithoutWork,
+    workWithoutPlans,
+    alignmentStatus,
+  };
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -42,6 +42,9 @@ interface GitHubSearchItem {
   draft: boolean;
   requested_reviewers?: GitHubUser[];
   repository_url?: string; // e.g., "https://api.github.com/repos/org/repo"
+  pull_request?: {
+    merged_at: string | null;
+  };
 }
 
 export interface GitHubReview {
@@ -507,6 +510,108 @@ export async function fetchTeamPRData(
           slackUserId: user.slackUserId,
           githubUsername: user.githubUsername,
           data,
+        };
+      })
+    );
+
+    results.push(...batchResults);
+  }
+
+  return results;
+}
+
+// ============================================================================
+// Merged PR Fetching
+// ============================================================================
+
+export interface MergedPR {
+  number: number;
+  title: string;
+  repo: string;
+  url: string;
+  mergedAt: string;
+}
+
+/**
+ * Fetch PRs merged by a user in an org since a given date
+ */
+export async function fetchMergedPRs(
+  token: string,
+  username: string,
+  org: string,
+  since: string // ISO date string, e.g. "2026-05-07"
+): Promise<MergedPR[]> {
+  const query = `is:pr is:merged author:${username} org:${org} merged:>${since}`;
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=desc&per_page=100`,
+      {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Accept': 'application/vnd.github.v3+json',
+          'User-Agent': 'omdim-bot',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(`GitHub API error for merged PRs (${username}): ${response.status} ${errorText}`);
+      return [];
+    }
+
+    const data = await response.json() as GitHubSearchResponse;
+
+    return data.items.map((item) => {
+      // Extract repo name from repository_url: "https://api.github.com/repos/{org}/{repo}"
+      const repoParts = (item.repository_url || '').split('/');
+      const repo = repoParts[repoParts.length - 1] || '';
+
+      return {
+        number: item.number,
+        title: item.title,
+        repo,
+        url: item.html_url,
+        mergedAt: item.pull_request?.merged_at || '',
+      };
+    });
+  } catch (error) {
+    console.error(`Failed to fetch merged PRs for ${username}:`, error);
+    return [];
+  }
+}
+
+export interface TeamMergedPRData {
+  slackUserId: string;
+  githubUsername: string;
+  mergedPRs: MergedPR[];
+}
+
+/**
+ * Fetch merged PRs for multiple users in an org since a given date
+ * Uses batching to avoid rate limits
+ */
+export async function fetchTeamMergedPRs(
+  token: string,
+  org: string,
+  users: Array<{ slackUserId: string; githubUsername: string }>,
+  since: string
+): Promise<TeamMergedPRData[]> {
+  const results: TeamMergedPRData[] = [];
+
+  // Process in batches of 5 to avoid rate limits
+  const batchSize = 5;
+  for (let i = 0; i < users.length; i += batchSize) {
+    const batch = users.slice(i, i + batchSize);
+
+    const batchResults = await Promise.all(
+      batch.map(async (user) => {
+        const mergedPRs = await fetchMergedPRs(token, user.githubUsername, org, since);
+        return {
+          slackUserId: user.slackUserId,
+          githubUsername: user.githubUsername,
+          mergedPRs,
         };
       })
     );

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -44,9 +44,11 @@ interface GitHubSearchItem {
   repository_url?: string; // e.g., "https://api.github.com/repos/org/repo"
 }
 
-interface GitHubReview {
+export interface GitHubReview {
   user: GitHubUser;
   submitted_at: string;
+  state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'DISMISSED' | 'PENDING';
+  body: string;
 }
 
 interface GitHubSearchResponse {
@@ -153,7 +155,9 @@ export async function fetchApprovedPRs(
 }
 
 /**
- * Fetch PRs where the user is requested as a reviewer
+ * Fetch PRs where the user is requested as a reviewer.
+ * Fetches reviews for each PR and filters out those where the reviewer
+ * has already acted and the ball is back in the author's court.
  */
 export async function fetchReviewRequests(
   token: string,
@@ -182,7 +186,7 @@ export async function fetchReviewRequests(
 
     const data = await response.json() as GitHubSearchResponse;
 
-    return data.items.map((item) => ({
+    const prs: GitHubPR[] = data.items.map((item) => ({
       number: item.number,
       title: item.title,
       url: item.html_url,
@@ -193,6 +197,28 @@ export async function fetchReviewRequests(
       updatedAt: item.updated_at,
       draft: item.draft,
     }));
+
+    if (prs.length === 0) return [];
+
+    // Fetch reviews for all PRs in parallel; fail-open on errors
+    const reviewsMap = new Map<number, GitHubReview[]>();
+    await Promise.all(
+      prs.map(async (pr) => {
+        const repoMatch = pr.url.match(/github\.com\/([^/]+)\/([^/]+)\/pull/);
+        if (!repoMatch) return; // fail-open: no repo info, keep PR
+
+        const [, owner, repo] = repoMatch;
+        try {
+          const reviews = await fetchPRReviews(token, owner, repo, pr.number);
+          reviewsMap.set(pr.number, reviews);
+        } catch (err) {
+          // fail-open: if reviews fetch fails, keep PR visible (don't add to map)
+          console.warn(`Could not fetch reviews for PR #${pr.number}:`, err);
+        }
+      })
+    );
+
+    return filterReviewRequests(prs, reviewsMap, username);
   } catch (error) {
     console.error('Failed to fetch review requests:', error);
     return [];
@@ -248,6 +274,91 @@ export async function fetchAwaitingReviewPRs(
 }
 
 /**
+ * Fetch all reviews for a specific PR
+ */
+export async function fetchPRReviews(
+  token: string,
+  owner: string,
+  repo: string,
+  prNumber: number
+): Promise<GitHubReview[]> {
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`,
+    {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github.v3+json',
+        'User-Agent': 'omdim-bot',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`GitHub API error fetching reviews for ${owner}/${repo}#${prNumber}: ${response.status} ${errorText}`);
+  }
+
+  return response.json() as Promise<GitHubReview[]>;
+}
+
+/**
+ * Filter review-requested PRs to only those where the reviewer still needs to act.
+ *
+ * Rules (fail-open: when in doubt, keep the PR visible):
+ * - Keep if reviewer has no reviews on this PR (fresh request)
+ * - Hide if reviewer's latest non-PENDING review was submitted at or after pr.updated_at
+ *   (reviewer acted, ball is in the author's court)
+ * - Hide if someone (non-author) submitted APPROVED and no CHANGES_REQUESTED came after it
+ * - PENDING reviews are ignored (not submitted yet)
+ * - Reviews by the PR author are ignored
+ */
+export function filterReviewRequests(
+  prs: GitHubPR[],
+  reviewsMap: Map<number, GitHubReview[]>,
+  username: string
+): GitHubPR[] {
+  return prs.filter((pr) => {
+    const allReviews = reviewsMap.get(pr.number);
+
+    // No review data available — fail-open, keep the PR
+    if (allReviews === undefined) return true;
+
+    // Ignore PENDING and reviews by the PR author
+    const submittedReviews = allReviews.filter(
+      (r) => r.state !== 'PENDING' && r.user.login.toLowerCase() !== pr.author.toLowerCase()
+    );
+
+    // Check if someone already approved and no CHANGES_REQUESTED supersedes it
+    const approvals = submittedReviews
+      .filter((r) => r.state === 'APPROVED')
+      .sort((a, b) => a.submitted_at.localeCompare(b.submitted_at));
+
+    if (approvals.length > 0) {
+      const lastApproval = approvals[approvals.length - 1];
+      const changesRequestedAfterApproval = submittedReviews.some(
+        (r) => r.state === 'CHANGES_REQUESTED' && r.submitted_at > lastApproval.submitted_at
+      );
+      if (!changesRequestedAfterApproval) return false;
+    }
+
+    // Reviewer's own reviews
+    const reviewerReviews = submittedReviews.filter(
+      (r) => r.user.login.toLowerCase() === username.toLowerCase()
+    );
+
+    if (reviewerReviews.length === 0) return true;
+
+    const latestReviewerReview = reviewerReviews[reviewerReviews.length - 1];
+
+    // If reviewer's latest review is at or after PR's last update,
+    // the ball is in the author's court — hide it
+    if (latestReviewerReview.submitted_at >= pr.updatedAt) return false;
+
+    return true;
+  });
+}
+
+/**
  * Fetch PRs where the user previously reviewed but new updates were pushed since.
  * These PRs no longer have the user in review-requested (author didn't re-request),
  * but the PR was updated after the user's last review — likely needs re-review.
@@ -284,27 +395,14 @@ export async function fetchPRsNeedingReReview(
 
     // For each PR, check if it was updated after the user's last review
     const prChecks = data.items.map(async (item): Promise<GitHubPR | null> => {
-      // Extract owner/repo from repository_url or html_url
+      // Extract owner/repo from html_url
       const repoMatch = item.html_url.match(/github\.com\/([^/]+)\/([^/]+)\/pull/);
       if (!repoMatch) return null;
 
       const [, owner, repo] = repoMatch;
 
       try {
-        const reviewsResponse = await fetch(
-          `https://api.github.com/repos/${owner}/${repo}/pulls/${item.number}/reviews`,
-          {
-            headers: {
-              'Authorization': `Bearer ${token}`,
-              'Accept': 'application/vnd.github.v3+json',
-              'User-Agent': 'omdim-bot',
-            },
-          }
-        );
-
-        if (!reviewsResponse.ok) return null;
-
-        const reviews = await reviewsResponse.json() as GitHubReview[];
+        const reviews = await fetchPRReviews(token, owner, repo, item.number);
 
         // Find the user's latest review
         const userReviews = reviews.filter(

--- a/lib/handlers/commands.ts
+++ b/lib/handlers/commands.ts
@@ -4,7 +4,7 @@
  */
 
 import { getDailies, getDaily, getSchedule, isAdmin, isSuperAdmin, getAdmins, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser, clearConfigCache, loadConfigOverrides, isDailyEnabled, getAllDailiesIncludingDisabled, getDailyManagers, getOverride } from '../config';
-import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride, getAllConfigOverrides } from '../db';
+import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride, getAllConfigOverrides, getBlockerStreaks, getUnplannedOverload } from '../db';
 import { formatDailyDigest, formatWeeklySummary, formatManagerDigest, formatFullReport, DigestPeriod, TrendData } from '../format';
 import { fetchLinearIssuesForUser, fetchGitHubPRsForUser } from './interactions';
 import { formatDate, getUserDate, getUserTimezone, sendPromptDM } from '../prompt';
@@ -242,6 +242,9 @@ export async function handleDigest(ctx: CommandContext): Promise<CommandResponse
             missingToday = await getMissingSubmissions(ctx.db, daily.name, endDate);
           }
 
+          const blockerStreaks = await getBlockerStreaks(ctx.db, daily.name, startDate, endDate);
+          const unplannedOverloads = await getUnplannedOverload(ctx.db, daily.name, startDate, endDate, 70);
+
           const digestText = formatManagerDigest({
             dailyName: daily.name,
             period,
@@ -251,6 +254,8 @@ export async function handleDigest(ctx: CommandContext): Promise<CommandResponse
             stats,
             totalWorkdays,
             missingToday,
+            blockerStreaks,
+            unplannedOverloads,
           });
           digestParts.push(digestText);
         } catch (err) {
@@ -309,6 +314,9 @@ export async function handleDigest(ctx: CommandContext): Promise<CommandResponse
       missingToday = await getMissingSubmissions(ctx.db, digestDailyName, endDate);
     }
 
+    const blockerStreaks = await getBlockerStreaks(ctx.db, digestDailyName, startDate, endDate);
+    const unplannedOverloads = await getUnplannedOverload(ctx.db, digestDailyName, startDate, endDate, 70);
+
     const digestText = formatManagerDigest({
       dailyName: digestDailyName,
       period,
@@ -318,6 +326,8 @@ export async function handleDigest(ctx: CommandContext): Promise<CommandResponse
       stats,
       totalWorkdays,
       missingToday,
+      blockerStreaks,
+      unplannedOverloads,
     });
 
     await sendDM(ctx.slackToken, ctx.userId, digestText);
@@ -611,6 +621,9 @@ export async function handleReport(ctx: CommandContext): Promise<CommandResponse
             trends = { current: currentStats, previous: previousStats };
           }
 
+          const blockerStreaks = await getBlockerStreaks(ctx.db, daily.name, startDate, endDate);
+          const unplannedOverloads = await getUnplannedOverload(ctx.db, daily.name, startDate, endDate, 70);
+
           const reportText = formatFullReport({
             dailyName: daily.name,
             period,
@@ -622,6 +635,8 @@ export async function handleReport(ctx: CommandContext): Promise<CommandResponse
             bottlenecks,
             dropStats,
             trends,
+            blockerStreaks,
+            unplannedOverloads,
           });
           reportParts.push(reportText);
         } catch (err) {
@@ -698,6 +713,9 @@ export async function handleReport(ctx: CommandContext): Promise<CommandResponse
       };
     }
 
+    const blockerStreaks = await getBlockerStreaks(ctx.db, reportDailyName, startDate, endDate);
+    const unplannedOverloads = await getUnplannedOverload(ctx.db, reportDailyName, startDate, endDate, 70);
+
     const reportText = formatFullReport({
       dailyName: reportDailyName,
       period,
@@ -709,6 +727,8 @@ export async function handleReport(ctx: CommandContext): Promise<CommandResponse
       bottlenecks,
       dropStats,
       trends,
+      blockerStreaks,
+      unplannedOverloads,
     });
 
     await sendDM(ctx.slackToken, ctx.userId, reportText);

--- a/lib/handlers/commands.ts
+++ b/lib/handlers/commands.ts
@@ -3,8 +3,8 @@
  * Handles: help, prompt, add, remove, list, digest, week, daily
  */
 
-import { getDailies, getDaily, getSchedule, isAdmin, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser, clearConfigCache, loadConfigOverrides, isDailyEnabled, getAllDailiesIncludingDisabled } from '../config';
-import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride } from '../db';
+import { getDailies, getDaily, getSchedule, isAdmin, isSuperAdmin, getAdmins, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser, clearConfigCache, loadConfigOverrides, isDailyEnabled, getAllDailiesIncludingDisabled, getDailyManagers, getOverride } from '../config';
+import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride, getAllConfigOverrides } from '../db';
 import { formatDailyDigest, formatWeeklySummary, formatManagerDigest, formatFullReport, DigestPeriod, TrendData } from '../format';
 import { fetchLinearIssuesForUser, fetchGitHubPRsForUser } from './interactions';
 import { formatDate, getUserDate, getUserTimezone, sendPromptDM } from '../prompt';
@@ -58,6 +58,8 @@ export function handleHelp(): CommandResponse {
     '    _period: `day` (default), `week`, `month`_\n' +
     '    _Use `all` to run for all dailies_\n\n' +
     '*Admin*\n' +
+    '`/standup admin [add|remove|list] [@user]` - Manage admins (super-admin only)\n' +
+    '`/standup manager [add|remove|list] <daily> [@user]` - Manage daily managers\n' +
     '`/standup prompt all <daily>` - Send prompts to all participants\n' +
     '`/standup pause <daily>` - Pause a daily (skip prompts, digests)\n' +
     '`/standup resume <daily>` - Resume a paused daily\n' +
@@ -1134,6 +1136,128 @@ export async function handleLinear(ctx: CommandContext): Promise<CommandResponse
 }
 
 // ============================================================================
+// Admin Management
+// ============================================================================
+
+async function handleAdmin(ctx: CommandContext): Promise<CommandResponse> {
+  const action = ctx.args[1]?.toLowerCase();
+
+  if (action === 'list') {
+    const { superAdmins, dbAdmins } = getAdmins();
+    const lines: string[] = ['*Admins*'];
+    lines.push('');
+    lines.push('*Super-admins* (config):');
+    for (const id of superAdmins) lines.push(`  • <@${id}>`);
+    if (dbAdmins.length > 0) {
+      lines.push('');
+      lines.push('*Admins* (added):');
+      for (const id of dbAdmins) lines.push(`  • <@${id}>`);
+    }
+    return ephemeralResponse(lines.join('\n'));
+  }
+
+  if (!isSuperAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only super-admins (defined in config) can manage admins.');
+  }
+
+  if (action === 'add') {
+    const targetId = parseUserId(ctx.args[2] || '');
+    if (!targetId) return ephemeralResponse('Usage: `/standup admin add @user`');
+    if (isAdmin(targetId)) return ephemeralResponse(`ℹ️ <@${targetId}> is already an admin.`);
+
+    const dbAdmins = getOverride<string[]>('global', 'admins') ?? [];
+    await setConfigOverride(ctx.db, 'global', 'admins', [...dbAdmins, targetId], ctx.userId);
+    await loadConfigOverrides(ctx.db);
+    return ephemeralResponse(`✅ <@${targetId}> is now an admin.`);
+  }
+
+  if (action === 'remove') {
+    const targetId = parseUserId(ctx.args[2] || '');
+    if (!targetId) return ephemeralResponse('Usage: `/standup admin remove @user`');
+    if (isSuperAdmin(targetId)) return ephemeralResponse('❌ Cannot remove a super-admin. Edit config.yaml instead.');
+
+    const dbAdmins = getOverride<string[]>('global', 'admins') ?? [];
+    if (!dbAdmins.includes(targetId)) return ephemeralResponse(`ℹ️ <@${targetId}> is not a DB-added admin.`);
+
+    await setConfigOverride(ctx.db, 'global', 'admins', dbAdmins.filter(id => id !== targetId), ctx.userId);
+    await loadConfigOverrides(ctx.db);
+    return ephemeralResponse(`✅ <@${targetId}> is no longer an admin.`);
+  }
+
+  return ephemeralResponse('Usage: `/standup admin [add|remove|list] [@user]`');
+}
+
+// ============================================================================
+// Manager Management
+// ============================================================================
+
+async function handleManager(ctx: CommandContext): Promise<CommandResponse> {
+  if (!isAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only admins can manage daily managers.');
+  }
+
+  const action = ctx.args[1]?.toLowerCase();
+  const dailyName = ctx.args[2];
+
+  if (action === 'list') {
+    if (!dailyName) return ephemeralResponse('Usage: `/standup manager list <daily>`');
+    const daily = getDaily(dailyName);
+    if (!daily) return ephemeralResponse(`❌ Daily "${dailyName}" not found.`);
+
+    const managers = getDailyManagers(daily);
+    if (managers.length === 0) return ephemeralResponse(`*${dailyName}* has no managers.`);
+
+    const list = managers.map(id => `  • <@${id}>`).join('\n');
+    return ephemeralResponse(`*${dailyName}* managers:\n${list}`);
+  }
+
+  if (action === 'add') {
+    const targetId = parseUserId(ctx.args[3] || '') || parseUserId(dailyName || '');
+    const resolvedDaily = parseUserId(dailyName || '') ? ctx.args[3] : dailyName;
+
+    if (!resolvedDaily || !targetId) {
+      return ephemeralResponse('Usage: `/standup manager add <daily> @user`');
+    }
+
+    const daily = getDaily(resolvedDaily);
+    if (!daily) return ephemeralResponse(`❌ Daily "${resolvedDaily}" not found.`);
+
+    const currentManagers = getDailyManagers(daily);
+    if (currentManagers.includes(targetId)) {
+      return ephemeralResponse(`ℹ️ <@${targetId}> is already a manager of *${resolvedDaily}*.`);
+    }
+
+    const dbManagers = getOverride<string[]>(resolvedDaily, 'managers') ?? [];
+    await setConfigOverride(ctx.db, resolvedDaily, 'managers', [...dbManagers, targetId], ctx.userId);
+    await loadConfigOverrides(ctx.db);
+    return ephemeralResponse(`✅ <@${targetId}> is now a manager of *${resolvedDaily}*. They'll receive digests and reports.`);
+  }
+
+  if (action === 'remove') {
+    const targetId = parseUserId(ctx.args[3] || '') || parseUserId(dailyName || '');
+    const resolvedDaily = parseUserId(dailyName || '') ? ctx.args[3] : dailyName;
+
+    if (!resolvedDaily || !targetId) {
+      return ephemeralResponse('Usage: `/standup manager remove <daily> @user`');
+    }
+
+    const daily = getDaily(resolvedDaily);
+    if (!daily) return ephemeralResponse(`❌ Daily "${resolvedDaily}" not found.`);
+
+    const dbManagers = getOverride<string[]>(resolvedDaily, 'managers') ?? [];
+    if (!dbManagers.includes(targetId)) {
+      return ephemeralResponse(`ℹ️ <@${targetId}> is not a DB-added manager of *${resolvedDaily}*. YAML managers must be removed from config.`);
+    }
+
+    await setConfigOverride(ctx.db, resolvedDaily, 'managers', dbManagers.filter(id => id !== targetId), ctx.userId);
+    await loadConfigOverrides(ctx.db);
+    return ephemeralResponse(`✅ <@${targetId}> is no longer a manager of *${resolvedDaily}*.`);
+  }
+
+  return ephemeralResponse('Usage: `/standup manager [add|remove|list] <daily> [@user]`');
+}
+
+// ============================================================================
 // Mass Prompt (Admin)
 // ============================================================================
 
@@ -1298,6 +1422,10 @@ export async function handleCommand(
       return handleLinear(ctx);
     case 'force-prompt':
       return handleForcePrompt(ctx);
+    case 'admin':
+      return handleAdmin(ctx);
+    case 'manager':
+      return handleManager(ctx);
     case 'config':
       return handleConfigReload(ctx);
     case 'pause':

--- a/lib/handlers/commands.ts
+++ b/lib/handlers/commands.ts
@@ -3,8 +3,8 @@
  * Handles: help, prompt, add, remove, list, digest, week, daily
  */
 
-import { getDailies, getDaily, getSchedule, isAdmin, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser } from '../config';
-import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId } from '../db';
+import { getDailies, getDaily, getSchedule, isAdmin, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser, clearConfigCache, loadConfigOverrides, isDailyEnabled, getAllDailiesIncludingDisabled } from '../config';
+import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride } from '../db';
 import { formatDailyDigest, formatWeeklySummary, formatManagerDigest, formatFullReport, DigestPeriod, TrendData } from '../format';
 import { fetchLinearIssuesForUser, fetchGitHubPRsForUser } from './interactions';
 import { formatDate, getUserDate, getUserTimezone, sendPromptDM } from '../prompt';
@@ -56,7 +56,11 @@ export function handleHelp(): CommandResponse {
     '`/standup digest <daily|all> [period]` - Get team summary (DM)\n' +
     '`/standup report <daily|all> [period]` - Get detailed team report (DM)\n' +
     '    _period: `day` (default), `week`, `month`_\n' +
-    '    _Use `all` to run for all dailies_'
+    '    _Use `all` to run for all dailies_\n\n' +
+    '*Admin*\n' +
+    '`/standup pause <daily>` - Pause a daily (skip prompts, digests)\n' +
+    '`/standup resume <daily>` - Resume a paused daily\n' +
+    '`/standup config reload` - Reload configuration'
   );
 }
 
@@ -121,7 +125,7 @@ export async function handleList(ctx: CommandContext): Promise<CommandResponse> 
 
   // No arg or 'all' → show all dailies with participants
   if (!listDailyName || isAllDailies(listDailyName)) {
-    const dailies = getDailies();
+    const dailies = getAllDailiesIncludingDisabled();
     if (dailies.length === 0) {
       return ephemeralResponse('No dailies configured.');
     }
@@ -132,6 +136,7 @@ export async function handleList(ctx: CommandContext): Promise<CommandResponse> 
         const participants = await getParticipants(ctx.db, daily.name);
         const oooRecords = await getActiveOOOForDaily(ctx.db, daily.name, todayStr);
         const oooUserIds = new Set(oooRecords.map(r => r.slack_user_id));
+        const pausedLabel = !isDailyEnabled(daily.name) ? ' ⏸️' : '';
 
         const userList = participants.length > 0
           ? participants.map(p => {
@@ -139,7 +144,7 @@ export async function handleList(ctx: CommandContext): Promise<CommandResponse> 
               return `<@${p.slack_user_id}>${oooLabel}`;
             }).join(', ')
           : '_no participants_';
-        results.push(`*${daily.name}* (${daily.channel}): ${userList}`);
+        results.push(`*${daily.name}*${pausedLabel} (${daily.channel}): ${userList}`);
       }
       return ephemeralResponse(results.join('\n'));
     } catch (err) {
@@ -1122,6 +1127,77 @@ export async function handleLinear(ctx: CommandContext): Promise<CommandResponse
 }
 
 // ============================================================================
+// Dynamic Configuration Commands
+// ============================================================================
+
+async function handleConfigReload(ctx: CommandContext): Promise<CommandResponse> {
+  if (!isAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only admins can reload config.');
+  }
+
+  clearConfigCache();
+  await loadConfigOverrides(ctx.db);
+
+  const dailies = getAllDailiesIncludingDisabled();
+  const enabledCount = dailies.filter(d => isDailyEnabled(d.name)).length;
+  const disabledCount = dailies.length - enabledCount;
+
+  let msg = `✅ Config reloaded. ${enabledCount} dailies active.`;
+  if (disabledCount > 0) {
+    msg += ` ${disabledCount} paused.`;
+  }
+  return ephemeralResponse(msg);
+}
+
+async function handlePause(ctx: CommandContext): Promise<CommandResponse> {
+  if (!isAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only admins can pause dailies.');
+  }
+
+  const dailyName = ctx.args[1];
+  if (!dailyName) {
+    return ephemeralResponse('Usage: `/standup pause <daily>`');
+  }
+
+  const daily = getDaily(dailyName);
+  if (!daily) {
+    return ephemeralResponse(`❌ Unknown daily: \`${dailyName}\``);
+  }
+
+  if (!isDailyEnabled(dailyName)) {
+    return ephemeralResponse(`ℹ️ \`${dailyName}\` is already paused.`);
+  }
+
+  await setConfigOverride(ctx.db, dailyName, 'enabled', false, ctx.userId);
+  await loadConfigOverrides(ctx.db);
+  return ephemeralResponse(`⏸️ \`${dailyName}\` is now paused. Prompts, digests, and reminders will be skipped.\nUse \`/standup resume ${dailyName}\` to re-enable.`);
+}
+
+async function handleResume(ctx: CommandContext): Promise<CommandResponse> {
+  if (!isAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only admins can resume dailies.');
+  }
+
+  const dailyName = ctx.args[1];
+  if (!dailyName) {
+    return ephemeralResponse('Usage: `/standup resume <daily>`');
+  }
+
+  const daily = getDaily(dailyName);
+  if (!daily) {
+    return ephemeralResponse(`❌ Unknown daily: \`${dailyName}\``);
+  }
+
+  if (isDailyEnabled(dailyName)) {
+    return ephemeralResponse(`ℹ️ \`${dailyName}\` is already active.`);
+  }
+
+  await deleteConfigOverride(ctx.db, dailyName, 'enabled');
+  await loadConfigOverrides(ctx.db);
+  return ephemeralResponse(`▶️ \`${dailyName}\` is now active again. Prompts, digests, and reminders will resume.`);
+}
+
+// ============================================================================
 // Main Router
 // ============================================================================
 
@@ -1166,6 +1242,12 @@ export async function handleCommand(
       return handleLinear(ctx);
     case 'force-prompt':
       return handleForcePrompt(ctx);
+    case 'config':
+      return handleConfigReload(ctx);
+    case 'pause':
+      return handlePause(ctx);
+    case 'resume':
+      return handleResume(ctx);
     default:
       return ephemeralResponse(
         `Unknown command: \`${subcommand}\`\nTry \`/standup help\` for usage.`

--- a/lib/handlers/commands.ts
+++ b/lib/handlers/commands.ts
@@ -58,6 +58,7 @@ export function handleHelp(): CommandResponse {
     '    _period: `day` (default), `week`, `month`_\n' +
     '    _Use `all` to run for all dailies_\n\n' +
     '*Admin*\n' +
+    '`/standup prompt all <daily>` - Send prompts to all participants\n' +
     '`/standup pause <daily>` - Pause a daily (skip prompts, digests)\n' +
     '`/standup resume <daily>` - Resume a paused daily\n' +
     '`/standup config reload` - Reload configuration'
@@ -328,6 +329,12 @@ export async function handleDigest(ctx: CommandContext): Promise<CommandResponse
 /** Send prompt DM with "Open Standup" button */
 export async function handlePrompt(ctx: CommandContext): Promise<CommandResponse> {
   const promptDailyName = ctx.args[1];
+  const massPromptDaily = ctx.args[2];
+
+  // Admin mass-prompt: `/standup prompt all <daily>`
+  if (promptDailyName && isAllDailies(promptDailyName) && massPromptDaily) {
+    return handleMassPrompt(ctx, massPromptDaily);
+  }
 
   try {
     // Get user's dailies
@@ -1124,6 +1131,55 @@ export async function handleLinear(ctx: CommandContext): Promise<CommandResponse
     console.error('Failed to manage Linear link:', err);
     return ephemeralResponse('❌ Failed to manage Linear link. Please try again.');
   }
+}
+
+// ============================================================================
+// Mass Prompt (Admin)
+// ============================================================================
+
+async function handleMassPrompt(ctx: CommandContext, dailyName: string): Promise<CommandResponse> {
+  if (!isAdmin(ctx.userId)) {
+    return ephemeralResponse('❌ Only admins can send mass prompts.');
+  }
+
+  const daily = getDaily(dailyName);
+  if (!daily) {
+    return ephemeralResponse(`❌ Daily "${dailyName}" not found.`);
+  }
+
+  const participants = await getParticipants(ctx.db, dailyName);
+  if (participants.length === 0) {
+    return ephemeralResponse(`❌ No participants in *${dailyName}*.`);
+  }
+
+  if (!ctx.triggerId) {
+    return ephemeralResponse('❌ Cannot open confirmation dialog. Please try again.');
+  }
+
+  const view = {
+    type: 'modal' as const,
+    callback_id: 'mass_prompt_confirm',
+    private_metadata: JSON.stringify({ dailyName }),
+    title: { type: 'plain_text' as const, text: 'Send Mass Prompt' },
+    submit: { type: 'plain_text' as const, text: 'Send Prompts' },
+    close: { type: 'plain_text' as const, text: 'Cancel' },
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `Send standup prompts to *all ${participants.length} participants* in *${dailyName}*?\n\nEach user will receive a DM with a standup prompt.`,
+        },
+      },
+    ],
+  };
+
+  const opened = await openModal(ctx.slackToken, ctx.triggerId, view);
+  if (!opened) {
+    return ephemeralResponse('❌ Failed to open confirmation dialog.');
+  }
+
+  return ephemeralResponse('Opening confirmation...');
 }
 
 // ============================================================================

--- a/lib/handlers/home.ts
+++ b/lib/handlers/home.ts
@@ -182,7 +182,7 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
               planLines.push(`❌ ~${item.text}~${sourceTag}`);
               break;
             default:
-              planLines.push(`⬜ ${item.text}${sourceTag}`);
+              planLines.push(`🎯 ${item.text}${sourceTag}`);
           }
         }
         blocks.push({

--- a/lib/handlers/home.ts
+++ b/lib/handlers/home.ts
@@ -3,7 +3,7 @@
  * Shows user's dailies with "Start Daily" buttons
  */
 
-import { DbClient, getUserDailies, getSubmissionForDate, getPreviousSubmission, Submission, getGitHubUsername, getLinearUserId, setGitHubUsername, setLinearUserId, getDmStandupPreference, getUserSettings, getActiveOOO } from '../db';
+import { DbClient, getUserDailies, getSubmissionForDate, getPreviousSubmission, Submission, getGitHubUsername, getLinearUserId, setGitHubUsername, setLinearUserId, getDmStandupPreference, getUserSettings, getActiveOOO, getActiveWorkItems } from '../db';
 import { getDaily, getGitHubConfig, getGitHubUsernameFromConfig, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser } from '../config';
 import { publishHomeView } from '../slack';
 import { formatDate, getUserDate, getUserTimezone } from '../prompt';
@@ -32,6 +32,7 @@ export interface AppHomeOpenedEvent {
 // ============================================================================
 
 interface PlanItem {
+  id?: number;      // work_item.id — needed for overflow menus
   text: string;
   status: 'done' | 'in_progress' | 'carried' | 'planned' | 'dropped';
   source?: string; // e.g. "PR #123", "LIN-456"
@@ -169,31 +170,69 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
 
       // Today's Plans section — always visible when submitted
       if (status.planItems && status.planItems.length > 0) {
-        const planLines: string[] = [];
         for (const item of status.planItems) {
           const sourceTag = item.source ? ` · _${item.source}_` : '';
+          const isActive = item.status === 'planned' || item.status === 'in_progress' || item.status === 'carried';
+
+          let itemText: string;
           switch (item.status) {
             case 'done':
-              planLines.push(`✅ ~${item.text}~${sourceTag}`);
+              itemText = `✅ ~${item.text}~${sourceTag}`;
               break;
             case 'in_progress':
-              planLines.push(`🔄 ${item.text}${sourceTag}`);
+              itemText = `🔄 ${item.text}${sourceTag}`;
               break;
             case 'carried':
-              planLines.push(`➡️ ${item.text} _(carried)_${sourceTag}`);
+              itemText = `➡️ ${item.text} _(carried)_${sourceTag}`;
               break;
             case 'dropped':
-              planLines.push(`❌ ~${item.text}~${sourceTag}`);
+              itemText = `❌ ~${item.text}~${sourceTag}`;
               break;
             default:
-              planLines.push(`🎯 ${item.text}${sourceTag}`);
+              itemText = `🎯 ${item.text}${sourceTag}`;
+          }
+
+          if (isActive && item.id !== undefined) {
+            // Interactive section with overflow menu for status changes
+            blocks.push({
+              type: 'section',
+              text: { type: 'mrkdwn', text: itemText },
+              accessory: {
+                type: 'overflow',
+                action_id: 'task_action',
+                options: [
+                  {
+                    text: { type: 'plain_text', text: '✅ Done', emoji: true },
+                    value: JSON.stringify({ itemId: item.id, dailyName: status.dailyName, action: 'done' }),
+                  },
+                  {
+                    text: { type: 'plain_text', text: '🔄 In Progress', emoji: true },
+                    value: JSON.stringify({ itemId: item.id, dailyName: status.dailyName, action: 'in_progress' }),
+                  },
+                  {
+                    text: { type: 'plain_text', text: '❌ Drop', emoji: true },
+                    value: JSON.stringify({ itemId: item.id, dailyName: status.dailyName, action: 'drop' }),
+                  },
+                ],
+              },
+            });
+          } else {
+            // Terminal state (done/dropped) or legacy item without an id — plain section
+            blocks.push({
+              type: 'section',
+              text: { type: 'mrkdwn', text: itemText },
+            });
           }
         }
+
+        // "Add Item" button at the end of each daily's task list
         blocks.push({
-          type: 'context',
+          type: 'actions',
           elements: [{
-            type: 'mrkdwn',
-            text: planLines.join('\n'),
+            type: 'button',
+            text: { type: 'plain_text', text: '➕ Add Item', emoji: true },
+            action_id: 'task_add',
+            value: status.dailyName,
           }],
         });
       }
@@ -543,27 +582,46 @@ export async function handleAppHomeOpened(
           droppedCount = droppedItems.length;
         }
 
-        // Build plan items list: in-progress, carried, new plans, done yesterday, dropped
+        // Build plan items list from work_items (with IDs for interactivity),
+        // falling back to JSONB arrays for older submissions without work_item records.
         planItems = [];
-        const completed = parseJsonArray(todaySubmission.yesterday_completed);
-        const incomplete = parseJsonArray(todaySubmission.yesterday_incomplete);
-        const inProgress = parseJsonArray(todaySubmission.yesterday_in_progress);
-        const plans = parseJsonArray(todaySubmission.today_plans);
+        const workItems = await getActiveWorkItems(ctx.db, userId, dailyName, todayStr);
 
-        for (const item of inProgress) {
-          planItems.push({ text: item, status: 'in_progress', source: extractSource(item) });
-        }
-        for (const item of incomplete) {
-          planItems.push({ text: item, status: 'carried', source: extractSource(item) });
-        }
-        for (const item of plans) {
-          planItems.push({ text: item, status: 'planned', source: extractSource(item) });
-        }
-        for (const item of completed) {
-          planItems.push({ text: item, status: 'done', source: extractSource(item) });
-        }
-        for (const item of droppedItems) {
-          planItems.push({ text: item, status: 'dropped', source: extractSource(item) });
+        if (workItems.length > 0) {
+          // Primary path: map work_items rows (has IDs for overflow menus)
+          for (const wi of workItems) {
+            let mappedStatus: PlanItem['status'];
+            switch (wi.status) {
+              case 'done':       mappedStatus = 'done';        break;
+              case 'in_progress': mappedStatus = 'in_progress'; break;
+              case 'carried':    mappedStatus = 'carried';     break;
+              case 'dropped':    mappedStatus = 'dropped';     break;
+              default:           mappedStatus = 'planned';     break; // 'pending'
+            }
+            planItems.push({ id: wi.id, text: wi.text, status: mappedStatus, source: extractSource(wi.text) });
+          }
+        } else {
+          // Fallback: parse JSONB arrays (backwards compatibility for submissions without work_item records)
+          const completed = parseJsonArray(todaySubmission.yesterday_completed);
+          const incomplete = parseJsonArray(todaySubmission.yesterday_incomplete);
+          const inProgress = parseJsonArray(todaySubmission.yesterday_in_progress);
+          const plans = parseJsonArray(todaySubmission.today_plans);
+
+          for (const item of inProgress) {
+            planItems.push({ text: item, status: 'in_progress', source: extractSource(item) });
+          }
+          for (const item of incomplete) {
+            planItems.push({ text: item, status: 'carried', source: extractSource(item) });
+          }
+          for (const item of plans) {
+            planItems.push({ text: item, status: 'planned', source: extractSource(item) });
+          }
+          for (const item of completed) {
+            planItems.push({ text: item, status: 'done', source: extractSource(item) });
+          }
+          for (const item of droppedItems) {
+            planItems.push({ text: item, status: 'dropped', source: extractSource(item) });
+          }
         }
       }
 

--- a/lib/handlers/home.ts
+++ b/lib/handlers/home.ts
@@ -225,15 +225,23 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
           }
         }
 
-        // "Add Item" button at the end of each daily's task list
+        // Action buttons at the end of each daily's task list
         blocks.push({
           type: 'actions',
-          elements: [{
-            type: 'button',
-            text: { type: 'plain_text', text: '➕ Add Item', emoji: true },
-            action_id: 'task_add',
-            value: status.dailyName,
-          }],
+          elements: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '➕ Add Item', emoji: true },
+              action_id: 'task_add',
+              value: status.dailyName,
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '✏️ Edit Standup', emoji: true },
+              action_id: 'home_edit_standup',
+              value: status.dailyName,
+            },
+          ],
         });
       }
     }

--- a/lib/handlers/home.ts
+++ b/lib/handlers/home.ts
@@ -31,12 +31,19 @@ export interface AppHomeOpenedEvent {
 // Home View Builder
 // ============================================================================
 
+interface PlanItem {
+  text: string;
+  status: 'done' | 'in_progress' | 'carried' | 'planned' | 'dropped';
+  source?: string; // e.g. "PR #123", "LIN-456"
+}
+
 interface DailyStatus {
   dailyName: string;
   todaySubmitted: boolean;
   tomorrowScheduled: boolean;
   submission?: Submission; // Today's submission for stats
   droppedCount?: number; // Items dropped from yesterday
+  planItems?: PlanItem[]; // Today's plan items with status
   prData?: UserPRData; // GitHub PR data if integration enabled
   linearData?: UserLinearData; // Linear data if integration enabled
 }
@@ -155,6 +162,37 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
           value: status.dailyName,
         },
       });
+
+      // Today's Plans section — always visible when submitted
+      if (status.planItems && status.planItems.length > 0) {
+        const planLines: string[] = [];
+        for (const item of status.planItems) {
+          const sourceTag = item.source ? ` · _${item.source}_` : '';
+          switch (item.status) {
+            case 'done':
+              planLines.push(`✅ ~${item.text}~${sourceTag}`);
+              break;
+            case 'in_progress':
+              planLines.push(`🔄 ${item.text}${sourceTag}`);
+              break;
+            case 'carried':
+              planLines.push(`➡️ ${item.text} _(carried)_${sourceTag}`);
+              break;
+            case 'dropped':
+              planLines.push(`❌ ~${item.text}~${sourceTag}`);
+              break;
+            default:
+              planLines.push(`⬜ ${item.text}${sourceTag}`);
+          }
+        }
+        blocks.push({
+          type: 'context',
+          elements: [{
+            type: 'mrkdwn',
+            text: planLines.join('\n'),
+          }],
+        });
+      }
     }
   }
 
@@ -245,7 +283,7 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*DM standup copy*\n${dmStatus} — get a private copy of your standup when it posts to the channel`,
+        text: `*DM standup copy*\n${dmStatus} — your plan is shown above; enable this for an extra DM copy`,
       },
       accessory: {
         type: 'button',
@@ -272,6 +310,12 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
     type: 'home',
     blocks,
   };
+}
+
+/** Extract source context from a plan item text (e.g., "[LIN-123] ..." → "LIN-123", "[repo#45] ..." → "repo#45") */
+function extractSource(text: string): string | undefined {
+  const match = text.match(/^\[([^\]]+)\]\s/);
+  return match ? match[1] : undefined;
 }
 
 /** Parse JSONB arrays from database (handles both array and string formats) */
@@ -385,10 +429,14 @@ export async function handleAppHomeOpened(
         }
       }
 
-      // Compute dropped count from previous submission
+      // Build plan items and compute dropped count from previous submission
       let droppedCount: number | undefined;
+      let planItems: PlanItem[] | undefined;
       if (todaySubmission) {
         const prevSubmission = await getPreviousSubmission(ctx.db, userId, dailyName, todayStr);
+
+        // Build dropped set from previous submission
+        const droppedItems: string[] = [];
         if (prevSubmission) {
           const prevPlans = new Set([
             ...parseJsonArray(prevSubmission.today_plans),
@@ -400,7 +448,33 @@ export async function handleAppHomeOpened(
             ...parseJsonArray(todaySubmission.yesterday_incomplete),
             ...parseJsonArray(todaySubmission.yesterday_in_progress),
           ]);
-          droppedCount = [...prevPlans].filter(item => !accountedFor.has(item)).length;
+          for (const item of prevPlans) {
+            if (!accountedFor.has(item)) droppedItems.push(item);
+          }
+          droppedCount = droppedItems.length;
+        }
+
+        // Build plan items list: in-progress, carried, new plans, done yesterday, dropped
+        planItems = [];
+        const completed = parseJsonArray(todaySubmission.yesterday_completed);
+        const incomplete = parseJsonArray(todaySubmission.yesterday_incomplete);
+        const inProgress = parseJsonArray(todaySubmission.yesterday_in_progress);
+        const plans = parseJsonArray(todaySubmission.today_plans);
+
+        for (const item of inProgress) {
+          planItems.push({ text: item, status: 'in_progress', source: extractSource(item) });
+        }
+        for (const item of incomplete) {
+          planItems.push({ text: item, status: 'carried', source: extractSource(item) });
+        }
+        for (const item of plans) {
+          planItems.push({ text: item, status: 'planned', source: extractSource(item) });
+        }
+        for (const item of completed) {
+          planItems.push({ text: item, status: 'done', source: extractSource(item) });
+        }
+        for (const item of droppedItems) {
+          planItems.push({ text: item, status: 'dropped', source: extractSource(item) });
         }
       }
 
@@ -410,6 +484,7 @@ export async function handleAppHomeOpened(
         tomorrowScheduled,
         submission: todaySubmission || undefined,
         droppedCount,
+        planItems,
         prData,
         linearData,
       });

--- a/lib/handlers/home.ts
+++ b/lib/handlers/home.ts
@@ -3,7 +3,7 @@
  * Shows user's dailies with "Start Daily" buttons
  */
 
-import { DbClient, getUserDailies, getSubmissionForDate, getPreviousSubmission, Submission, getGitHubUsername, getLinearUserId, setGitHubUsername, setLinearUserId, getDmStandupPreference } from '../db';
+import { DbClient, getUserDailies, getSubmissionForDate, getPreviousSubmission, Submission, getGitHubUsername, getLinearUserId, setGitHubUsername, setLinearUserId, getDmStandupPreference, getUserSettings, getActiveOOO } from '../db';
 import { getDaily, getGitHubConfig, getGitHubUsernameFromConfig, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser } from '../config';
 import { publishHomeView } from '../slack';
 import { formatDate, getUserDate, getUserTimezone } from '../prompt';
@@ -49,9 +49,13 @@ interface DailyStatus {
 }
 
 export interface LinkedAccounts {
-  github: string | null;  // username or null
-  linear: string | null;  // user ID or null
-  dmStandup: boolean;     // whether DM standup copies are enabled
+  github: string | null;
+  linear: string | null;
+  dmStandup: boolean;
+  maxItems: number | null;
+  stalePrDays: number | null;
+  linearTeamFilter: string[] | null;
+  oooStatus?: { startDate: string; endDate: string } | null;
 }
 
 /**
@@ -267,17 +271,55 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
       });
     }
 
-    // DM preferences
+    // Settings section
     blocks.push({
       type: 'header',
       text: {
         type: 'plain_text',
-        text: '⚙️ Preferences',
+        text: '⚙️ Settings',
         emoji: true,
       },
     });
 
-    const dmStatus = linkedAccounts.dmStandup ? '✅ Enabled' : '❌ Disabled';
+    // OOO management
+    if (linkedAccounts.oooStatus) {
+      const formatShort = (d: string) => {
+        const date = new Date(d + 'T00:00:00');
+        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      };
+      const rangeText = linkedAccounts.oooStatus.startDate === linkedAccounts.oooStatus.endDate
+        ? formatShort(linkedAccounts.oooStatus.startDate)
+        : `${formatShort(linkedAccounts.oooStatus.startDate)} – ${formatShort(linkedAccounts.oooStatus.endDate)}`;
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Out of Office*\n🏖️ ${rangeText}`,
+        },
+        accessory: {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Clear OOO', emoji: true },
+          action_id: 'home_clear_ooo',
+          style: 'danger',
+        },
+      });
+    } else {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '*Out of Office*\nNot set',
+        },
+        accessory: {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Set OOO', emoji: true },
+          action_id: 'home_set_ooo',
+        },
+      });
+    }
+
+    // DM standup copy
+    const dmStatus = linkedAccounts.dmStandup ? '✅ On' : '❌ Off';
     const dmButtonText = linkedAccounts.dmStandup ? 'Disable' : 'Enable';
     blocks.push({
       type: 'section',
@@ -289,6 +331,53 @@ export function buildHomeView(dailyStatuses: DailyStatus[], linkedAccounts?: Lin
         type: 'button',
         text: { type: 'plain_text', text: dmButtonText, emoji: true },
         action_id: 'home_toggle_dm_standup',
+      },
+    });
+
+    // Max items per list
+    const maxItemsLabel = linkedAccounts.maxItems ? `${linkedAccounts.maxItems} items` : 'No limit';
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Max items per list*\n${maxItemsLabel} — PRs and Linear tickets shown in modal and post`,
+      },
+      accessory: {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Change', emoji: true },
+        action_id: 'home_set_max_items',
+      },
+    });
+
+    // Stale PR threshold
+    const stalePrLabel = linkedAccounts.stalePrDays ? `${linkedAccounts.stalePrDays} days` : '3 days (default)';
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Stale PR threshold*\n${stalePrLabel} — reviews older than this are flagged`,
+      },
+      accessory: {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Change', emoji: true },
+        action_id: 'home_set_stale_pr_days',
+      },
+    });
+
+    // Linear team filter
+    const linearFilterLabel = linkedAccounts.linearTeamFilter
+      ? linkedAccounts.linearTeamFilter.join(', ')
+      : 'All teams';
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Linear teams*\n${linearFilterLabel} — which teams' cycles to include`,
+      },
+      accessory: {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Change', emoji: true },
+        action_id: 'home_set_linear_teams',
       },
     });
 
@@ -490,16 +579,30 @@ export async function handleAppHomeOpened(
       });
     }
 
-    // Fetch linked accounts and preferences
-    const [githubUsername, linearUserId, dmStandup] = await Promise.all([
+    // Fetch linked accounts, preferences, and OOO status
+    const [githubUsername, linearUserId, settings] = await Promise.all([
       getGitHubUsername(ctx.db, userId),
       getLinearUserId(ctx.db, userId),
-      getDmStandupPreference(ctx.db, userId),
+      getUserSettings(ctx.db, userId),
     ]);
+
+    // Check OOO for the first daily (shows earliest active OOO)
+    let oooStatus: { startDate: string; endDate: string } | null = null;
+    if (userDailies.length > 0) {
+      const ooo = await getActiveOOO(ctx.db, userId, userDailies[0].daily_name, todayStr);
+      if (ooo) {
+        oooStatus = { startDate: ooo.start_date, endDate: ooo.end_date };
+      }
+    }
+
     const linkedAccounts: LinkedAccounts = {
       github: githubUsername,
       linear: linearUserId,
-      dmStandup,
+      dmStandup: settings.dmStandup,
+      maxItems: settings.maxItems,
+      stalePrDays: settings.stalePrDays,
+      linearTeamFilter: settings.linearTeamFilter,
+      oooStatus,
     };
 
     // Build and publish the home view

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -591,7 +591,8 @@ export async function handleStandupSubmission(
   // Queue if: tomorrow mode OR today mode but before scheduled posting time
   const scheduledTime = scheduleConfig?.default_time || '10:00';
   const isBeforeScheduledTime = !hasScheduledTimePassed(scheduledTime, userDate);
-  const shouldQueue = isTomorrowMode || isBeforeScheduledTime;
+  const devMode = ctx.env?.DEV_MODE === 'true';
+  const shouldQueue = isTomorrowMode || (!devMode && isBeforeScheduledTime);
 
   // Run the heavy work (DB saves, API calls) in the background so Slack
   // gets an immediate 200 response and doesn't show "trouble connecting".

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -26,6 +26,10 @@ import {
   getRecentlyDoneLinearItems,
   getDmStandupPreference,
   setDmStandupPreference,
+  updateUserSetting,
+  getUserDailies,
+  setOOO,
+  clearOOO,
 } from '../db';
 import { handleAppHomeOpened, AppHomeOpenedEvent, HomeContext } from './home';
 import { fetchUserPRData, UserPRData } from '../github';
@@ -69,7 +73,8 @@ export interface InteractionPayload {
       values: Record<string, Record<string, {
         value?: string;
         selected_option?: { value: string };
-        selected_options?: Array<{ value: string }>;
+        selected_options?: Array<{ value: string; text?: { type: string; text: string } }>;
+        selected_date?: string;
         rich_text_value?: RichTextBlock;  // Slack uses rich_text_value, not rich_text
       }>>;
     };
@@ -1016,6 +1021,201 @@ export async function handleToggleDmStandup(
 }
 
 // ============================================================================
+// Settings Handlers
+// ============================================================================
+
+async function handleSetOOO(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const view = {
+    type: 'modal',
+    callback_id: 'ooo_set_submission',
+    title: { type: 'plain_text', text: 'Set Out of Office' },
+    submit: { type: 'plain_text', text: 'Set OOO' },
+    blocks: [
+      {
+        type: 'input',
+        block_id: 'ooo_start',
+        element: { type: 'datepicker', action_id: 'start_date' },
+        label: { type: 'plain_text', text: 'Start date' },
+      },
+      {
+        type: 'input',
+        block_id: 'ooo_end',
+        element: { type: 'datepicker', action_id: 'end_date' },
+        label: { type: 'plain_text', text: 'End date' },
+      },
+    ],
+  };
+
+  return openModal(ctx.slackToken, payload.trigger_id, view);
+}
+
+async function handleClearOOO(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const userId = payload.user.id;
+  try {
+    const dailies = await getUserDailies(ctx.db, userId);
+    for (const d of dailies) {
+      await clearOOO(ctx.db, userId, d.daily_name);
+    }
+    await refreshHome(userId, ctx);
+    return true;
+  } catch (error) {
+    console.error('Failed to clear OOO:', error);
+    return false;
+  }
+}
+
+async function handleOOOSetSubmission(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<InteractionResult> {
+  const userId = payload.user.id;
+  const values = payload.view?.state?.values;
+  const startDate = values?.ooo_start?.start_date?.selected_date;
+  const endDate = values?.ooo_end?.end_date?.selected_date;
+
+  if (!startDate || !endDate) {
+    return { response_action: 'errors', errors: { ooo_start: 'Please select both dates' } };
+  }
+  if (endDate < startDate) {
+    return { response_action: 'errors', errors: { ooo_end: 'End date must be on or after start date' } };
+  }
+
+  try {
+    const dailies = await getUserDailies(ctx.db, userId);
+    for (const d of dailies) {
+      await setOOO(ctx.db, userId, d.daily_name, startDate, endDate);
+    }
+    await refreshHome(userId, ctx);
+    return true;
+  } catch (error) {
+    console.error('Failed to set OOO:', error);
+    return false;
+  }
+}
+
+async function handleSetMaxItems(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const view = {
+    type: 'modal',
+    callback_id: 'settings_max_items',
+    title: { type: 'plain_text', text: 'Max Items Per List' },
+    submit: { type: 'plain_text', text: 'Save' },
+    blocks: [
+      {
+        type: 'input',
+        block_id: 'max_items',
+        element: {
+          type: 'static_select',
+          action_id: 'value',
+          placeholder: { type: 'plain_text', text: 'Select limit' },
+          options: [
+            { text: { type: 'plain_text', text: 'No limit' }, value: '0' },
+            { text: { type: 'plain_text', text: '3 items' }, value: '3' },
+            { text: { type: 'plain_text', text: '5 items' }, value: '5' },
+            { text: { type: 'plain_text', text: '10 items' }, value: '10' },
+          ],
+        },
+        label: { type: 'plain_text', text: 'Max PRs and Linear tickets shown' },
+      },
+    ],
+  };
+  return openModal(ctx.slackToken, payload.trigger_id, view);
+}
+
+async function handleSetStalePrDays(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const view = {
+    type: 'modal',
+    callback_id: 'settings_stale_pr_days',
+    title: { type: 'plain_text', text: 'Stale PR Threshold' },
+    submit: { type: 'plain_text', text: 'Save' },
+    blocks: [
+      {
+        type: 'input',
+        block_id: 'stale_pr_days',
+        element: {
+          type: 'static_select',
+          action_id: 'value',
+          placeholder: { type: 'plain_text', text: 'Select threshold' },
+          options: [
+            { text: { type: 'plain_text', text: '1 day' }, value: '1' },
+            { text: { type: 'plain_text', text: '2 days' }, value: '2' },
+            { text: { type: 'plain_text', text: '3 days (default)' }, value: '3' },
+            { text: { type: 'plain_text', text: '5 days' }, value: '5' },
+            { text: { type: 'plain_text', text: '7 days' }, value: '7' },
+          ],
+        },
+        label: { type: 'plain_text', text: 'Flag reviews older than' },
+      },
+    ],
+  };
+  return openModal(ctx.slackToken, payload.trigger_id, view);
+}
+
+async function handleSetLinearTeams(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const view = {
+    type: 'modal',
+    callback_id: 'settings_linear_teams',
+    title: { type: 'plain_text', text: 'Linear Team Filter' },
+    submit: { type: 'plain_text', text: 'Save' },
+    blocks: [
+      {
+        type: 'input',
+        block_id: 'linear_teams',
+        optional: true,
+        element: {
+          type: 'plain_text_input',
+          action_id: 'value',
+          placeholder: { type: 'plain_text', text: 'e.g. ENG,PLATFORM (leave empty for all)' },
+        },
+        label: { type: 'plain_text', text: 'Linear team IDs (comma-separated)' },
+      },
+    ],
+  };
+  return openModal(ctx.slackToken, payload.trigger_id, view);
+}
+
+async function handleSettingsSubmission(
+  payload: InteractionPayload,
+  ctx: InteractionContext,
+  callbackId: string
+): Promise<InteractionResult> {
+  const userId = payload.user.id;
+  const values = payload.view?.state?.values;
+
+  try {
+    if (callbackId === 'settings_max_items') {
+      const val = parseInt(values?.max_items?.value?.selected_option?.value || '0', 10);
+      await updateUserSetting(ctx.db, userId, 'max_items', val === 0 ? null : val);
+    } else if (callbackId === 'settings_stale_pr_days') {
+      const val = parseInt(values?.stale_pr_days?.value?.selected_option?.value || '3', 10);
+      await updateUserSetting(ctx.db, userId, 'stale_pr_days', val === 3 ? null : val);
+    } else if (callbackId === 'settings_linear_teams') {
+      const val = values?.linear_teams?.value?.value?.trim() || '';
+      await updateUserSetting(ctx.db, userId, 'linear_team_filter', val || null);
+    }
+    await refreshHome(userId, ctx);
+    return true;
+  } catch (error) {
+    console.error(`Failed to save setting ${callbackId}:`, error);
+    return false;
+  }
+}
+
+// ============================================================================
 // Main Router
 // ============================================================================
 
@@ -1057,6 +1257,11 @@ export async function handleInteraction(
     if (actionId === 'home_unlink_github') return handleUnlinkGitHub(payload, ctx);
     if (actionId === 'home_unlink_linear') return handleUnlinkLinear(payload, ctx);
     if (actionId === 'home_toggle_dm_standup') return handleToggleDmStandup(payload, ctx);
+    if (actionId === 'home_set_ooo') return handleSetOOO(payload, ctx);
+    if (actionId === 'home_clear_ooo') return handleClearOOO(payload, ctx);
+    if (actionId === 'home_set_max_items') return handleSetMaxItems(payload, ctx);
+    if (actionId === 'home_set_stale_pr_days') return handleSetStalePrDays(payload, ctx);
+    if (actionId === 'home_set_linear_teams') return handleSetLinearTeams(payload, ctx);
   }
 
   // Handle modal submission
@@ -1070,6 +1275,19 @@ export async function handleInteraction(
   }
   if (payload.type === 'view_submission' && payload.view?.callback_id === 'linear_link_submission') {
     return handleLinearLinkSubmission(payload, ctx);
+  }
+
+  // Handle OOO set submission
+  if (payload.type === 'view_submission' && payload.view?.callback_id === 'ooo_set_submission') {
+    return handleOOOSetSubmission(payload, ctx);
+  }
+
+  // Handle settings modal submissions
+  if (payload.type === 'view_submission') {
+    const callbackId = payload.view?.callback_id || '';
+    if (callbackId.startsWith('settings_')) {
+      return handleSettingsSubmission(payload, ctx, callbackId);
+    }
   }
 
   // Unknown interaction type

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -643,6 +643,13 @@ export async function handleStandupSubmission(
         console.error('Failed to send standup DM copy:', error);
       }
     }
+
+    // Refresh App Home so user sees their plan immediately
+    try {
+      await refreshHome(userId, ctx);
+    } catch (error) {
+      console.error('Failed to refresh App Home after submission:', error);
+    }
   };
 
   // Use waitUntil for background processing if available (Cloudflare Workers),

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -33,14 +33,17 @@ import {
   getParticipants,
   setOOO,
   clearOOO,
+  updateWorkItemStatus,
+  addWorkItem,
+  updateSubmissionArrays,
 } from '../db';
 import { handleAppHomeOpened, AppHomeOpenedEvent, HomeContext } from './home';
 import { fetchUserPRData, UserPRData } from '../github';
 import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue, UserLinearData, extractLinearReferences, fetchWorkflowStates, markIssuesInProgress as markLinearIssuesInProgress, commentOnIssue, resolveIdentifiers } from '../linear';
-import { postStandupToChannel, sendStandupDM } from '../format';
+import { postStandupToChannel, sendStandupDM, formatStandupBlocks, StandupData } from '../format';
 import { buildStandupModal, YesterdayData, SubmissionPrefill } from '../modal';
 import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed, sendPromptDM } from '../prompt';
-import { openModal, parseRichText, RichTextBlock, sendDM } from '../slack';
+import { openModal, parseRichText, RichTextBlock, sendDM, updateMessage } from '../slack';
 import { StandupMode } from '../modal';
 
 // ============================================================================
@@ -68,7 +71,7 @@ export interface InteractionPayload {
   type: string;
   trigger_id: string;
   user: { id: string };
-  actions?: Array<{ action_id: string; value: string }>;
+  actions?: Array<{ action_id: string; value: string; selected_option?: { value: string } }>;
   view?: {
     callback_id: string;
     private_metadata: string;
@@ -1321,6 +1324,220 @@ async function handleSettingsSubmission(
 }
 
 // ============================================================================
+// Phase 4: Standup Post Sync
+// ============================================================================
+
+/** Parse JSONB arrays (handles both array and string formats) */
+function parseJsonArray(value: string[] | null): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  try {
+    return JSON.parse(value as unknown as string);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Rebuild and update the standup post in the channel after an App Home mutation.
+ * No-ops if the submission doesn't exist, hasn't been posted, or has no message ts.
+ */
+async function syncStandupPost(
+  db: DbClient,
+  slackToken: string,
+  userId: string,
+  dailyName: string,
+  date: string
+): Promise<void> {
+  const submission = await getSubmissionForDate(db, userId, dailyName, date);
+  if (!submission || !submission.posted || !submission.slack_message_ts) return;
+
+  const daily = getDaily(dailyName);
+  if (!daily || !daily.channel) return;
+
+  // Fetch carry counts for in-progress items (for "Day X" annotations)
+  const inProgressItems = parseJsonArray(submission.yesterday_in_progress);
+  let inProgressCarryCounts: Record<string, number> | undefined;
+  if (inProgressItems.length > 0) {
+    try {
+      inProgressCarryCounts = await getInProgressCarryCounts(db, userId, dailyName, inProgressItems);
+    } catch (error) {
+      console.error('Failed to get in-progress carry counts for sync:', error);
+    }
+  }
+
+  const githubOrg = getGitHubConfig(daily)?.org;
+
+  const data: StandupData = {
+    yesterdayCompleted: parseJsonArray(submission.yesterday_completed),
+    yesterdayIncomplete: parseJsonArray(submission.yesterday_incomplete),
+    yesterdayInProgress: inProgressItems,
+    yesterdayDropped: [], // dropped items aren't tracked on the submission record
+    unplanned: parseJsonArray(submission.unplanned),
+    todayPlans: parseJsonArray(submission.today_plans),
+    blockers: submission.blockers || '',
+    customAnswers: submission.custom_answers || {},
+    questions: daily.questions,
+    fieldOrder: daily.field_order,
+    inProgressCarryCounts,
+    githubOrg,
+  };
+
+  const blocks = formatStandupBlocks(userId, dailyName, data);
+  const fallbackText = `*<@${userId}>* submitted their standup`;
+
+  await updateMessage(slackToken, daily.channel, submission.slack_message_ts, fallbackText, blocks);
+}
+
+// ============================================================================
+// Phase 3: App Home Task Action Handlers
+// ============================================================================
+
+/**
+ * Handle overflow menu selection on a task item (done / in_progress / drop)
+ * action_id: "task_action", value JSON: { itemId, dailyName, action }
+ */
+async function handleTaskAction(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const selectedValue = payload.actions?.[0]?.selected_option?.value;
+  if (!selectedValue) {
+    console.error('No selected_option value in task_action');
+    return false;
+  }
+
+  let parsed: { itemId: number; dailyName: string; action: string };
+  try {
+    parsed = JSON.parse(selectedValue);
+  } catch {
+    console.error('Failed to parse task_action value:', selectedValue);
+    return false;
+  }
+
+  const { itemId, dailyName, action } = parsed;
+  const userId = payload.user.id;
+
+  // Map "drop" → "dropped" for DB; others pass through
+  const dbStatus = action === 'drop' ? 'dropped' : action as 'done' | 'in_progress';
+
+  const userInfo = await getUserTimezone(ctx.slackToken, userId);
+  const tzOffset = userInfo?.tz_offset || 0;
+  const todayStr = formatDate(getUserDate(tzOffset));
+
+  await updateWorkItemStatus(ctx.db, itemId, dbStatus, dbStatus === 'done' ? todayStr : undefined);
+
+  const submission = await getSubmissionForDate(ctx.db, userId, dailyName, todayStr);
+  if (submission) {
+    await updateSubmissionArrays(ctx.db, submission.id, userId, dailyName, todayStr);
+  }
+
+  await refreshHome(userId, ctx);
+
+  if (submission) {
+    const syncPromise = syncStandupPost(ctx.db, ctx.slackToken, userId, dailyName, todayStr)
+      .catch(err => console.error('syncStandupPost failed:', err));
+    ctx.waitUntil?.(syncPromise);
+  }
+
+  return true;
+}
+
+/**
+ * Handle "Add Item" button click from App Home task list
+ * action_id: "task_add", value: dailyName
+ */
+async function handleTaskAdd(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const dailyName = payload.actions?.[0]?.value;
+  if (!dailyName) {
+    console.error('No dailyName in task_add action');
+    return false;
+  }
+
+  const userId = payload.user.id;
+  const triggerId = payload.trigger_id;
+
+  const userInfo = await getUserTimezone(ctx.slackToken, userId);
+  const tzOffset = userInfo?.tz_offset || 0;
+  const todayStr = formatDate(getUserDate(tzOffset));
+
+  const submission = await getSubmissionForDate(ctx.db, userId, dailyName, todayStr);
+  if (!submission) {
+    await sendDM(
+      ctx.slackToken,
+      userId,
+      `You need to submit your *${dailyName}* standup first before adding items.`
+    );
+    return true;
+  }
+
+  const modal = {
+    type: 'modal',
+    callback_id: 'task_add_submission',
+    title: { type: 'plain_text', text: 'Add Item' },
+    submit: { type: 'plain_text', text: 'Add' },
+    private_metadata: JSON.stringify({ dailyName, date: todayStr, submissionId: submission.id }),
+    blocks: [
+      {
+        type: 'input',
+        block_id: 'task_text',
+        label: { type: 'plain_text', text: 'Item' },
+        element: {
+          type: 'plain_text_input',
+          action_id: 'task_text_input',
+          placeholder: { type: 'plain_text', text: 'What are you adding?' },
+          multiline: false,
+        },
+      },
+    ],
+  };
+
+  return openModal(ctx.slackToken, triggerId, modal);
+}
+
+/**
+ * Handle "Add Item" modal submission
+ * callback_id: "task_add_submission"
+ */
+async function handleTaskAddSubmission(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<InteractionResult> {
+  const userId = payload.user.id;
+
+  let metadata: { dailyName: string; date: string; submissionId: number };
+  try {
+    metadata = JSON.parse(payload.view!.private_metadata);
+  } catch {
+    console.error('Failed to parse task_add_submission metadata');
+    return false;
+  }
+
+  const { dailyName, date, submissionId } = metadata;
+
+  const text = payload.view!.state.values.task_text?.task_text_input?.value?.trim();
+  if (!text) {
+    return {
+      response_action: 'errors',
+      errors: { task_text: 'Please enter an item' },
+    };
+  }
+
+  await addWorkItem(ctx.db, userId, dailyName, text, date, submissionId);
+  await updateSubmissionArrays(ctx.db, submissionId, userId, dailyName, date);
+  await refreshHome(userId, ctx);
+
+  const syncPromise = syncStandupPost(ctx.db, ctx.slackToken, userId, dailyName, date)
+    .catch(err => console.error('syncStandupPost failed:', err));
+  ctx.waitUntil?.(syncPromise);
+
+  return true;
+}
+
+// ============================================================================
 // Main Router
 // ============================================================================
 
@@ -1367,6 +1584,13 @@ export async function handleInteraction(
     if (actionId === 'home_set_max_items') return handleSetMaxItems(payload, ctx);
     if (actionId === 'home_set_stale_pr_days') return handleSetStalePrDays(payload, ctx);
     if (actionId === 'home_set_linear_teams') return handleSetLinearTeams(payload, ctx);
+    if (actionId === 'task_action') return handleTaskAction(payload, ctx);
+    if (actionId === 'task_add') return handleTaskAdd(payload, ctx);
+  }
+
+  // Handle task_add modal submission
+  if (payload.type === 'view_submission' && payload.view?.callback_id === 'task_add_submission') {
+    return handleTaskAddSubmission(payload, ctx);
   }
 
   // Handle modal submission

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -43,7 +43,7 @@ import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue, UserLinearDa
 import { postStandupToChannel, sendStandupDM, formatStandupBlocks, StandupData } from '../format';
 import { buildStandupModal, YesterdayData, SubmissionPrefill } from '../modal';
 import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed, sendPromptDM } from '../prompt';
-import { openModal, parseRichText, RichTextBlock, sendDM, updateMessage, extractMentionedUserIds } from '../slack';
+import { openModal, parseRichText, RichTextBlock, sendDM, updateMessage, extractMentionedUserIds, updateModal } from '../slack';
 import { StandupMode } from '../modal';
 
 // ============================================================================
@@ -73,6 +73,8 @@ export interface InteractionPayload {
   user: { id: string };
   actions?: Array<{ action_id: string; value: string; selected_option?: { value: string } }>;
   view?: {
+    id?: string;
+    hash?: string;
     callback_id: string;
     private_metadata: string;
     state: {
@@ -1783,6 +1785,12 @@ export async function handleInteraction(
     return handleHomeStartDaily(payload, ctx);
   }
 
+  // Handle "Show all" expand buttons in standup modal
+  if (payload.type === 'block_actions') {
+    const actionId = payload.actions?.[0]?.action_id;
+    if (actionId?.startsWith('show_all_')) return handleShowAllInModal(payload, ctx);
+  }
+
   // Handle link/unlink account buttons from App Home
   if (payload.type === 'block_actions') {
     const actionId = payload.actions?.[0]?.action_id;
@@ -1838,6 +1846,66 @@ export async function handleInteraction(
   }
 
   // Unknown interaction type
+  return true;
+}
+
+async function handleShowAllInModal(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const actionId = payload.actions?.[0]?.action_id;
+  if (!actionId || !payload.view?.id) return false;
+
+  const sectionMap: Record<string, string> = {
+    show_all_linear: 'linear',
+    show_all_reviews: 'reviews',
+    show_all_my_prs: 'my_prs',
+  };
+  const section = sectionMap[actionId];
+  if (!section) return false;
+
+  let metadata: { dailyName: string; yesterdayPlans?: string[]; mode?: string; targetDate?: string; sections?: { blockers: boolean; unplanned: boolean } };
+  try {
+    metadata = JSON.parse(payload.view.private_metadata);
+  } catch {
+    return false;
+  }
+
+  const userId = payload.user.id;
+  const daily = getDaily(metadata.dailyName);
+  if (!daily) return false;
+
+  // Re-fetch integration data (same as modal open)
+  const [{ prData, reviewerMap }, linearResult] = await Promise.all([
+    fetchGitHubPRsForUser(daily, userId, ctx),
+    fetchLinearIssuesForUser(daily, userId, ctx),
+  ]);
+
+  const userInfo = await getUserTimezone(ctx.slackToken, userId);
+  const tzOffset = userInfo?.tz_offset || 0;
+  const userDate = getUserDate(tzOffset);
+
+  const expandedSections = new Set([section]);
+
+  const modal = buildStandupModal(
+    metadata.dailyName,
+    null,
+    daily.questions || [],
+    daily.field_order,
+    userDate,
+    (metadata.mode as StandupMode) || 'today',
+    undefined,
+    linearResult.issues,
+    prData,
+    reviewerMap,
+    undefined,
+    undefined,
+    undefined,
+    metadata.sections || getDailySections(daily),
+    expandedSections,
+  );
+
+  await updateModal(ctx.slackToken, payload.view.id, modal);
   return true;
 }
 

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -34,7 +34,7 @@ import {
 } from '../db';
 import { handleAppHomeOpened, AppHomeOpenedEvent, HomeContext } from './home';
 import { fetchUserPRData, UserPRData } from '../github';
-import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue, UserLinearData } from '../linear';
+import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue, UserLinearData, extractLinearReferences, fetchWorkflowStates, markIssuesInProgress as markLinearIssuesInProgress, commentOnIssue, resolveIdentifiers } from '../linear';
 import { postStandupToChannel, sendStandupDM } from '../format';
 import { buildStandupModal, YesterdayData, SubmissionPrefill } from '../modal';
 import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed, sendPromptDM } from '../prompt';
@@ -588,6 +588,42 @@ export async function handleStandupSubmission(
     } catch (error) {
       // Don't fail the submission if work item tracking fails
       console.error('Failed to track work items:', error);
+    }
+
+    // Mark selected Linear tickets as "In Progress" and comment blockers
+    try {
+      const linearConfig = daily ? getLinearConfig(daily) : null;
+      const linearToken = linearConfig && ctx.env ? ctx.env[linearConfig.tokenEnvVar] : undefined;
+      if (linearToken) {
+        if (linearSelections && linearSelections.length > 0) {
+          const teamId = daily ? getLinearTeamIdForUser(daily, userId) : undefined;
+          if (teamId) {
+            const states = await fetchWorkflowStates(linearToken, teamId);
+            const startedState = states.get('started');
+            if (startedState) {
+              const identifiers = linearSelections.map(opt => opt.value);
+              const idMap = await resolveIdentifiers(linearToken, identifiers);
+              const issueIds = [...idMap.values()];
+              if (issueIds.length > 0) {
+                const result = await markLinearIssuesInProgress(linearToken, issueIds, startedState.id);
+                console.log(`Linear: marked ${result.updated} issues in-progress, ${result.skipped} skipped`);
+              }
+            }
+          }
+        }
+
+        if (blockers) {
+          const refs = extractLinearReferences(blockers);
+          if (refs.length > 0) {
+            const idMap = await resolveIdentifiers(linearToken, refs);
+            for (const [, issueId] of idMap) {
+              await commentOnIssue(linearToken, issueId, `🚧 Blocker reported in standup by <@${userId}>:\n\n${blockers}`);
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Failed to process Linear actions:', error);
     }
 
     // Get carry counts for in-progress items (for attention warnings)

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -43,7 +43,7 @@ import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue, UserLinearDa
 import { postStandupToChannel, sendStandupDM, formatStandupBlocks, StandupData } from '../format';
 import { buildStandupModal, YesterdayData, SubmissionPrefill } from '../modal';
 import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed, sendPromptDM } from '../prompt';
-import { openModal, parseRichText, RichTextBlock, sendDM, updateMessage } from '../slack';
+import { openModal, parseRichText, RichTextBlock, sendDM, updateMessage, extractMentionedUserIds } from '../slack';
 import { StandupMode } from '../modal';
 
 // ============================================================================
@@ -742,6 +742,24 @@ export async function handleStandupSubmission(
       }
     } catch (error) {
       console.error('Failed to process Linear actions:', error);
+    }
+
+    // Blocker @-mention DMs: notify mentioned participants
+    if (blockers) {
+      try {
+        const mentionedIds = extractMentionedUserIds(blockers);
+        if (mentionedIds.length > 0) {
+          const participants = await getParticipants(ctx.db, dailyName);
+          const participantIds = new Set(participants.map(p => p.slack_user_id));
+          for (const mentionedId of mentionedIds) {
+            if (mentionedId === userId) continue;
+            if (!participantIds.has(mentionedId)) continue;
+            await sendDM(ctx.slackToken, mentionedId, `🚧 <@${userId}> flagged you in a blocker:\n\n_${blockers}_`);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to send blocker mention DMs:', error);
+      }
     }
 
     // Get carry counts for in-progress items (for attention warnings)

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -513,12 +513,15 @@ export async function handleStandupSubmission(
     // Plan-size soft warning: send a DM if the submitted plan count exceeds the threshold.
     // Counts everything that lands in today's plans: typed items + checked integrations
     // (already merged into todayPlans) + yesterday's carry-over + in-progress.
-    const maxPlanItems = getMaxPlanItems();
+    const maxPlanItems = getMaxPlanItems(dailyName);
     if (maxPlanItems > 0) {
-      const submittedPlanCount = todayPlans.length + yesterdayIncomplete.length + yesterdayInProgress.length;
+      const newPlanCount = todayPlans.length;
+      const carriedCount = yesterdayIncomplete.length + yesterdayInProgress.length;
+      const submittedPlanCount = newPlanCount + carriedCount;
       if (submittedPlanCount >= maxPlanItems) {
         const dayWord = isTomorrowMode ? 'for tomorrow' : 'today';
-        const warningMsg = `⚠️ You're planning ${submittedPlanCount} items ${dayWord}. Teams usually stay under ${maxPlanItems} to keep the day focused.`;
+        const breakdown = carriedCount > 0 ? ` (${newPlanCount} new + ${carriedCount} carried)` : '';
+        const warningMsg = `⚠️ You're planning ${submittedPlanCount} items${breakdown} ${dayWord}. Teams usually stay under ${maxPlanItems} to keep the day focused.`;
         try {
           await sendDM(ctx.slackToken, userId, warningMsg);
         } catch (error) {

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -775,10 +775,7 @@ export async function handleStandupSubmission(
       }
     }
 
-    // Post to channel
-    // NOTE: We do NOT re-fetch PR data here. The user's checkbox selections
-    // are already included in todayPlans — re-fetching would show ALL PRs
-    // regardless of what the user selected.
+    // Post to channel (or update existing post on re-submit)
     if (daily?.channel) {
       const standupData = {
         yesterdayCompleted,
@@ -795,17 +792,24 @@ export async function handleStandupSubmission(
         githubOrg,
       };
 
-      const messageTs = await postStandupToChannel(
-        ctx.slackToken,
-        daily.channel,
-        userId,
-        dailyName,
-        standupData
-      );
+      if (submission.slack_message_ts) {
+        // Re-submit: update the existing channel post in place
+        const blocks = formatStandupBlocks(userId, dailyName, standupData);
+        const fallbackText = `*<@${userId}>* updated their standup`;
+        await updateMessage(ctx.slackToken, daily.channel, submission.slack_message_ts, fallbackText, blocks);
+      } else {
+        // First submit: post new message
+        const messageTs = await postStandupToChannel(
+          ctx.slackToken,
+          daily.channel,
+          userId,
+          dailyName,
+          standupData
+        );
 
-      // Store message timestamp for future reference
-      if (messageTs && submission.id) {
-        await updateSubmissionMessageTs(ctx.db, submission.id, messageTs);
+        if (messageTs && submission.id) {
+          await updateSubmissionMessageTs(ctx.db, submission.id, messageTs);
+        }
       }
 
       // Send DM copy if user preference allows
@@ -1020,6 +1024,129 @@ export async function handleHomeStartDaily(
     autoCompletedIds,
     mergedPRsHome.length > 0 ? mergedPRsHome : undefined,
     getDailySections(daily)
+  );
+
+  return openModal(ctx.slackToken, triggerId, modal);
+}
+
+// ============================================================================
+// Button Handler: Edit Standup
+// ============================================================================
+
+/**
+ * Handle "Edit Standup" button from App Home
+ * Reopens the modal pre-filled with today's submission data
+ */
+export async function handleEditStandup(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const dailyName = payload.actions?.[0]?.value;
+  if (!dailyName) {
+    console.error('No daily name in home_edit_standup action');
+    return false;
+  }
+
+  const userId = payload.user.id;
+  const triggerId = payload.trigger_id;
+
+  const daily = getDaily(dailyName);
+  if (!daily) {
+    console.error(`Daily "${dailyName}" not found`);
+    return false;
+  }
+
+  const userInfo = await getUserTimezone(ctx.slackToken, userId);
+  const tzOffset = userInfo?.tz_offset || 0;
+  const userDate = getUserDate(tzOffset);
+  const todayStr = formatDate(userDate);
+
+  // Fetch today's submission for prefill
+  const todaySubmission = await getSubmissionForDate(ctx.db, userId, dailyName, todayStr);
+  if (!todaySubmission) {
+    await sendDM(ctx.slackToken, userId, `No standup found for today in *${dailyName}*. Use "Start Daily" to submit one.`);
+    return true;
+  }
+
+  // Build prefill from today's submission
+  const prefill: SubmissionPrefill = {
+    todayPlans: todaySubmission.today_plans || undefined,
+    unplanned: todaySubmission.unplanned || undefined,
+    blockers: todaySubmission.blockers || undefined,
+    customAnswers: todaySubmission.custom_answers || undefined,
+  };
+
+  // Build yesterday data from the submission *before* today (same logic as handleOpenStandup)
+  const previousSubmission = await getPreviousSubmission(ctx.db, userId, dailyName, todayStr);
+
+  let yesterdayData: YesterdayData | null = null;
+  if (previousSubmission) {
+    const todayPlans = previousSubmission.today_plans
+      ? (Array.isArray(previousSubmission.today_plans)
+          ? previousSubmission.today_plans
+          : JSON.parse(previousSubmission.today_plans as unknown as string))
+      : [];
+    const carriedItems = previousSubmission.yesterday_incomplete
+      ? (Array.isArray(previousSubmission.yesterday_incomplete)
+          ? previousSubmission.yesterday_incomplete
+          : JSON.parse(previousSubmission.yesterday_incomplete as unknown as string))
+      : [];
+    const inProgressItems = previousSubmission.yesterday_in_progress
+      ? (Array.isArray(previousSubmission.yesterday_in_progress)
+          ? previousSubmission.yesterday_in_progress
+          : JSON.parse(previousSubmission.yesterday_in_progress as unknown as string))
+      : [];
+    const allPlans = [...inProgressItems, ...carriedItems, ...todayPlans];
+    if (allPlans.length > 0) {
+      yesterdayData = {
+        plans: allPlans,
+        completed: [],
+        incomplete: [],
+        inProgressCount: inProgressItems.length,
+      };
+    }
+  }
+
+  // Fetch integrations in parallel
+  const yesterdayDate = new Date(userDate);
+  yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+  const sinceDate = previousSubmission?.date || formatDate(yesterdayDate);
+
+  const [linearResult, githubResult, mergedPRs] = await Promise.all([
+    fetchLinearIssuesForUser(daily, userId, ctx),
+    fetchGitHubPRsForUser(daily, userId, ctx),
+    fetchMergedPRsForUser(daily, userId, ctx, sinceDate),
+  ]);
+
+  let doneIdentifiers: Set<string> | undefined;
+  let autoCompletedIds: Set<string> | undefined;
+
+  if (linearResult.allActiveIdentifiers.length > 0 || yesterdayData) {
+    try {
+      const recentlyDoneItems = await getRecentlyDoneLinearItems(ctx.db, userId, dailyName);
+      const doneIds = new Set(
+        recentlyDoneItems.map(text => text.match(/^\[([^\]]+)\]/)?.[1]).filter((id): id is string => !!id)
+      );
+      if (doneIds.size > 0) doneIdentifiers = doneIds;
+      if (yesterdayData && linearResult.allActiveIdentifiers.length > 0) {
+        const activeSet = new Set(linearResult.allActiveIdentifiers);
+        const autoDone = new Set<string>();
+        for (const plan of yesterdayData.plans) {
+          const match = plan.match(/^\[([^\]]+)\]\s/);
+          if (match && !activeSet.has(match[1]) && !doneIds.has(match[1])) autoDone.add(match[1]);
+        }
+        if (autoDone.size > 0) autoCompletedIds = autoDone;
+      }
+    } catch (error) {
+      console.error('Failed to compute done/auto-completed sets:', error);
+    }
+  }
+
+  const sects = getDailySections(daily);
+  const modal = buildStandupModal(
+    dailyName, yesterdayData, daily.questions || [], daily.field_order, userDate,
+    'today', prefill, linearResult.issues, githubResult.prData, githubResult.reviewerMap,
+    doneIdentifiers, autoCompletedIds, mergedPRs.length > 0 ? mergedPRs : undefined, sects
   );
 
   return openModal(ctx.slackToken, triggerId, modal);
@@ -1659,6 +1786,7 @@ export async function handleInteraction(
     if (actionId === 'home_set_max_items') return handleSetMaxItems(payload, ctx);
     if (actionId === 'home_set_stale_pr_days') return handleSetStalePrDays(payload, ctx);
     if (actionId === 'home_set_linear_teams') return handleSetLinearTeams(payload, ctx);
+    if (actionId === 'home_edit_standup') return handleEditStandup(payload, ctx);
     if (actionId === 'task_action') return handleTaskAction(payload, ctx);
     if (actionId === 'task_add') return handleTaskAdd(payload, ctx);
   }

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -1593,7 +1593,7 @@ async function syncStandupPost(
   };
 
   const blocks = formatStandupBlocks(userId, dailyName, data);
-  const fallbackText = `*<@${userId}>* submitted their standup`;
+  const fallbackText = `*<@${userId}>*`;
 
   await updateMessage(slackToken, daily.channel, submission.slack_message_ts, fallbackText, blocks);
 }

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -596,24 +596,28 @@ export async function handleStandupSubmission(
     // are already included in todayPlans — re-fetching would show ALL PRs
     // regardless of what the user selected.
     if (daily?.channel) {
+      const githubConfig = getGitHubConfig(daily);
+      const standupData = {
+        yesterdayCompleted,
+        yesterdayIncomplete,
+        yesterdayInProgress,
+        yesterdayDropped,
+        unplanned,
+        todayPlans,
+        blockers,
+        customAnswers,
+        questions: daily.questions,
+        fieldOrder: daily.field_order,
+        inProgressCarryCounts,
+        githubOrg: githubConfig?.org,
+      };
+
       const messageTs = await postStandupToChannel(
         ctx.slackToken,
         daily.channel,
         userId,
         dailyName,
-        {
-          yesterdayCompleted,
-          yesterdayIncomplete,
-          yesterdayInProgress,
-          yesterdayDropped,
-          unplanned,
-          todayPlans,
-          blockers,
-          customAnswers,
-          questions: daily.questions,
-          fieldOrder: daily.field_order,
-          inProgressCarryCounts,
-        }
+        standupData
       );
 
       // Store message timestamp for future reference
@@ -625,19 +629,7 @@ export async function handleStandupSubmission(
       try {
         const dmEnabled = await getDmStandupPreference(ctx.db, userId);
         if (dmEnabled) {
-          await sendStandupDM(ctx.slackToken, userId, dailyName, daily.channel, {
-            yesterdayCompleted,
-            yesterdayIncomplete,
-            yesterdayInProgress,
-            yesterdayDropped,
-            unplanned,
-            todayPlans,
-            blockers,
-            customAnswers,
-            questions: daily.questions,
-            fieldOrder: daily.field_order,
-            inProgressCarryCounts,
-          });
+          await sendStandupDM(ctx.slackToken, userId, dailyName, daily.channel, standupData);
         }
       } catch (error) {
         console.error('Failed to send standup DM copy:', error);

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -16,6 +16,8 @@ import {
   markItemsInProgress,
   getInProgressCarryCounts,
   createWorkItems,
+  linkItemsToSubmission,
+  ItemSource,
   snoozeItem,
   getSubmissionForDate,
   getGitHubUsername,
@@ -410,15 +412,41 @@ export async function handleStandupSubmission(
   const todayPlans = parseLines(values.today_plans?.plans_input?.value);
   const blockers = parseRichText(values.blockers?.blockers_input?.rich_text_value) || '';
 
-  // Parse Linear ticket selections and append to todayPlans
-  // Parse integration checkbox selections — extract display text from the option's text field
-  // Format is "*IDENTIFIER* Title" in mrkdwn, so strip the bold markers
+  // Parse integration checkbox selections — extract display text and structured source info
+  // Format is "*IDENTIFIER* Title" in mrkdwn, so strip the bold markers for flat text
   const parseOptionText = (text: string): string => text.replace(/^\*([^*]+)\*\s*/, '[$1] ');
+  const extractIdentifier = (text: string): string | undefined => {
+    const m = text.match(/^\*([^*]+)\*\s*/);
+    return m ? m[1] : undefined;
+  };
+
+  interface StructuredItem {
+    text: string;
+    source: ItemSource;
+    sourceRef?: string;
+    sourceUrl?: string;
+  }
+  const structuredPlans: StructuredItem[] = [];
+
+  // Manual text plans
+  for (const plan of todayPlans) {
+    structuredPlans.push({ text: plan, source: 'manual' });
+  }
+
+  const githubOrg = daily ? getGitHubConfig(daily)?.org : undefined;
 
   const linearSelections = values.linear_tickets?.linear_tickets_input?.selected_options;
   if (linearSelections && linearSelections.length > 0) {
     for (const option of linearSelections) {
-      todayPlans.push(parseOptionText(option.text?.text || option.value));
+      const flatText = parseOptionText(option.text?.text || option.value);
+      todayPlans.push(flatText);
+      const identifier = extractIdentifier(option.text?.text || '');
+      structuredPlans.push({
+        text: flatText,
+        source: 'linear_ticket',
+        sourceRef: identifier,
+        sourceUrl: identifier ? `https://linear.app/issue/${identifier}` : undefined,
+      });
     }
   }
 
@@ -426,7 +454,16 @@ export async function handleStandupSubmission(
   const reviewSelections = values.review_requests?.review_requests_input?.selected_options;
   if (reviewSelections && reviewSelections.length > 0) {
     for (const option of reviewSelections) {
-      todayPlans.push(parseOptionText(option.text?.text || option.value));
+      const flatText = parseOptionText(option.text?.text || option.value);
+      todayPlans.push(flatText);
+      const ref = option.value; // "repo#42"
+      const [repo, num] = ref.split('#');
+      structuredPlans.push({
+        text: flatText,
+        source: 'github_pr',
+        sourceRef: ref,
+        sourceUrl: githubOrg ? `https://github.com/${githubOrg}/${repo}/pull/${num}` : undefined,
+      });
     }
   }
   const myPrSelections = values.my_prs?.my_prs_input?.selected_options;
@@ -438,6 +475,14 @@ export async function handleStandupSubmission(
         planText += ` — waiting on ${reviewers}`;
       }
       todayPlans.push(planText);
+      const ref = option.value; // "repo#42"
+      const [repo, num] = ref.split('#');
+      structuredPlans.push({
+        text: planText,
+        source: 'github_pr',
+        sourceRef: ref,
+        sourceUrl: githubOrg ? `https://github.com/${githubOrg}/${repo}/pull/${num}` : undefined,
+      });
     }
   }
 
@@ -561,27 +606,51 @@ export async function handleStandupSubmission(
       // Mark yesterday's items based on status
       if (yesterdayCompleted.length > 0) {
         await markItemsDone(ctx.db, userId, dailyName, yesterdayCompleted, todayStr);
+        await linkItemsToSubmission(ctx.db, submission.id, userId, dailyName, yesterdayCompleted, 'yesterday_completed');
       }
       if (yesterdayDropped.length > 0) {
         await markItemsDropped(ctx.db, userId, dailyName, yesterdayDropped);
+        await linkItemsToSubmission(ctx.db, submission.id, userId, dailyName, yesterdayDropped, 'yesterday_dropped');
       }
       if (yesterdayIncomplete.length > 0) {
         await incrementCarryCount(ctx.db, userId, dailyName, yesterdayIncomplete);
+        await linkItemsToSubmission(ctx.db, submission.id, userId, dailyName, yesterdayIncomplete, 'yesterday_incomplete');
       }
       if (yesterdayInProgress.length > 0) {
         await markItemsInProgress(ctx.db, userId, dailyName, yesterdayInProgress);
+        await linkItemsToSubmission(ctx.db, submission.id, userId, dailyName, yesterdayInProgress, 'yesterday_in_progress');
       }
 
-      // Create new work items for today's plans
-      if (todayPlans.length > 0) {
+      // Create new work items for today's plans (with structured source metadata)
+      if (structuredPlans.length > 0) {
         await createWorkItems(
           ctx.db,
-          todayPlans.map(text => ({
+          structuredPlans.map((item, i) => ({
+            slackUserId: userId,
+            dailyName,
+            text: item.text,
+            date: todayStr,
+            submissionId: submission.id,
+            source: item.source,
+            sourceRef: item.sourceRef,
+            sourceUrl: item.sourceUrl,
+            itemType: 'plan' as const,
+          }))
+        );
+      }
+
+      // Create work items for unplanned items
+      if (unplanned.length > 0) {
+        await createWorkItems(
+          ctx.db,
+          unplanned.map((text, i) => ({
             slackUserId: userId,
             dailyName,
             text,
             date: todayStr,
             submissionId: submission.id,
+            source: 'manual' as const,
+            itemType: 'unplanned' as const,
           }))
         );
       }
@@ -641,7 +710,6 @@ export async function handleStandupSubmission(
     // are already included in todayPlans — re-fetching would show ALL PRs
     // regardless of what the user selected.
     if (daily?.channel) {
-      const githubConfig = getGitHubConfig(daily);
       const standupData = {
         yesterdayCompleted,
         yesterdayIncomplete,
@@ -654,7 +722,7 @@ export async function handleStandupSubmission(
         questions: daily.questions,
         fieldOrder: daily.field_order,
         inProgressCarryCounts,
-        githubOrg: githubConfig?.org,
+        githubOrg,
       };
 
       const messageTs = await postStandupToChannel(

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -418,6 +418,7 @@ export async function handleStandupSubmission(
     sections?: { blockers: boolean; unplanned: boolean };
     unmappedReviewers?: string[];
     prReviewerTags?: Record<string, string>;
+    prCategories?: Record<string, string>;
   };
   const dailyName = metadata.dailyName;
   const yesterdayPlanItems = metadata.yesterdayPlans || [];
@@ -506,12 +507,13 @@ export async function handleStandupSubmission(
   const reviewSelections = values.review_requests?.review_requests_input?.selected_options;
   if (reviewSelections && reviewSelections.length > 0) {
     for (const option of reviewSelections) {
-      const flatText = parseOptionText(option.text?.text || option.value);
-      todayPlans.push(flatText);
+      let planText = parseOptionText(option.text?.text || option.value);
+      planText += ' _(to review)_';
+      todayPlans.push(planText);
       const ref = option.value; // "repo#42"
       const [repo, num] = ref.split('#');
       structuredPlans.push({
-        text: flatText,
+        text: planText,
         source: 'github_pr',
         sourceRef: ref,
         sourceUrl: githubOrg ? `https://github.com/${githubOrg}/${repo}/pull/${num}` : undefined,
@@ -525,6 +527,10 @@ export async function handleStandupSubmission(
       const reviewers = metadata.prReviewerTags?.[option.value];
       if (reviewers) {
         planText += ` — waiting on ${reviewers}`;
+      }
+      const category = metadata.prCategories?.[option.value];
+      if (category) {
+        planText += ` _(${category})_`;
       }
       todayPlans.push(planText);
       const ref = option.value; // "repo#42"

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -1731,11 +1731,14 @@ async function handleTaskAddSubmission(
 
   await addWorkItem(ctx.db, userId, dailyName, text, date, submissionId);
   await updateSubmissionArrays(ctx.db, submissionId, userId, dailyName, date);
-  await refreshHome(userId, ctx);
 
-  const syncPromise = syncStandupPost(ctx.db, ctx.slackToken, userId, dailyName, date)
-    .catch(err => console.error('syncStandupPost failed:', err));
-  ctx.waitUntil?.(syncPromise);
+  // Refresh home and sync post in background so Slack gets a fast 200
+  const bgWork = Promise.all([
+    refreshHome(userId, ctx).catch(err => console.error('refreshHome failed:', err)),
+    syncStandupPost(ctx.db, ctx.slackToken, userId, dailyName, date)
+      .catch(err => console.error('syncStandupPost failed:', err)),
+  ]);
+  ctx.waitUntil?.(bgWork);
 
   return true;
 }

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -3,7 +3,7 @@
  * Handles: open_standup button, standup_submission modal
  */
 
-import { getDaily, getConfigError, getSchedule, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser, getMaxPlanItems, isAdmin, getGitHubIntelligenceConfig } from '../config';
+import { getDaily, getConfigError, getSchedule, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser, getMaxPlanItems, isAdmin, getGitHubIntelligenceConfig, getDailySections } from '../config';
 import {
   DbClient,
   getPreviousSubmission,
@@ -383,7 +383,8 @@ export async function handleOpenStandup(
   }
 
   // Build and open modal
-  const modal = buildStandupModal(dailyName, yesterdayData, daily.questions || [], daily.field_order, userDate, 'today', undefined, linearResult.issues, githubResult.prData, githubResult.reviewerMap, doneIdentifiers, autoCompletedIds, mergedPRs.length > 0 ? mergedPRs : undefined);
+  const sects = getDailySections(daily);
+  const modal = buildStandupModal(dailyName, yesterdayData, daily.questions || [], daily.field_order, userDate, 'today', undefined, linearResult.issues, githubResult.prData, githubResult.reviewerMap, doneIdentifiers, autoCompletedIds, mergedPRs.length > 0 ? mergedPRs : undefined, sects);
   return openModal(ctx.slackToken, triggerId, modal);
 }
 
@@ -414,6 +415,7 @@ export async function handleStandupSubmission(
     yesterdayPlans?: string[];
     mode?: StandupMode;
     targetDate?: string;
+    sections?: { blockers: boolean; unplanned: boolean };
     unmappedReviewers?: string[];
     prReviewerTags?: Record<string, string>;
   };
@@ -456,10 +458,11 @@ export async function handleStandupSubmission(
     }
   });
 
-  // Parse text inputs
-  const unplanned = parseLines(values.unplanned?.unplanned_input?.value);
+  // Parse text inputs (gate by sections config from metadata)
+  const sectionsCfg = metadata.sections ?? { blockers: true, unplanned: true };
+  const unplanned = sectionsCfg.unplanned ? parseLines(values.unplanned?.unplanned_input?.value) : [];
   const todayPlans = parseLines(values.today_plans?.plans_input?.value);
-  const blockers = parseRichText(values.blockers?.blockers_input?.rich_text_value) || '';
+  const blockers = sectionsCfg.blockers ? (parseRichText(values.blockers?.blockers_input?.rich_text_value) || '') : '';
 
   // Parse integration checkbox selections — extract display text and structured source info
   // Format is "*IDENTIFIER* Title" in mrkdwn, so strip the bold markers for flat text
@@ -1015,7 +1018,8 @@ export async function handleHomeStartDaily(
     githubResult.reviewerMap,
     doneIdentifiers,
     autoCompletedIds,
-    mergedPRsHome.length > 0 ? mergedPRsHome : undefined
+    mergedPRsHome.length > 0 ? mergedPRsHome : undefined,
+    getDailySections(daily)
   );
 
   return openModal(ctx.slackToken, triggerId, modal);

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -3,7 +3,7 @@
  * Handles: open_standup button, standup_submission modal
  */
 
-import { getDaily, getConfigError, getSchedule, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser, getMaxPlanItems } from '../config';
+import { getDaily, getConfigError, getSchedule, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser, getMaxPlanItems, isAdmin } from '../config';
 import {
   DbClient,
   getPreviousSubmission,
@@ -28,6 +28,7 @@ import {
   setDmStandupPreference,
   updateUserSetting,
   getUserDailies,
+  getParticipants,
   setOOO,
   clearOOO,
 } from '../db';
@@ -36,7 +37,7 @@ import { fetchUserPRData, UserPRData } from '../github';
 import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue, UserLinearData } from '../linear';
 import { postStandupToChannel, sendStandupDM } from '../format';
 import { buildStandupModal, YesterdayData, SubmissionPrefill } from '../modal';
-import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed } from '../prompt';
+import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed, sendPromptDM } from '../prompt';
 import { openModal, parseRichText, RichTextBlock, sendDM } from '../slack';
 import { StandupMode } from '../modal';
 
@@ -1282,6 +1283,11 @@ export async function handleInteraction(
     return handleOOOSetSubmission(payload, ctx);
   }
 
+  // Handle mass prompt confirmation
+  if (payload.type === 'view_submission' && payload.view?.callback_id === 'mass_prompt_confirm') {
+    return handleMassPromptConfirm(payload, ctx);
+  }
+
   // Handle settings modal submissions
   if (payload.type === 'view_submission') {
     const callbackId = payload.view?.callback_id || '';
@@ -1291,5 +1297,41 @@ export async function handleInteraction(
   }
 
   // Unknown interaction type
+  return true;
+}
+
+async function handleMassPromptConfirm(
+  payload: InteractionPayload,
+  ctx: InteractionContext
+): Promise<boolean> {
+  const userId = payload.user.id;
+  if (!isAdmin(userId)) return false;
+
+  let metadata: { dailyName: string };
+  try {
+    metadata = JSON.parse(payload.view?.private_metadata || '{}');
+  } catch {
+    return false;
+  }
+
+  const { dailyName } = metadata;
+  if (!dailyName) return false;
+
+  const participants = await getParticipants(ctx.db, dailyName);
+  let sent = 0;
+  let failed = 0;
+
+  for (const p of participants) {
+    const ok = await sendPromptDM(ctx.slackToken, p.slack_user_id, dailyName);
+    if (ok) sent++;
+    else failed++;
+  }
+
+  let summary = `📬 Sent prompts to ${sent} user${sent !== 1 ? 's' : ''} in *${dailyName}*.`;
+  if (failed > 0) {
+    summary += `\n⚠️ ${failed} failed.`;
+  }
+
+  await sendDM(ctx.slackToken, userId, summary);
   return true;
 }

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -3,7 +3,7 @@
  * Handles: open_standup button, standup_submission modal
  */
 
-import { getDaily, getConfigError, getSchedule, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser, getMaxPlanItems, isAdmin } from '../config';
+import { getDaily, getConfigError, getSchedule, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getLinearConfig, getLinearUserIdFromConfig, getLinearTeamIdForUser, getMaxPlanItems, isAdmin, getGitHubIntelligenceConfig } from '../config';
 import {
   DbClient,
   getPreviousSubmission,
@@ -38,7 +38,7 @@ import {
   updateSubmissionArrays,
 } from '../db';
 import { handleAppHomeOpened, AppHomeOpenedEvent, HomeContext } from './home';
-import { fetchUserPRData, UserPRData } from '../github';
+import { fetchUserPRData, UserPRData, fetchMergedPRs, MergedPR } from '../github';
 import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue, UserLinearData, extractLinearReferences, fetchWorkflowStates, markIssuesInProgress as markLinearIssuesInProgress, commentOnIssue, resolveIdentifiers } from '../linear';
 import { postStandupToChannel, sendStandupDM, formatStandupBlocks, StandupData } from '../format';
 import { buildStandupModal, YesterdayData, SubmissionPrefill } from '../modal';
@@ -223,6 +223,46 @@ export async function fetchGitHubPRsForUser(
   }
 }
 
+/**
+ * Fetch merged PRs for a user if GitHub intelligence auto_populate is enabled
+ */
+async function fetchMergedPRsForUser(
+  daily: ReturnType<typeof getDaily>,
+  userId: string,
+  ctx: InteractionContext,
+  since: string
+): Promise<MergedPR[]> {
+  if (!daily) return [];
+
+  const githubIntelConfig = getGitHubIntelligenceConfig(daily);
+  if (!githubIntelConfig?.auto_populate) return [];
+
+  const githubConfig = getGitHubConfig(daily);
+  if (!githubConfig || !ctx.env) return [];
+
+  const githubToken = ctx.env[githubConfig.tokenEnvVar];
+  if (!githubToken) return [];
+
+  // Get GitHub username: config mapping takes precedence over DB
+  let githubUsername = getGitHubUsernameFromConfig(daily, userId);
+  if (!githubUsername) {
+    githubUsername = await getGitHubUsername(ctx.db, userId);
+  }
+
+  if (!githubUsername) return [];
+
+  try {
+    const mergedPRs = await withTimeout(
+      fetchMergedPRs(githubToken, githubUsername, githubConfig.org, since),
+      INTEGRATION_TIMEOUT_MS, 'GitHub merged PRs API'
+    );
+    return mergedPRs;
+  } catch (error) {
+    console.error('Failed to fetch merged PRs:', error);
+    return [];
+  }
+}
+
 // ============================================================================
 // Button Handler: Open Standup
 // ============================================================================
@@ -296,10 +336,16 @@ export async function handleOpenStandup(
     }
   }
 
-  // Fetch Linear issues and GitHub PRs in parallel
-  const [linearResult, githubResult] = await Promise.all([
+  // Compute "since" date for merged PRs: use previous submission date, or yesterday
+  const yesterdayDate = new Date(userDate);
+  yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+  const sinceDate = previousSubmission?.date || formatDate(yesterdayDate);
+
+  // Fetch Linear issues, GitHub PRs, and merged PRs in parallel
+  const [linearResult, githubResult, mergedPRs] = await Promise.all([
     fetchLinearIssuesForUser(daily, userId, ctx),
     fetchGitHubPRsForUser(daily, userId, ctx),
+    fetchMergedPRsForUser(daily, userId, ctx, sinceDate),
   ]);
 
   // Compute done suppression and auto-completed sets
@@ -337,7 +383,7 @@ export async function handleOpenStandup(
   }
 
   // Build and open modal
-  const modal = buildStandupModal(dailyName, yesterdayData, daily.questions || [], daily.field_order, userDate, 'today', undefined, linearResult.issues, githubResult.prData, githubResult.reviewerMap, doneIdentifiers, autoCompletedIds);
+  const modal = buildStandupModal(dailyName, yesterdayData, daily.questions || [], daily.field_order, userDate, 'today', undefined, linearResult.issues, githubResult.prData, githubResult.reviewerMap, doneIdentifiers, autoCompletedIds, mergedPRs.length > 0 ? mergedPRs : undefined);
   return openModal(ctx.slackToken, triggerId, modal);
 }
 
@@ -893,10 +939,16 @@ export async function handleHomeStartDaily(
     }
   }
 
-  // Fetch Linear issues and GitHub PRs in parallel
-  const [linearResult, githubResult] = await Promise.all([
+  // Compute "since" date for merged PRs: yesterday relative to user's local date
+  const yesterdayDateHome = new Date(userDate);
+  yesterdayDateHome.setDate(yesterdayDateHome.getDate() - 1);
+  const sinceDateHome = formatDate(yesterdayDateHome);
+
+  // Fetch Linear issues, GitHub PRs, and merged PRs in parallel
+  const [linearResult, githubResult, mergedPRsHome] = await Promise.all([
     fetchLinearIssuesForUser(daily, userId, ctx),
     fetchGitHubPRsForUser(daily, userId, ctx),
+    fetchMergedPRsForUser(daily, userId, ctx, sinceDateHome),
   ]);
 
   // Compute done suppression and auto-completed sets
@@ -944,7 +996,8 @@ export async function handleHomeStartDaily(
     githubResult.prData,
     githubResult.reviewerMap,
     doneIdentifiers,
-    autoCompletedIds
+    autoCompletedIds,
+    mergedPRsHome.length > 0 ? mergedPRsHome : undefined
   );
 
   return openModal(ctx.slackToken, triggerId, modal);

--- a/lib/handlers/webhooks.ts
+++ b/lib/handlers/webhooks.ts
@@ -306,7 +306,7 @@ async function syncChannelPost(
   };
 
   const blocks = formatStandupBlocks(userId, dailyName, data);
-  const fallbackText = `*<@${userId}>* submitted their standup`;
+  const fallbackText = `*<@${userId}>*`;
 
   await updateMessage(slackToken, daily.channel, submission.slack_message_ts!, fallbackText, blocks);
 }

--- a/lib/handlers/webhooks.ts
+++ b/lib/handlers/webhooks.ts
@@ -1,0 +1,330 @@
+/**
+ * Webhook handlers for external integrations
+ * Currently: Linear issue status changes → standup auto-update
+ */
+
+import { DbClient, WorkItem, getActiveWorkItemsBySourceRef, updateWorkItemStatus, updateSubmissionArrays, getSubmissionForDate } from '../db';
+import { getDaily, getLinearIntelligenceConfig, getGitHubConfig } from '../config';
+import { sendDM, updateMessage } from '../slack';
+import { formatStandupBlocks, StandupData } from '../format';
+import { handleAppHomeOpened, AppHomeOpenedEvent, HomeContext } from './home';
+import { formatDate } from '../prompt';
+import { getInProgressCarryCounts } from '../db';
+import { Env } from '../../api/index';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface LinearWebhookPayload {
+  action: 'create' | 'update' | 'remove';
+  type: string; // "Issue", "Comment", etc.
+  data: {
+    id: string;
+    identifier: string;
+    title: string;
+    state: { id: string; name: string; type: string };
+    assignee?: { id: string };
+    priority: number;
+    url: string;
+  };
+  updatedFrom?: {
+    stateId?: string;
+  };
+  url: string;
+  createdAt: string;
+  webhookTimestamp: number;
+}
+
+// ============================================================================
+// Signature Verification
+// ============================================================================
+
+/**
+ * Verify Linear webhook signature (HMAC-SHA256)
+ * Linear sends the signature in the "Linear-Signature" header.
+ * It's computed as: HMAC-SHA256(webhookSecret, rawBody)
+ */
+export async function verifyLinearSignature(
+  body: string,
+  signature: string,
+  secret: string
+): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(body));
+  const expected = Array.from(new Uint8Array(sig))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+  return expected === signature;
+}
+
+// ============================================================================
+// Main Handler
+// ============================================================================
+
+/**
+ * Handle incoming Linear webhook request.
+ * Called from api/index.ts for POST /api/webhooks/linear
+ */
+export async function handleLinearWebhook(
+  request: Request,
+  env: Env,
+  db: DbClient,
+  ctx?: ExecutionContext
+): Promise<Response> {
+  // 1. Read body as text (must be done before any other body access)
+  const body = await request.text();
+
+  // 2. Get signature header (Linear may send it lowercase or title-case)
+  const signature =
+    request.headers.get('Linear-Signature') ||
+    request.headers.get('linear-signature') ||
+    '';
+
+  // 3. Get secret — if not configured, skip processing gracefully
+  const secret = env.LINEAR_WEBHOOK_SECRET;
+  if (!secret) {
+    console.log('LINEAR_WEBHOOK_SECRET not configured — skipping Linear webhook');
+    return new Response('OK', { status: 200 });
+  }
+
+  // 4. Verify signature
+  const isValid = await verifyLinearSignature(body, signature, secret);
+  if (!isValid) {
+    console.warn('Linear webhook signature verification failed');
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  // 5. Parse payload
+  let payload: LinearWebhookPayload;
+  try {
+    payload = JSON.parse(body) as LinearWebhookPayload;
+  } catch (err) {
+    console.error('Failed to parse Linear webhook body:', err);
+    return new Response('Bad Request', { status: 400 });
+  }
+
+  // 6. Only process issue updates
+  if (payload.action !== 'update' || payload.type !== 'Issue') {
+    return new Response('OK', { status: 200 });
+  }
+
+  // 7. Only process if the state actually changed
+  if (!payload.updatedFrom?.stateId) {
+    return new Response('OK', { status: 200 });
+  }
+
+  // 8. Look up work items to check auto_update config and find the daily
+  const identifier = payload.data.identifier;
+  const items = await getActiveWorkItemsBySourceRef(db, identifier);
+
+  if (items.length === 0) {
+    // Issue not tracked in any standup — ignore
+    return new Response('OK', { status: 200 });
+  }
+
+  // Check auto_update config using the first matching item's daily
+  const firstDaily = getDaily(items[0].daily_name);
+  if (!firstDaily) {
+    return new Response('OK', { status: 200 });
+  }
+  const intelConfig = getLinearIntelligenceConfig(firstDaily);
+  if (!intelConfig?.auto_update) {
+    return new Response('OK', { status: 200 });
+  }
+
+  // 9. Process status change — run synchronously (fast enough for 5s window)
+  const process = processIssueStatusChange(payload, items, db, env.SLACK_BOT_TOKEN, env, ctx);
+
+  if (ctx) {
+    ctx.waitUntil(process);
+  } else {
+    await process;
+  }
+
+  return new Response('OK', { status: 200 });
+}
+
+// ============================================================================
+// Status Change Processor
+// ============================================================================
+
+/**
+ * Map Linear state type to internal work item status.
+ * Returns null for state types we don't act on.
+ */
+function mapLinearState(stateType: string): 'done' | 'in_progress' | null {
+  switch (stateType) {
+    case 'completed':
+      return 'done';
+    case 'started':
+      return 'in_progress';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Parse JSONB arrays from database (handles both array and string formats)
+ */
+function parseJsonArray(value: string[] | null): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  try {
+    return JSON.parse(value as unknown as string);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Process an issue status change from a Linear webhook.
+ * For each matching work item:
+ *   - Update work item status
+ *   - Sync submission JSONB arrays
+ *   - Update channel post
+ *   - Refresh App Home
+ *   - Send DM notification
+ */
+async function processIssueStatusChange(
+  payload: LinearWebhookPayload,
+  items: WorkItem[],
+  db: DbClient,
+  slackToken: string,
+  env: Env,
+  ctx?: ExecutionContext
+): Promise<void> {
+  const newStateType = payload.data.state.type;
+  const newStatus = mapLinearState(newStateType);
+
+  if (!newStatus) {
+    // State type not actionable (e.g., "backlog", "cancelled") — skip
+    return;
+  }
+
+  const todayStr = formatDate(new Date());
+
+  for (const item of items) {
+    try {
+      // a. Update work item status
+      await updateWorkItemStatus(db, item.id, newStatus, newStatus === 'done' ? todayStr : undefined);
+
+      // b. Sync submission JSONB arrays if we have a submission
+      if (item.submission_id) {
+        await updateSubmissionArrays(db, item.submission_id, item.slack_user_id, item.daily_name, item.created_date);
+      }
+
+      // c. Get daily config for the channel
+      const daily = getDaily(item.daily_name);
+      if (!daily) continue;
+
+      // d. Update channel post if it exists
+      const submission = item.submission_id
+        ? await getSubmissionForDate(db, item.slack_user_id, item.daily_name, item.created_date)
+        : null;
+
+      if (submission?.posted && submission.slack_message_ts) {
+        await syncChannelPost(db, slackToken, item.slack_user_id, item.daily_name, item.created_date, submission, daily);
+      }
+
+      // e. Refresh App Home (non-critical — run in background if we have ctx)
+      const homeRefresh = refreshAppHome(db, slackToken, item.slack_user_id, env);
+      if (ctx) {
+        ctx.waitUntil(homeRefresh);
+      } else {
+        await homeRefresh;
+      }
+
+      // f. Send DM notification
+      const emoji = newStatus === 'done' ? '✅' : '🔄';
+      const statusLabel = newStatus === 'done' ? 'marked done' : 'marked in progress';
+      const dmText = `${emoji} Linear auto-update: [${payload.data.identifier}] ${payload.data.title} — ${statusLabel}`;
+      const dmSend = sendDM(slackToken, item.slack_user_id, dmText);
+      if (ctx) {
+        ctx.waitUntil(dmSend);
+      } else {
+        await dmSend;
+      }
+    } catch (err) {
+      console.error(`Failed to process webhook update for work item ${item.id}:`, err);
+      // Continue processing remaining items — don't let one failure block others
+    }
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Rebuild and push the updated standup post to the channel.
+ * Mirrors syncStandupPost from interactions.ts.
+ */
+async function syncChannelPost(
+  db: DbClient,
+  slackToken: string,
+  userId: string,
+  dailyName: string,
+  date: string,
+  submission: Awaited<ReturnType<typeof getSubmissionForDate>>,
+  daily: ReturnType<typeof getDaily>
+): Promise<void> {
+  if (!submission || !daily) return;
+
+  const inProgressItems = parseJsonArray(submission.yesterday_in_progress);
+  let inProgressCarryCounts: Record<string, number> | undefined;
+  if (inProgressItems.length > 0) {
+    try {
+      inProgressCarryCounts = await getInProgressCarryCounts(db, userId, dailyName, inProgressItems);
+    } catch (err) {
+      console.error('Failed to get in-progress carry counts for webhook sync:', err);
+    }
+  }
+
+  const githubOrg = getGitHubConfig(daily)?.org;
+
+  const data: StandupData = {
+    yesterdayCompleted: parseJsonArray(submission.yesterday_completed),
+    yesterdayIncomplete: parseJsonArray(submission.yesterday_incomplete),
+    yesterdayInProgress: inProgressItems,
+    yesterdayDropped: [],
+    unplanned: parseJsonArray(submission.unplanned),
+    todayPlans: parseJsonArray(submission.today_plans),
+    blockers: submission.blockers || '',
+    customAnswers: submission.custom_answers || {},
+    questions: daily.questions,
+    fieldOrder: daily.field_order,
+    inProgressCarryCounts,
+    githubOrg,
+  };
+
+  const blocks = formatStandupBlocks(userId, dailyName, data);
+  const fallbackText = `*<@${userId}>* submitted their standup`;
+
+  await updateMessage(slackToken, daily.channel, submission.slack_message_ts!, fallbackText, blocks);
+}
+
+/**
+ * Refresh the App Home view for a user.
+ */
+async function refreshAppHome(
+  db: DbClient,
+  slackToken: string,
+  userId: string,
+  env: Env
+): Promise<void> {
+  try {
+    const event: AppHomeOpenedEvent = { type: 'app_home_opened', user: userId, tab: 'home' };
+    const homeCtx: HomeContext = { db, slackToken, env };
+    await handleAppHomeOpened(event, homeCtx);
+  } catch (err) {
+    console.error(`Failed to refresh App Home for ${userId}:`, err);
+  }
+}

--- a/lib/linear-intelligence.ts
+++ b/lib/linear-intelligence.ts
@@ -1,0 +1,128 @@
+/**
+ * Linear Intelligence — Phase 1 & 2
+ * Pure data transformation: plan-vs-Linear cross-reference and priority alignment.
+ * No Slack or DB dependencies.
+ */
+
+import { WorkItem } from './db';
+import { LinearIssue, extractLinearReferences } from './linear';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface AlignmentResult {
+  slackUserId: string;
+  plansNotInLinear: string[];       // manual plan item texts with no Linear match
+  linearNotInPlans: LinearIssue[];  // assigned issues missing from plans
+  priorityAlignment: 'on-track' | 'off-track';
+  missedHighPriority: LinearIssue[]; // urgent/high items not in plans
+}
+
+// ============================================================================
+// Core Matching
+// ============================================================================
+
+/**
+ * Match a work item to a Linear issue.
+ * Rules (in priority order):
+ *   1. item.source === 'linear_ticket' AND item.source_ref === issue.identifier
+ *   2. item.source === 'manual' AND extractLinearReferences(item.text) contains issue.identifier
+ *   3. github_pr items never match (excluded)
+ */
+export function matchItemToIssue(
+  item: WorkItem,
+  issues: LinearIssue[]
+): LinearIssue | null {
+  if (item.source === 'github_pr') return null;
+
+  if (item.source === 'linear_ticket' && item.source_ref) {
+    return issues.find(i => i.identifier === item.source_ref) ?? null;
+  }
+
+  if (item.source === 'manual') {
+    const refs = extractLinearReferences(item.text);
+    if (refs.length > 0) {
+      return issues.find(i => refs.includes(i.identifier)) ?? null;
+    }
+  }
+
+  return null;
+}
+
+// ============================================================================
+// Priority Alignment
+// ============================================================================
+
+/**
+ * Check if high-priority Linear issues (priority <= 2, i.e. Urgent/High) are in today's plans.
+ * Priority 0 = No priority — treated as lowest, NOT high-priority.
+ */
+export function computePriorityAlignment(
+  workItems: WorkItem[],
+  linearIssues: LinearIssue[]
+): { status: 'on-track' | 'off-track'; missedHighPriority: LinearIssue[] } {
+  const highPriority = linearIssues.filter(i => i.priority >= 1 && i.priority <= 2);
+
+  if (highPriority.length === 0) {
+    return { status: 'on-track', missedHighPriority: [] };
+  }
+
+  // Build a set of all source_refs from work items for fast lookup
+  const coveredRefs = new Set<string>(
+    workItems
+      .filter(item => item.source_ref != null)
+      .map(item => item.source_ref as string)
+  );
+
+  const missed = highPriority.filter(issue => !coveredRefs.has(issue.identifier));
+
+  return {
+    status: missed.length > 0 ? 'off-track' : 'on-track',
+    missedHighPriority: missed,
+  };
+}
+
+// ============================================================================
+// Main Alignment Computation
+// ============================================================================
+
+/**
+ * Compute full plan-vs-Linear alignment for a single user.
+ *
+ * - plansNotInLinear: manual items that don't reference any assigned Linear issue
+ * - linearNotInPlans: assigned Linear issues not covered by any work item
+ * - priorityAlignment: whether all Urgent/High issues appear in plans
+ */
+export function computeLinearAlignment(
+  slackUserId: string,
+  workItems: WorkItem[],
+  linearIssues: LinearIssue[]
+): AlignmentResult {
+  // ---- linear not in plans ----
+  // For each Linear issue, check if any work item matches it
+  const linearNotInPlans: LinearIssue[] = linearIssues.filter(issue => {
+    return !workItems.some(item => {
+      const matched = matchItemToIssue(item, [issue]);
+      return matched !== null;
+    });
+  });
+
+  // ---- plans not in Linear ----
+  // For each manual work item, check if it matches any Linear issue
+  const plansNotInLinear: string[] = workItems
+    .filter(item => item.source === 'manual')
+    .filter(item => matchItemToIssue(item, linearIssues) === null)
+    .map(item => item.text);
+
+  // ---- priority alignment ----
+  const { status, missedHighPriority } = computePriorityAlignment(workItems, linearIssues);
+
+  return {
+    slackUserId,
+    plansNotInLinear,
+    linearNotInPlans,
+    priorityAlignment: status,
+    missedHighPriority,
+  };
+}

--- a/lib/linear.ts
+++ b/lib/linear.ts
@@ -435,6 +435,155 @@ export async function fetchTeamCycleData(
   }
 }
 
+// ============================================================================
+// Mutations & Utilities
+// ============================================================================
+
+export function extractLinearReferences(text: string): string[] {
+  const matches = text.match(/\b([A-Z]+-\d+)\b/g);
+  if (!matches) return [];
+  return [...new Set(matches)];
+}
+
+interface WorkflowStatesResponse {
+  team: {
+    states: {
+      nodes: Array<{ id: string; name: string; type: string }>;
+    };
+  };
+}
+
+const WORKFLOW_STATES_QUERY = `
+  query WorkflowStates($teamId: String!) {
+    team(id: $teamId) {
+      states {
+        nodes { id name type }
+      }
+    }
+  }
+`;
+
+export async function fetchWorkflowStates(
+  token: string,
+  teamId: string
+): Promise<Map<string, { id: string; name: string }>> {
+  const data = await linearQuery<WorkflowStatesResponse>(
+    token,
+    WORKFLOW_STATES_QUERY,
+    { teamId }
+  );
+  const map = new Map<string, { id: string; name: string }>();
+  for (const state of data.team.states.nodes) {
+    map.set(state.type, { id: state.id, name: state.name });
+  }
+  return map;
+}
+
+interface IssueUpdateResponse {
+  issueUpdate: { success: boolean };
+}
+
+const ISSUE_UPDATE_MUTATION = `
+  mutation IssueUpdate($issueId: String!, $stateId: String!) {
+    issueUpdate(id: $issueId, input: { stateId: $stateId }) {
+      success
+    }
+  }
+`;
+
+export async function updateIssueState(
+  token: string,
+  issueId: string,
+  stateId: string
+): Promise<boolean> {
+  const data = await linearQuery<IssueUpdateResponse>(
+    token,
+    ISSUE_UPDATE_MUTATION,
+    { issueId, stateId }
+  );
+  return data.issueUpdate.success;
+}
+
+export async function markIssuesInProgress(
+  token: string,
+  issueIds: string[],
+  inProgressStateId: string
+): Promise<{ updated: number; skipped: number }> {
+  let updated = 0;
+  let skipped = 0;
+  for (const issueId of issueIds) {
+    try {
+      const success = await updateIssueState(token, issueId, inProgressStateId);
+      if (success) {
+        updated++;
+      } else {
+        skipped++;
+      }
+    } catch (error) {
+      console.error(`Failed to update issue ${issueId}:`, error);
+      skipped++;
+    }
+  }
+  return { updated, skipped };
+}
+
+interface CommentCreateResponse {
+  commentCreate: { success: boolean };
+}
+
+const COMMENT_CREATE_MUTATION = `
+  mutation CommentCreate($issueId: String!, $body: String!) {
+    commentCreate(input: { issueId: $issueId, body: $body }) {
+      success
+    }
+  }
+`;
+
+export async function commentOnIssue(
+  token: string,
+  issueId: string,
+  body: string
+): Promise<boolean> {
+  const data = await linearQuery<CommentCreateResponse>(
+    token,
+    COMMENT_CREATE_MUTATION,
+    { issueId, body }
+  );
+  return data.commentCreate.success;
+}
+
+interface IssueByIdentifierResponse {
+  issue: { id: string; identifier: string } | null;
+}
+
+const ISSUE_BY_IDENTIFIER_QUERY = `
+  query IssueByIdentifier($id: String!) {
+    issue(id: $id) { id identifier }
+  }
+`;
+
+export async function resolveIdentifiers(
+  token: string,
+  identifiers: string[]
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  for (const identifier of identifiers) {
+    try {
+      const data = await linearQuery<IssueByIdentifierResponse>(
+        token,
+        ISSUE_BY_IDENTIFIER_QUERY,
+        { id: identifier }
+      );
+      if (data.issue) {
+        map.set(data.issue.identifier, data.issue.id);
+      }
+    } catch (error) {
+      console.error(`Failed to resolve identifier ${identifier}:`, error);
+    }
+  }
+  return map;
+}
+
 /**
  * Calculate cycle progress from a list of issues
  */

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -116,7 +116,8 @@ export function buildStandupModal(
   doneIdentifiers?: Set<string>,
   autoCompletedIds?: Set<string>,
   mergedPRs?: MergedPR[],
-  sections?: { blockers: boolean; unplanned: boolean }
+  sections?: { blockers: boolean; unplanned: boolean },
+  expandedSections?: Set<string>
 ): ModalView {
   const blocks: Block[] = [];
   const isFirstDay = !yesterday || yesterday.plans.length === 0;
@@ -253,8 +254,9 @@ export function buildStandupModal(
       }
     });
 
-    // Render grouped items with section labels when there are mixed sources
-    const hasMixedSources = [manualItems, prItems, linearItems].filter(g => g.length > 0).length > 1;
+    // Render grouped items with section labels when there are mixed sources (and enough items to warrant it)
+    const totalYesterdayItems = manualItems.length + prItems.length + linearItems.length;
+    const hasMixedSources = [manualItems, prItems, linearItems].filter(g => g.length > 0).length > 1 && totalYesterdayItems >= 4;
 
     const renderYesterdayItem = (plan: string, index: number) => {
       const isInProgress = yesterday?.inProgressCount != null && index < yesterday.inProgressCount;
@@ -465,7 +467,8 @@ export function buildStandupModal(
       case 'today_plans':
         // Integration checkboxes go right above today's plans
         if (linearIssues && linearIssues.length > 0) {
-          const displayIssues = linearIssues.slice(0, 10);
+          const linearLimit = expandedSections?.has('linear') ? 10 : 3;
+          const displayIssues = linearIssues.slice(0, linearLimit);
           const linearOptions = displayIssues.map((issue) => ({
             text: {
               type: 'mrkdwn' as const,
@@ -493,12 +496,15 @@ export function buildStandupModal(
               emoji: true,
             },
           });
-          if (linearIssues.length > 10) {
+          if (linearIssues.length > linearLimit) {
             blocks.push({
-              type: 'context',
+              type: 'actions',
+              block_id: 'linear_show_all',
               elements: [{
-                type: 'mrkdwn',
-                text: `_Showing 10 of ${linearIssues.length} assigned tickets_`,
+                type: 'button',
+                action_id: 'show_all_linear',
+                text: { type: 'plain_text', text: `Show all ${linearIssues.length} tickets`, emoji: true },
+                value: 'expand',
               }],
             });
           }
@@ -536,7 +542,8 @@ export function buildStandupModal(
             type: 'context',
             elements: [{ type: 'mrkdwn', text: '_PRs from teammates that need your review_' }],
           });
-          const reviewPRs = prData.reviewRequests.slice(0, 10);
+          const reviewsLimit = expandedSections?.has('reviews') ? 10 : 3;
+          const reviewPRs = prData.reviewRequests.slice(0, reviewsLimit);
           const reviewOptions = reviewPRs.map((pr) => {
             const repoMatch = pr.url.match(/github\.com\/[^/]+\/([^/]+)/);
             const repo = repoMatch?.[1] || 'unknown';
@@ -568,12 +575,15 @@ export function buildStandupModal(
               emoji: true,
             },
           });
-          if (prData.reviewRequests.length > 10) {
+          if (prData.reviewRequests.length > reviewsLimit) {
             blocks.push({
-              type: 'context',
+              type: 'actions',
+              block_id: 'reviews_show_all',
               elements: [{
-                type: 'mrkdwn',
-                text: `_Showing 10 of ${prData.reviewRequests.length} review requests_`,
+                type: 'button',
+                action_id: 'show_all_reviews',
+                text: { type: 'plain_text', text: `Show all ${prData.reviewRequests.length} review requests`, emoji: true },
+                value: 'expand',
               }],
             });
           }
@@ -617,7 +627,8 @@ export function buildStandupModal(
             prCategories[`${repo}#${pr.number}`] = 'draft';
             myPRsCategorized.push({ pr, category: 'Draft' });
           }
-          const displayMyPRs = myPRsCategorized.slice(0, 10);
+          const myPRsLimit = expandedSections?.has('my_prs') ? 10 : 3;
+          const displayMyPRs = myPRsCategorized.slice(0, myPRsLimit);
           const myPROptions = displayMyPRs.map(({ pr, category, descSuffix }) => {
             const repoMatch = pr.url.match(/github\.com\/[^/]+\/([^/]+)/);
             const repo = repoMatch?.[1] || 'unknown';
@@ -651,12 +662,15 @@ export function buildStandupModal(
             },
           });
           const totalMyPRs = prData.awaitingReview.length + prData.readyToMerge.length + prData.draftPRs.length;
-          if (totalMyPRs > 10) {
+          if (totalMyPRs > myPRsLimit) {
             blocks.push({
-              type: 'context',
+              type: 'actions',
+              block_id: 'my_prs_show_all',
               elements: [{
-                type: 'mrkdwn',
-                text: `_Showing 10 of ${totalMyPRs} PRs_`,
+                type: 'button',
+                action_id: 'show_all_my_prs',
+                text: { type: 'plain_text', text: `Show all ${totalMyPRs} PRs`, emoji: true },
+                value: 'expand',
               }],
             });
           }

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -424,6 +424,7 @@ export function buildStandupModal(
 
   let unmappedReviewerLogins: string[] = [];
   const prReviewerTags: Record<string, string> = {};
+  const prCategories: Record<string, string> = {};
 
   // Render fields in order
   orderedFields.forEach((field, idx) => {
@@ -600,9 +601,22 @@ export function buildStandupModal(
               const repo = repoMatch?.[1] || 'unknown';
               prReviewerTags[`${repo}#${pr.number}`] = reviewerNames.join(', ');
             }
+            const repoMatchCat = pr.url.match(/github\.com\/[^/]+\/([^/]+)/);
+            const repoCat = repoMatchCat?.[1] || 'unknown';
+            prCategories[`${repoCat}#${pr.number}`] = 'awaiting review';
           }
-          for (const pr of prData.readyToMerge) myPRsCategorized.push({ pr, category: 'Ready to Merge' });
-          for (const pr of prData.draftPRs) myPRsCategorized.push({ pr, category: 'Draft' });
+          for (const pr of prData.readyToMerge) {
+            const repoMatch = pr.url.match(/github\.com\/[^/]+\/([^/]+)/);
+            const repo = repoMatch?.[1] || 'unknown';
+            prCategories[`${repo}#${pr.number}`] = 'ready to merge';
+            myPRsCategorized.push({ pr, category: 'Ready to Merge' });
+          }
+          for (const pr of prData.draftPRs) {
+            const repoMatch = pr.url.match(/github\.com\/[^/]+\/([^/]+)/);
+            const repo = repoMatch?.[1] || 'unknown';
+            prCategories[`${repo}#${pr.number}`] = 'draft';
+            myPRsCategorized.push({ pr, category: 'Draft' });
+          }
           const displayMyPRs = myPRsCategorized.slice(0, 10);
           const myPROptions = displayMyPRs.map(({ pr, category, descSuffix }) => {
             const repoMatch = pr.url.match(/github\.com\/[^/]+\/([^/]+)/);
@@ -745,6 +759,7 @@ export function buildStandupModal(
       ...(sections ? { sections } : {}),
       ...(unmappedReviewerLogins.length > 0 ? { unmappedReviewers: unmappedReviewerLogins } : {}),
       ...(Object.keys(prReviewerTags).length > 0 ? { prReviewerTags } : {}),
+      ...(Object.keys(prCategories).length > 0 ? { prCategories } : {}),
   });
   console.log(`private_metadata length: ${metadata.length}`);
 

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -190,18 +190,19 @@ export function buildStandupModal(
   // pre-checked integration items (currently none), and prefill today-plans (edit mode).
   // Free-text input in the plans textarea can't be observed here — the post-submit DM
   // covers that path.
-  const maxPlanItems = getMaxPlanItems();
+  const maxPlanItems = getMaxPlanItems(dailyName);
   if (maxPlanItems > 0) {
     const carryForwardCount = yesterdayPlans.length - (autoCompletedIds?.size || 0);
     const prefillCount = prefill?.todayPlans?.length || 0;
     const openTimeCount = carryForwardCount + prefillCount;
     if (openTimeCount >= maxPlanItems) {
       const dayWord = mode === 'tomorrow' ? 'for tomorrow' : 'today';
+      const breakdown = carryForwardCount > 0 && prefillCount > 0 ? ` (${prefillCount} new + ${carryForwardCount} carried)` : '';
       blocks.push({
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `⚠️ You're planning ${openTimeCount} items ${dayWord}. Teams usually stay under ${maxPlanItems} to keep the day focused.`,
+          text: `⚠️ You're planning ${openTimeCount} items${breakdown} ${dayWord}. Teams usually stay under ${maxPlanItems} to keep the day focused.`,
         },
       });
       blocks.push({ type: 'divider' });

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -115,7 +115,8 @@ export function buildStandupModal(
   reviewerMap?: Map<string, string>,
   doneIdentifiers?: Set<string>,
   autoCompletedIds?: Set<string>,
-  mergedPRs?: MergedPR[]
+  mergedPRs?: MergedPR[],
+  sections?: { blockers: boolean; unplanned: boolean }
 ): ModalView {
   const blocks: Block[] = [];
   const isFirstDay = !yesterday || yesterday.plans.length === 0;
@@ -356,30 +357,31 @@ export function buildStandupModal(
     }
 
     // Unplanned completions - grouped with yesterday (both are "what happened")
-    const unplannedYesterdayElement: Record<string, unknown> = {
-      type: 'plain_text_input',
-      action_id: 'unplanned_input',
-      multiline: true,
-      placeholder: {
-        type: 'plain_text',
-        text: 'Fixed urgent prod bug\nHelped teammate with code review\nUnblocked design team',
-      },
-    };
-    // Pre-fill if editing existing submission
-    if (prefill?.unplanned && prefill.unplanned.length > 0) {
-      unplannedYesterdayElement.initial_value = prefill.unplanned.join('\n');
+    if (sections?.unplanned ?? true) {
+      const unplannedYesterdayElement: Record<string, unknown> = {
+        type: 'plain_text_input',
+        action_id: 'unplanned_input',
+        multiline: true,
+        placeholder: {
+          type: 'plain_text',
+          text: 'Fixed urgent prod bug\nHelped teammate with code review\nUnblocked design team',
+        },
+      };
+      if (prefill?.unplanned && prefill.unplanned.length > 0) {
+        unplannedYesterdayElement.initial_value = prefill.unplanned.join('\n');
+      }
+      blocks.push({
+        type: 'input',
+        block_id: 'unplanned',
+        optional: true,
+        element: unplannedYesterdayElement,
+        label: {
+          type: 'plain_text',
+          text: '✨ Unplanned wins',
+          emoji: true,
+        },
+      });
     }
-    blocks.push({
-      type: 'input',
-      block_id: 'unplanned',
-      optional: true,
-      element: unplannedYesterdayElement,
-      label: {
-        type: 'plain_text',
-        text: '✨ Unplanned wins',
-        emoji: true,
-      },
-    });
 
     blocks.push({ type: 'divider' });
   }
@@ -387,8 +389,11 @@ export function buildStandupModal(
   // Build ordered list of remaining fields (exclude unplanned if already shown above)
   const orderedFields: OrderedField[] = [];
 
+  const showUnplanned = sections?.unplanned ?? true;
+  const showBlockers = sections?.blockers ?? true;
+
   // Only add unplanned to ordered fields if this is first day (wasn't shown above)
-  if (isFirstDay) {
+  if (isFirstDay && showUnplanned) {
     orderedFields.push({ type: 'unplanned', order: order.unplanned });
   }
 
@@ -399,7 +404,9 @@ export function buildStandupModal(
   if (prData && (prData.awaitingReview.length + prData.readyToMerge.length + prData.draftPRs.length > 0)) {
     orderedFields.push({ type: 'my_prs', order: order.my_prs });
   }
-  orderedFields.push({ type: 'blockers', order: order.blockers });
+  if (showBlockers) {
+    orderedFields.push({ type: 'blockers', order: order.blockers });
+  }
 
   // Add custom questions with their indices
   customQuestions.forEach((question, index) => {
@@ -735,6 +742,7 @@ export function buildStandupModal(
       yesterdayPlans,
       mode,
       targetDate: targetDateStr,
+      ...(sections ? { sections } : {}),
       ...(unmappedReviewerLogins.length > 0 ? { unmappedReviewers: unmappedReviewerLogins } : {}),
       ...(Object.keys(prReviewerTags).length > 0 ? { prReviewerTags } : {}),
   });

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -4,7 +4,7 @@
  */
 
 import { Question, FieldOrder, getMaxPlanItems } from './config';
-import { UserPRData, GitHubPR } from './github';
+import { UserPRData, GitHubPR, MergedPR } from './github';
 import { LinearIssue } from './linear';
 
 // Re-export openModal from slack.ts for backward compatibility
@@ -114,11 +114,13 @@ export function buildStandupModal(
   prData?: UserPRData,
   reviewerMap?: Map<string, string>,
   doneIdentifiers?: Set<string>,
-  autoCompletedIds?: Set<string>
+  autoCompletedIds?: Set<string>,
+  mergedPRs?: MergedPR[]
 ): ModalView {
   const blocks: Block[] = [];
   const isFirstDay = !yesterday || yesterday.plans.length === 0;
-  const yesterdayPlans = yesterday?.plans || [];
+  // We may append merged PR plan items to this array later; keep it mutable
+  const yesterdayPlans: string[] = [...(yesterday?.plans || [])];
 
   // Deduplicate: extract integration IDs from yesterday's plans so we don't
   // show the same Linear tickets or GitHub PRs as both "yesterday" items and
@@ -314,6 +316,42 @@ export function buildStandupModal(
       }
       for (const { plan, index } of linearItems) {
         renderYesterdayItem(plan, index);
+      }
+    }
+
+    // Merged PRs auto-populate: add up to 5 new (non-duplicate) merged PRs as yesterday items
+    if (mergedPRs && mergedPRs.length > 0) {
+      const newMergedPRs = mergedPRs
+        .filter(pr => !yesterdayIntegrationIds.has(`${pr.repo}#${pr.number}`))
+        .slice(0, 5);
+
+      if (newMergedPRs.length > 0) {
+        if ([manualItems, prItems, linearItems].filter(g => g.length > 0).length > 0) {
+          blocks.push({
+            type: 'context',
+            elements: [{ type: 'mrkdwn', text: '*📦 Merged PRs*' }],
+          });
+        }
+        for (const pr of newMergedPRs) {
+          const planText = `[${pr.repo}#${pr.number}] ${pr.title}`;
+          // Append to yesterdayPlans so the submission handler can find it at this index
+          const index = yesterdayPlans.length;
+          yesterdayPlans.push(planText);
+          blocks.push({
+            type: 'section',
+            block_id: `yesterday_item_${index}`,
+            text: {
+              type: 'mrkdwn',
+              text: planText.length > 60 ? planText.substring(0, 57) + '...' : planText,
+            },
+            accessory: {
+              type: 'static_select',
+              action_id: `item_status_${index}`,
+              options: YESTERDAY_ITEM_OPTIONS,
+              initial_option: YESTERDAY_ITEM_OPTIONS[2], // Default to "Done" for merged PRs
+            },
+          });
+        }
       }
     }
 

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -221,6 +221,7 @@ export function buildStandupModal(
   }
 
   // Yesterday section: plans + unplanned (grouped as "what happened")
+  // Items are grouped by source: manual first, then PR items, then Linear items
   if (!isFirstDay && yesterdayPlans.length > 0) {
     blocks.push({
       type: 'section',
@@ -230,8 +231,28 @@ export function buildStandupModal(
       },
     });
 
-    // Add a dropdown for each yesterday's plan item
+    // Classify items by source for grouped display
+    const manualItems: Array<{ plan: string; index: number }> = [];
+    const prItems: Array<{ plan: string; index: number }> = [];
+    const linearItems: Array<{ plan: string; index: number }> = [];
+
     yesterdayPlans.forEach((plan, index) => {
+      const idMatch = plan.match(/^\[([^\]]+)\]\s/);
+      if (idMatch) {
+        if (idMatch[1].includes('#')) {
+          prItems.push({ plan, index });
+        } else {
+          linearItems.push({ plan, index });
+        }
+      } else {
+        manualItems.push({ plan, index });
+      }
+    });
+
+    // Render grouped items with section labels when there are mixed sources
+    const hasMixedSources = [manualItems, prItems, linearItems].filter(g => g.length > 0).length > 1;
+
+    const renderYesterdayItem = (plan: string, index: number) => {
       const isInProgress = yesterday?.inProgressCount != null && index < yesterday.inProgressCount;
       const linearId = plan.match(/^\[([^\]]+)\]\s/)?.[1];
       const isAutoCompleted = linearId && autoCompletedIds?.has(linearId);
@@ -254,7 +275,46 @@ export function buildStandupModal(
             : YESTERDAY_ITEM_OPTIONS[0],  // Carry over
         },
       });
-    });
+    };
+
+    // Manual items first
+    if (manualItems.length > 0) {
+      if (hasMixedSources) {
+        blocks.push({
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: '*✍️ Manual items*' }],
+        });
+      }
+      for (const { plan, index } of manualItems) {
+        renderYesterdayItem(plan, index);
+      }
+    }
+
+    // PR items
+    if (prItems.length > 0) {
+      if (hasMixedSources) {
+        blocks.push({
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: '*📦 PR items*' }],
+        });
+      }
+      for (const { plan, index } of prItems) {
+        renderYesterdayItem(plan, index);
+      }
+    }
+
+    // Linear items
+    if (linearItems.length > 0) {
+      if (hasMixedSources) {
+        blocks.push({
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: '*🎫 Linear items*' }],
+        });
+      }
+      for (const { plan, index } of linearItems) {
+        renderYesterdayItem(plan, index);
+      }
+    }
 
     // Unplanned completions - grouped with yesterday (both are "what happened")
     const unplannedYesterdayElement: Record<string, unknown> = {
@@ -425,7 +485,10 @@ export function buildStandupModal(
 
       case 'review_requests':
         if (prData) {
-          // PRs where others are requesting my review
+          blocks.push({
+            type: 'context',
+            elements: [{ type: 'mrkdwn', text: '_PRs from teammates that need your review_' }],
+          });
           const reviewPRs = prData.reviewRequests.slice(0, 10);
           const reviewOptions = reviewPRs.map((pr) => {
             const repoMatch = pr.url.match(/github\.com\/[^/]+\/([^/]+)/);
@@ -472,6 +535,10 @@ export function buildStandupModal(
 
       case 'my_prs':
         if (prData) {
+          blocks.push({
+            type: 'context',
+            elements: [{ type: 'mrkdwn', text: '_Your authored PRs — select to track in your standup_' }],
+          });
           // PRs I authored: awaiting review, ready to merge, draft
           const myPRsCategorized: Array<{ pr: GitHubPR; category: string; descSuffix?: string }> = [];
           for (const pr of prData.awaitingReview) {

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -5,11 +5,10 @@
  * - Tracks prompt status to avoid duplicate prompts
  */
 
-import { DbClient, Participant, getAllParticipants, getOrCreatePrompt, updatePromptSent, getCachedUser, upsertCachedUser, getActiveOOO, getUnpostedSubmissions, markSubmissionPosted, Submission, markItemsDone, markItemsDropped, incrementCarryCount, markItemsInProgress, createWorkItems, getGitHubUsername, getUsersWithGitHubLinks, wasReminderSent, recordReminderSent, getDmStandupPreference, getMissingSubmissions } from './db';
-import { getSchedule, getConfigError, getDaily, getDailies, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getReminderMinutesBefore, getNudgeMinutesBefore, getDigestTime } from './config';
+import { DbClient, Participant, getAllParticipants, getOrCreatePrompt, updatePromptSent, getCachedUser, upsertCachedUser, getActiveOOO, getUnpostedSubmissions, markSubmissionPosted, Submission, markItemsDone, markItemsDropped, incrementCarryCount, markItemsInProgress, createWorkItems, wasReminderSent, recordReminderSent, getDmStandupPreference, getMissingSubmissions } from './db';
+import { getSchedule, getConfigError, getDaily, getDailies, getGitHubConfig, getReminderMinutesBefore, getNudgeMinutesBefore, getDigestTime } from './config';
 import { getUserInfo, postMessage } from './slack';
 import { postStandupToChannel, sendStandupDM } from './format';
-import { fetchUserPRData, UserPRData } from './github';
 
 // ============================================================================
 // User Timezone with Caching
@@ -488,30 +487,6 @@ export async function runScheduledPosts(
 }
 
 /**
- * Build a map from GitHub login (lowercase) → Slack user ID
- * Combines config mappings + DB self-linked accounts (config takes precedence)
- */
-async function buildGitHubUserMap(
-  daily: ReturnType<typeof getDaily>,
-  db: DbClient
-): Promise<Map<string, string>> {
-  if (!daily) return new Map();
-  const map = new Map<string, string>();
-
-  const dbLinks = await getUsersWithGitHubLinks(db);
-  for (const link of dbLinks) {
-    map.set(link.githubUsername.toLowerCase(), link.slackUserId);
-  }
-
-  const configMappings = getGitHubUserMappings(daily);
-  for (const mapping of configMappings) {
-    map.set(mapping.githubUsername.toLowerCase(), mapping.slackUserId);
-  }
-
-  return map;
-}
-
-/**
  * Process a single scheduled submission
  */
 async function processScheduledSubmission(
@@ -576,31 +551,7 @@ async function processScheduledSubmission(
     return Array.isArray(val) ? val : JSON.parse(val as unknown as string);
   };
 
-  // Fetch GitHub PR data if integration is enabled
-  let prData: UserPRData | undefined;
-  let reviewerSlackMap: Map<string, string> | undefined;
   const githubConfig = getGitHubConfig(daily);
-  if (githubConfig && env) {
-    const githubToken = env[githubConfig.tokenEnvVar];
-    if (githubToken) {
-      // Get GitHub username: config mapping takes precedence over DB
-      let githubUsername = getGitHubUsernameFromConfig(daily, userId);
-      if (!githubUsername) {
-        githubUsername = await getGitHubUsername(db, userId);
-      }
-
-      if (githubUsername) {
-        try {
-          [prData, reviewerSlackMap] = await Promise.all([
-            fetchUserPRData(githubToken, githubUsername, githubConfig.org),
-            buildGitHubUserMap(daily, db),
-          ]);
-        } catch (error) {
-          console.error('Failed to fetch PR data for scheduled post:', error);
-        }
-      }
-    }
-  }
 
   const yesterdayInProgress = parseJsonbArray(submission.yesterday_in_progress);
 
@@ -620,8 +571,6 @@ async function processScheduledSubmission(
       customAnswers: submission.custom_answers || {},
       questions: daily.questions,
       fieldOrder: daily.field_order,
-      prData,
-      reviewerSlackMap,
       githubOrg: githubConfig?.org,
     }
   );
@@ -650,8 +599,6 @@ async function processScheduledSubmission(
         customAnswers: submission.custom_answers || {},
         questions: daily.questions,
         fieldOrder: daily.field_order,
-        prData,
-        reviewerSlackMap,
         githubOrg: githubConfig?.org,
       });
     }

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -622,6 +622,7 @@ async function processScheduledSubmission(
       fieldOrder: daily.field_order,
       prData,
       reviewerSlackMap,
+      githubOrg: githubConfig?.org,
     }
   );
 
@@ -651,6 +652,7 @@ async function processScheduledSubmission(
         fieldOrder: daily.field_order,
         prData,
         reviewerSlackMap,
+        githubOrg: githubConfig?.org,
       });
     }
   } catch (error) {

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -5,8 +5,8 @@
  * - Tracks prompt status to avoid duplicate prompts
  */
 
-import { DbClient, Participant, getAllParticipants, getOrCreatePrompt, updatePromptSent, getCachedUser, upsertCachedUser, getActiveOOO, getUnpostedSubmissions, markSubmissionPosted, Submission, markItemsDone, markItemsDropped, incrementCarryCount, markItemsInProgress, createWorkItems, getGitHubUsername, getUsersWithGitHubLinks, wasReminderSent, recordReminderSent, getDmStandupPreference } from './db';
-import { getSchedule, getConfigError, getDaily, getDailies, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getReminderMinutesBefore } from './config';
+import { DbClient, Participant, getAllParticipants, getOrCreatePrompt, updatePromptSent, getCachedUser, upsertCachedUser, getActiveOOO, getUnpostedSubmissions, markSubmissionPosted, Submission, markItemsDone, markItemsDropped, incrementCarryCount, markItemsInProgress, createWorkItems, getGitHubUsername, getUsersWithGitHubLinks, wasReminderSent, recordReminderSent, getDmStandupPreference, getMissingSubmissions } from './db';
+import { getSchedule, getConfigError, getDaily, getDailies, getGitHubConfig, getGitHubUsernameFromConfig, getGitHubUserMappings, getReminderMinutesBefore, getNudgeMinutesBefore, getDigestTime } from './config';
 import { getUserInfo, postMessage } from './slack';
 import { postStandupToChannel, sendStandupDM } from './format';
 import { fetchUserPRData, UserPRData } from './github';
@@ -818,5 +818,89 @@ export async function runReminderCron(
   }
 
   console.log(`Reminder cron complete: ${stats.sent} sent, ${stats.skipped} skipped, ${stats.errors} errors`);
+  return stats;
+}
+
+// ============================================================================
+// Nudge Cron (per-user DM before digest time)
+// ============================================================================
+
+export async function runNudgeCron(
+  db: DbClient,
+  slackToken: string
+): Promise<{ sent: number; skipped: number; errors: number }> {
+  const stats = { sent: 0, skipped: 0, errors: 0 };
+
+  const configErr = getConfigError();
+  if (configErr) {
+    console.error('Nudge cron aborted due to config error:', configErr);
+    return stats;
+  }
+
+  const digestTime = getDigestTime();
+  const [digestHour, digestMinute] = digestTime.split(':').map(Number);
+  const digestUTCMinutes = digestHour * 60 + digestMinute;
+
+  const now = new Date();
+  const nowUTCMinutes = now.getUTCHours() * 60 + now.getUTCMinutes();
+
+  const dailies = getDailies();
+
+  for (const daily of dailies) {
+    try {
+      const nudgeMinutes = getNudgeMinutesBefore(daily);
+      if (nudgeMinutes === 0) {
+        stats.skipped++;
+        continue;
+      }
+
+      const schedule = getSchedule(daily.schedule);
+      if (!schedule?.timezone) {
+        stats.skipped++;
+        continue;
+      }
+
+      const localNow = getTimeInTimezone(schedule.timezone);
+      if (!isWorkday(schedule.days, localNow)) {
+        stats.skipped++;
+        continue;
+      }
+
+      const nudgeUTCMinutes = digestUTCMinutes - nudgeMinutes;
+      const diff = nowUTCMinutes - nudgeUTCMinutes;
+      if (diff < 0 || diff >= 30) {
+        stats.skipped++;
+        continue;
+      }
+
+      const todayStr = formatDate(localNow);
+      const missing = await getMissingSubmissions(db, daily.name, todayStr);
+      if (missing.length === 0) {
+        stats.skipped++;
+        continue;
+      }
+
+      for (const userId of missing) {
+        try {
+          const blocks = buildPromptBlocks(daily.name, 0);
+          const text = `⏰ The *${daily.name}* digest posts in ~${nudgeMinutes} minutes — don't forget your standup!`;
+          const sent = await postMessage(slackToken, userId, text, blocks);
+          if (sent) {
+            stats.sent++;
+          } else {
+            stats.errors++;
+          }
+        } catch (err) {
+          console.error(`Error sending nudge to ${userId} for ${daily.name}:`, err);
+          stats.errors++;
+        }
+      }
+    } catch (err) {
+      console.error(`Error in nudge cron for ${daily.name}:`, err);
+      stats.errors++;
+    }
+  }
+
+  console.log(`Nudge cron complete: ${stats.sent} sent, ${stats.skipped} skipped, ${stats.errors} errors`);
   return stats;
 }

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -117,6 +117,24 @@ export function parseUserId(text: string): string | null {
   return match ? match[1] : null;
 }
 
+/**
+ * Extract all unique Slack user IDs mentioned in a mrkdwn string.
+ * Matches <@U123> and <@U123|display-name> formats.
+ */
+export function extractMentionedUserIds(text: string): string[] {
+  const pattern = /<@(U[A-Z0-9]+)(?:\|[^>]*)?>/g;
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    if (!seen.has(match[1])) {
+      seen.add(match[1]);
+      ids.push(match[1]);
+    }
+  }
+  return ids;
+}
+
 // ============================================================================
 // Response Helpers
 // ============================================================================

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -320,6 +320,47 @@ export async function publishHomeView(
 }
 
 /**
+ * Update an existing message in a Slack channel
+ * @returns true if successful, false otherwise
+ */
+export async function updateMessage(
+  slackToken: string,
+  channel: string,
+  ts: string,
+  text: string,
+  blocks?: unknown[]
+): Promise<boolean> {
+  try {
+    const response = await fetch('https://slack.com/api/chat.update', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${slackToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        channel,
+        ts,
+        text,
+        blocks,
+        mrkdwn: true,
+      }),
+    });
+
+    const result = await response.json() as { ok: boolean; error?: string };
+
+    if (!result.ok) {
+      console.error('Failed to update message:', result.error);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Error updating message:', error);
+    return false;
+  }
+}
+
+/**
  * Get user info from Slack API (timezone data)
  */
 export async function getUserInfo(

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -303,6 +303,30 @@ export async function openModal(
 }
 
 /**
+ * Update an existing modal dialog
+ */
+export async function updateModal(
+  slackToken: string,
+  viewId: string,
+  view: unknown
+): Promise<boolean> {
+  const response = await fetch('https://slack.com/api/views.update', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${slackToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ view_id: viewId, view }),
+  });
+  const data = await response.json() as { ok: boolean; error?: string };
+  if (!data.ok) {
+    console.error('Failed to update modal:', data.error);
+    return false;
+  }
+  return true;
+}
+
+/**
  * Publish a view to App Home
  */
 export async function publishHomeView(

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -116,15 +116,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
+### Schedule-Aware Prompting ✅
+- [x] Read `schedule` config per-daily to determine working days
+- [x] Skip cron-triggered prompts on off-days (e.g., weekends)
+- [x] OOO and off-day logic combined: neither prompts nor counts as "missing"
+- [x] `/standup force-prompt` still works on off-days (manual override)
+- [x] Daily digest and OOO channel notices skip off-days (timezone-aware)
+
+---
+
 ## Up Next
-
-### Schedule-Aware Prompting
-Respect off-days in the daily schedule — don't prompt on weekends or other non-working days.
-
-- [ ] Read `schedule` config per-daily to determine working days
-- [ ] Skip cron-triggered prompts on off-days (e.g., weekends)
-- [ ] OOO and off-day logic combined: neither prompts nor counts as "missing"
-- [ ] `/standup force-prompt` still works on off-days (manual override)
 
 ### Visual Polish
 - [ ] Use `:white_check_mark:` / `:ballot_box_with_check:` for done items

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -140,16 +140,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
+### Team Summary Post ✅
+- [x] Post channel-level summary at digest time
+- [x] One line per person: name + top 1–2 plan items
+- [x] Blockers called out in a separate section
+- [x] Each line links to the person's full standup post (↗)
+- [x] Opt-in per-daily via `team_summary: true` config
+
+---
+
 ## Up Next
-
-### Team Summary Post
-Post a single consolidated summary to the daily channel with the key items from each team member's standup.
-
-- [ ] After all standups are in (or at digest time), post a channel-level summary
-- [ ] One line per person: name + top 1–2 items (highest-signal plans or blockers)
-- [ ] Blockers called out in a separate section so they're impossible to miss
-- [ ] Linkable: each person's line links to their full standup post in the thread
-- [ ] Configurable per-daily: opt-in via config toggle
 
 ### CI Pipeline
 - [ ] GitHub Actions for automated test runs

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -132,17 +132,15 @@ See `requirements.md` and `architecture.md`
 - [x] 🎯 for new plan items, ⚡ for unplanned items (was ☑️)
 - [x] Consistent emoji across standup post, App Home, and DM
 
+### Plan Size Warning (Follow-on) ✅
+- [x] Per-daily override: `max_plan_items` in daily config
+- [ ] Live validation (deferred — Slack modal limitations)
+- [x] Digest surfacing for users who routinely over-plan (avg plan count in team section)
+- [x] Distinguish net-new vs carried-over items in the count (breakdown in warning DM + modal)
+
 ---
 
 ## Up Next
-
-### Plan Size Warning (Follow-on)
-First Version shipped (see Shipped > Plan Size Warning). Remaining scope:
-
-- [ ] Per-daily override: `max_plan_items` in daily config
-- [ ] Live validation (warning updates as the user types/adds items)
-- [ ] Digest/report surfacing for users who routinely over-plan
-- [ ] Distinguish net-new vs carried-over items in the count
 
 ### Team Summary Post
 Post a single consolidated summary to the daily channel with the key items from each team member's standup.

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -97,17 +97,15 @@ See `requirements.md` and `architecture.md`
 - [x] App Home refreshes after submission so user sees plan immediately
 - [x] Source context per item (PR link, Linear ticket identifier) shown inline
 
+### Standup Modal Reorganization ✅
+- [x] Yesterday items grouped by source: manual → PR → Linear (with section headers when mixed)
+- [x] Clearer section headers: "✍️ Manual items", "📦 PR items", "🎫 Linear items"
+- [x] Context hints on PR and My PR sections explaining what each shows
+- [x] Reduced cognitive load through visual separation between source types
+
 ---
 
 ## Up Next
-
-### Standup Modal Reorganization
-Current modal is cluttered and mixes authored PRs with review requests without clear context.
-
-- [ ] Split "Yesterday" PRs into distinct groups: "My PRs" vs "PRs I reviewed"
-- [ ] Clearer section headers and visual separation between PR / Linear / manual items
-- [ ] Inline source hint per item (e.g., "from PR #123", "from LIN-456")
-- [ ] Reduce cognitive load — consider collapsible sections
 
 ### Readable Standup Post
 Give each line in the posted standup more context and make integration items actionable.

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -176,15 +176,15 @@ See `requirements.md` and `architecture.md`
 - [x] Store config overrides in DB (`config_overrides` table, takes precedence over YAML)
 - [x] Paused dailies shown with ⏸️ in `/standup list`
 
+### Force Prompt Command (Full) ✅
+- [x] `/standup force-prompt <daily>` - force prompt yourself
+- [x] `/standup prompt all <daily>` - admin command to prompt all participants
+- [x] Confirmation modal before mass-prompting (shows participant count)
+- [x] Summary DM: "Sent prompts to 7 users in daily-il"
+
 ---
 
 ## Planned
-
-### Force Prompt Command (Full)
-- [x] `/standup force-prompt <daily>` - force prompt yourself
-- [ ] `/standup prompt all <daily>` - admin command to prompt all participants
-- [ ] Confirmation step before mass-prompting
-- [ ] Show summary: "Sent prompts to 7 users"
 
 ### Admin Management
 - [ ] `/standup admin add @user` - add admin (super-admin only)

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -197,12 +197,15 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Planned
+### Remaining Stats & Analytics ✅
+- [x] Blocker streak tracking: consecutive days with blockers per user, surfaced in digest (🚧) and full report
+- [x] Unplanned overload alert: flag users with >70% unplanned work (⚡) in digest and report
+- [x] Unplanned rate trend comparison in full report Period Trends section
+- ~~Trend visualization (sparklines in Slack?)~~ — Skipped: Slack Block Kit doesn't support sparklines; existing ↑↓→ indicators are sufficient
 
-### Remaining Stats & Analytics
-- [ ] Blocker resolution time tracking
-- [ ] Trend visualization (sparklines in Slack?)
-- [ ] Unplanned overload alert (>70% unplanned work)
+---
+
+## Planned
 
 ### GitHub PR Filtering
 - [ ] Exclude PRs where user has commented and is awaiting author response

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -232,30 +232,33 @@ See `requirements.md` and `architecture.md`
 - [ ] Full integration context (live PR status, Linear ticket state) — deferred
 - [ ] Bidirectional sync from channel post edits — deferred (Slack limitation)
 
----
+### Linear Intelligence ✅
 
-## Planned
-
-### Linear Intelligence
-
-**Cross-Reference Plans vs Linear (Phase 1)** ✅
+**Cross-Reference Plans vs Linear**
 - [x] Match plan items to assigned Linear issues (source_ref exact match + text regex fallback)
 - [x] Flag in digest: "Plans not in Linear" and "Linear items not in plans"
 - [x] Gated on `intelligence.enabled: true` in daily config
 - [x] GitHub PR items excluded from "plans not in Linear"
-- [ ] Weekly report: plan-to-Linear alignment score per user
-- [ ] Configurable strictness: `off` / `soft` / `strict`
+- [ ] Weekly report: plan-to-Linear alignment score per user — deferred
+- [ ] Configurable strictness: `off` / `soft` / `strict` — deferred
 
-**Priority Alignment Reporting (Phase 2)** ✅
+**Priority Alignment Reporting**
 - [x] Compare active standup items against Linear priority ordering
 - [x] Digest: per-user alignment summary (on-track / off-track)
 - [x] Flags Urgent (P1) and High (P2) issues missing from plans
-- [ ] Individual DM: alignment report to off-track individuals
+- [ ] Individual DM: alignment report to off-track individuals — deferred
 
-**Auto-Update Items from Linear Status (Phase 3)**
-- [ ] Webhook or poll for Linear status changes on linked issues
-- [ ] Auto-mark standup items Done/In Progress based on Linear state
-- [ ] Notify user in DM when auto-updates happen
+**Auto-Update Items from Linear Status**
+- [x] Webhook endpoint (`POST /api/webhooks/linear`) for Linear status change events
+- [x] HMAC-SHA256 signature verification
+- [x] Auto-mark standup items Done/In Progress based on Linear state
+- [x] Notify user in DM when auto-updates happen
+- [x] Update channel post and refresh App Home after auto-update
+- [x] Gated on `intelligence.auto_update` config per-daily
+
+---
+
+## Planned
 
 ### GitHub Work Alignment
 - [ ] Compare "today's plans" keywords to commit messages/PR titles

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -222,18 +222,19 @@ See `requirements.md` and `architecture.md`
 - [x] Fire-and-forget: non-blocking, wrapped in try/catch so submission never fails due to Linear errors
 - [x] Full test coverage: 52 tests for all new Linear functions
 
+### App Home: Today's Tasks Management ✅
+- [x] Interactive task list in App Home with per-item overflow menus (done / in-progress / drop)
+- [x] Quick-add new items via modal (triggered by "Add Item" button)
+- [x] Mark items done / in-progress / drop from App Home
+- [x] Source tags shown per item (manual, PR, Linear)
+- [x] Real-time sync: changes in App Home update the standup post in the channel via chat.update
+- [x] Backward compat: JSONB fallback for submissions without work_item records
+- [ ] Full integration context (live PR status, Linear ticket state) — deferred
+- [ ] Bidirectional sync from channel post edits — deferred (Slack limitation)
+
 ---
 
 ## Planned
-
-### App Home: Today's Tasks Management
-View and manage today's standup items directly from the App Home tab.
-
-- [ ] Show today's planned items as an editable list in App Home
-- [ ] Quick-add new items inline
-- [ ] Mark items done / in-progress / drop from App Home
-- [ ] Show integration context (linked PR status, Linear ticket state) alongside each item
-- [ ] Real-time sync: changes in App Home reflect in the standup post (and vice versa)
 
 ### Linear Intelligence
 

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -149,10 +149,8 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Up Next
-
-### CI Pipeline
-- [ ] GitHub Actions for automated test runs
+### CI Pipeline ✅
+- [x] GitHub Actions workflow: type check + test on push/PR to main and dev
 
 ---
 

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -169,13 +169,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Planned
+### Dynamic Configuration ✅
+- [x] Hot-reload config changes without redeploying (DB overrides loaded per-request)
+- [x] Pause/resume dailies: `/standup pause <daily>` / `/standup resume <daily>`
+- [x] Admin command to reload config: `/standup config reload`
+- [x] Store config overrides in DB (`config_overrides` table, takes precedence over YAML)
+- [x] Paused dailies shown with ⏸️ in `/standup list`
 
-### Dynamic Configuration
-- [ ] Hot-reload config changes without redeploying
-- [ ] Pause/resume dailies via config flag (`enabled: false`)
-- [ ] Admin command to reload config: `/standup config reload`
-- [ ] Store config overrides in DB (takes precedence over YAML)
+---
+
+## Planned
 
 ### Force Prompt Command (Full)
 - [x] `/standup force-prompt <daily>` - force prompt yourself

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -90,6 +90,13 @@ See `requirements.md` and `architecture.md`
 - [x] Static warning copy; non-blocking; not dismissible
 - [x] Counts all plan items regardless of source (manual, PR, Linear)
 
+### App Home: Today's Plans ✅
+- [x] Show today's submitted plan items in the App Home tab (done / in-progress / planned / carried / dropped)
+- [x] DM copy defaults to off — App Home is the primary place to review your plan
+- [x] DM copy toggle still available in Preferences for users who prefer it
+- [x] App Home refreshes after submission so user sees plan immediately
+- [x] Source context per item (PR link, Linear ticket identifier) shown inline
+
 ---
 
 ## Up Next
@@ -139,6 +146,15 @@ First Version shipped (see Shipped > Plan Size Warning). Remaining scope:
 - [ ] Live validation (warning updates as the user types/adds items)
 - [ ] Digest/report surfacing for users who routinely over-plan
 - [ ] Distinguish net-new vs carried-over items in the count
+
+### Team Summary Post
+Post a single consolidated summary to the daily channel with the key items from each team member's standup.
+
+- [ ] After all standups are in (or at digest time), post a channel-level summary
+- [ ] One line per person: name + top 1–2 items (highest-signal plans or blockers)
+- [ ] Blockers called out in a separate section so they're impossible to miss
+- [ ] Linkable: each person's line links to their full standup post in the thread
+- [ ] Configurable per-daily: opt-in via config toggle
 
 ### CI Pipeline
 - [ ] GitHub Actions for automated test runs

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -108,17 +108,15 @@ See `requirements.md` and `architecture.md`
 - [x] Source icons: 📦 for PRs, 🎫 for Linear tickets; manual items unchanged
 - [x] Reader can tell at a glance where each item came from
 
+### Report OOO to Daily ✅
+- [x] Post OOO notice to daily channel when a user's OOO period begins (at digest time)
+- [x] Include OOO users in the daily digest (e.g., "Out today: @alice, @bob")
+- [x] Show return date alongside name
+- [ ] Optional per-daily toggle in config (deferred to Dynamic Configuration)
+
 ---
 
 ## Up Next
-
-### Report OOO to Daily
-Surface OOO status in the daily channel so the team sees who's out without checking `/standup list`.
-
-- [ ] Post OOO notice to daily channel when a user's OOO period begins
-- [ ] Include OOO users in the daily digest (e.g., "Out today: @alice, @bob")
-- [ ] Show return date alongside name
-- [ ] Optional per-daily toggle in config
 
 ### Schedule-Aware Prompting
 Respect off-days in the daily schedule — don't prompt on weekends or other non-working days.

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -184,17 +184,20 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Planned
+### Admin Management ✅
+- [x] `/standup admin add @user` - add admin (super-admin only)
+- [x] `/standup admin remove @user` - remove admin
+- [x] `/standup admin list` - show all admins (super-admins + DB admins)
+- [x] Super-admins defined in config (can manage other admins)
+- [x] DB admins stored via `config_overrides` table
+- [x] `/standup manager add <daily> @user` - admin assigns a daily manager
+- [x] `/standup manager remove <daily> @user` - admin removes a daily manager
+- [x] `/standup manager list <daily>` - show managers for a daily
+- [x] Daily managers merged from YAML + DB (deduplicated)
 
-### Admin Management
-- [ ] `/standup admin add @user` - add admin (super-admin only)
-- [ ] `/standup admin remove @user` - remove admin
-- [ ] `/standup admin list` - show all admins
-- [ ] Define super-admins in config (can manage other admins)
-- [ ] `/standup manager add <daily> @user` - admin assigns a daily manager
-- [ ] `/standup manager remove <daily> @user` - admin removes a daily manager
-- [ ] `/standup manager list <daily>` - show managers for a daily
-- [ ] Daily managers receive digest and report without being reporters
+---
+
+## Planned
 
 ### Remaining Stats & Analytics
 - [ ] Blocker resolution time tracking

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -125,13 +125,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Up Next
+### Visual Polish ✅
+- [x] ✅ for completed items (was ☑️)
+- [x] ➡️ for carried-over items (was ⬜)
+- [x] ❌ for dropped items (unchanged)
+- [x] 🎯 for new plan items, ⚡ for unplanned items (was ☑️)
+- [x] Consistent emoji across standup post, App Home, and DM
 
-### Visual Polish
-- [ ] Use `:white_check_mark:` / `:ballot_box_with_check:` for done items
-- [ ] Use `:arrow_right:` for continued items
-- [ ] Use `:x:` for dropped items
-- [ ] Consider emoji prefixes for plan items (🎯 planned, ⚡ unplanned)
+---
+
+## Up Next
 
 ### Plan Size Warning (Follow-on)
 First Version shipped (see Shipped > Plan Size Warning). Remaining scope:

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -256,14 +256,14 @@ See `requirements.md` and `architecture.md`
 - [x] Update channel post and refresh App Home after auto-update
 - [x] Gated on `intelligence.auto_update` config per-daily
 
----
-
-## Planned
-
-### GitHub Work Alignment
-- [ ] Compare "today's plans" keywords to commit messages/PR titles
-- [ ] Surface misalignment: "You said X but worked on Y"
-- [ ] Auto-populate yesterday's work from commits
+### GitHub Work Alignment ✅
+- [x] Compare "today's plans" keywords to merged PR titles (keyword overlap matching)
+- [x] Surface misalignment in manager digest: "plans without matching PRs" and "merged PRs unplanned"
+- [x] Auto-populate yesterday's work from merged PRs in standup modal
+- [x] GitHub Search API integration (`is:pr is:merged author:X org:Y`)
+- [x] Config: `intelligence.github.work_alignment` and `auto_populate` per-daily
+- [x] Dedup merged PRs against existing yesterday items by source_ref
+- [x] Cap auto-populated merged PRs at 5 (modal block limit)
 
 ---
 

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -214,11 +214,19 @@ See `requirements.md` and `architecture.md`
 
 ---
 
+### Linear Enhancements ✅
+- [x] Mark issues as "in progress" when selected as today's plan in standup modal
+- [x] Auto-resolve identifiers to Linear issue UUIDs via GraphQL API
+- [x] Fetch team workflow states to find correct "started" state ID
+- [x] Link blockers to Linear issues: extract references (e.g., ENG-123) from blockers text, post comment on the Linear issue
+- [x] Fire-and-forget: non-blocking, wrapped in try/catch so submission never fails due to Linear errors
+- [x] Full test coverage: 52 tests for all new Linear functions
+
+---
+
 ## Planned
 
-### Linear Enhancements
-- [ ] Mark issues as "in progress" when added to standup
-- [ ] Link blockers to Linear issues
+(No items currently planned)
 
 ---
 

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -205,12 +205,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
-## Planned
+### GitHub PR Filtering ✅
+- [x] Exclude PRs where reviewer already commented/reviewed and PR not updated since (ball in author's court)
+- [x] Hide PRs already approved by someone else (no action needed)
+- [x] "Ball in court" heuristic: reviewer's latest review timestamp vs PR's `updated_at`
+- [x] Fail-open design: if reviews can't be fetched, PR stays visible
+- [x] Extracted `fetchPRReviews()` helper, shared by review-request filtering and re-review detection
 
-### GitHub PR Filtering
-- [ ] Exclude PRs where user has commented and is awaiting author response
-- [ ] Only show review requests that actually need the user's action
-- [ ] Detect "ball in their court" vs "ball in your court" via comment recency
+---
+
+## Planned
 
 ### Linear Enhancements
 - [ ] Mark issues as "in progress" when added to standup

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -267,6 +267,35 @@ See `requirements.md` and `architecture.md`
 
 ---
 
+## Up Next
+
+### Blocker @-Mention Notifications ✅
+- [x] Detect `<@U...>` mentions in blocker text, DM mentioned participants
+- [x] Skip self-mentions and non-participants
+- [x] Today-mode only (no DMs for queued/tomorrow submissions)
+
+### Nudge Reminder
+- [ ] Per-daily `nudge_minutes_before` config (0 to disable, default 0)
+- [ ] DM participants who haven't submitted, N minutes before digest time
+- [ ] Respect OOO, paused dailies, non-workdays
+
+### Standup Templates
+- [ ] Per-daily `sections` config: toggle `blockers` and `unplanned` on/off
+- [ ] `today_plans` and `yesterday` always shown (locked)
+- [ ] Backward compatible defaults (all sections on)
+
+### Weekly Personal Recap DM
+- [ ] Friday DM to each participant: completed, carried, dropped, merged PRs, blockers
+- [ ] Per-daily `weekly_recap` config (default true)
+- [ ] Piggyback on existing weekly digest cron
+
+### Edit After Submit
+- [ ] "Edit Standup" button on channel post and App Home
+- [ ] Reopen modal pre-filled with today's plans/unplanned
+- [ ] Work item reconciliation on re-submit, channel post updated in place
+
+---
+
 ## Later
 
 ### Performance & Scaling

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -279,10 +279,10 @@ See `requirements.md` and `architecture.md`
 - [x] DM participants who haven't submitted, N minutes before digest time
 - [x] Respect OOO, paused dailies, non-workdays
 
-### Standup Templates
-- [ ] Per-daily `sections` config: toggle `blockers` and `unplanned` on/off
-- [ ] `today_plans` and `yesterday` always shown (locked)
-- [ ] Backward compatible defaults (all sections on)
+### Standup Templates ✅
+- [x] Per-daily `sections` config: toggle `blockers` and `unplanned` on/off
+- [x] `today_plans` and `yesterday` always shown (locked)
+- [x] Backward compatible defaults (all sections on)
 
 ### Weekly Personal Recap DM
 - [ ] Friday DM to each participant: completed, carried, dropped, merged PRs, blockers

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -103,17 +103,14 @@ See `requirements.md` and `architecture.md`
 - [x] Context hints on PR and My PR sections explaining what each shows
 - [x] Reduced cognitive load through visual separation between source types
 
+### Readable Standup Post ✅
+- [x] Integration items enriched with clickable links: PR items link to GitHub, Linear items to Linear
+- [x] Source icons: 📦 for PRs, 🎫 for Linear tickets; manual items unchanged
+- [x] Reader can tell at a glance where each item came from
+
 ---
 
 ## Up Next
-
-### Readable Standup Post
-Give each line in the posted standup more context and make integration items actionable.
-
-- [ ] Show source per line (e.g., "✅ Fix auth bug — _from PR #123_")
-- [ ] Clickable items: PR/Linear items link to source URL
-- [ ] Consistent source icons (GitHub vs Linear vs manual)
-- [ ] Reader can tell at a glance where each item came from
 
 ### Report OOO to Daily
 Surface OOO status in the daily channel so the team sees who's out without checking `/standup list`.

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -289,10 +289,10 @@ See `requirements.md` and `architecture.md`
 - [x] Per-daily `weekly_recap` config (default true)
 - [x] Piggyback on existing weekly digest cron
 
-### Edit After Submit
-- [ ] "Edit Standup" button on channel post and App Home
-- [ ] Reopen modal pre-filled with today's plans/unplanned
-- [ ] Work item reconciliation on re-submit, channel post updated in place
+### Edit After Submit ✅
+- [x] "Edit Standup" button on App Home (visible when today's submission exists)
+- [x] Reopen modal pre-filled with today's plans/unplanned/blockers
+- [x] Channel post updated in place on re-submit (no duplicate messages)
 
 ---
 

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -284,10 +284,10 @@ See `requirements.md` and `architecture.md`
 - [x] `today_plans` and `yesterday` always shown (locked)
 - [x] Backward compatible defaults (all sections on)
 
-### Weekly Personal Recap DM
-- [ ] Friday DM to each participant: completed, carried, dropped, merged PRs, blockers
-- [ ] Per-daily `weekly_recap` config (default true)
-- [ ] Piggyback on existing weekly digest cron
+### Weekly Personal Recap DM ✅
+- [x] Weekly DM to each participant: completed, carried, blockers
+- [x] Per-daily `weekly_recap` config (default true)
+- [x] Piggyback on existing weekly digest cron
 
 ### Edit After Submit
 - [ ] "Edit Standup" button on channel post and App Home

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -238,21 +238,24 @@ See `requirements.md` and `architecture.md`
 
 ### Linear Intelligence
 
-**Cross-Reference Plans vs Linear**
-- [ ] Match plan items to assigned Linear issues (fuzzy title match + issue ID)
-- [ ] Flag in digest: "Plans not in Linear" and "Linear items not in plans"
+**Cross-Reference Plans vs Linear (Phase 1)** ✅
+- [x] Match plan items to assigned Linear issues (source_ref exact match + text regex fallback)
+- [x] Flag in digest: "Plans not in Linear" and "Linear items not in plans"
+- [x] Gated on `intelligence.enabled: true` in daily config
+- [x] GitHub PR items excluded from "plans not in Linear"
 - [ ] Weekly report: plan-to-Linear alignment score per user
 - [ ] Configurable strictness: `off` / `soft` / `strict`
 
-**Auto-Update Items from Linear Status**
+**Priority Alignment Reporting (Phase 2)** ✅
+- [x] Compare active standup items against Linear priority ordering
+- [x] Digest: per-user alignment summary (on-track / off-track)
+- [x] Flags Urgent (P1) and High (P2) issues missing from plans
+- [ ] Individual DM: alignment report to off-track individuals
+
+**Auto-Update Items from Linear Status (Phase 3)**
 - [ ] Webhook or poll for Linear status changes on linked issues
 - [ ] Auto-mark standup items Done/In Progress based on Linear state
 - [ ] Notify user in DM when auto-updates happen
-
-**Priority Alignment Reporting**
-- [ ] Compare active standup items against Linear priority ordering
-- [ ] Digest: per-user alignment summary (on-track / off-track)
-- [ ] Individual DM: alignment report to off-track individuals
 
 ### GitHub Work Alignment
 - [ ] Compare "today's plans" keywords to commit messages/PR titles

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -161,17 +161,15 @@ See `requirements.md` and `architecture.md`
 - [x] Stale PR threshold override: `stale_pr_days` setting (default 3)
 - [x] Consolidated all settings under "⚙️ Settings" section in App Home
 
+### In-Progress Item Tracking (Full) ✅
+- [x] In-progress items auto-carry to today (no re-prompting needed)
+- [x] Track consecutive in-progress days per item in DB (`carry_count` increments daily)
+- [x] Items in-progress for 3+ days flagged as "needs attention" in digest (`🔄`) and report
+- [x] Visual indicator in standup post: `🔄 Day X` / `⚠️ Day X — needs attention`
+
 ---
 
 ## Planned
-
-### In-Progress Item Tracking (Full)
-Build on the existing in-progress status to add smart carry-over and attention flagging.
-
-- [ ] In-progress items auto-carry to today (no re-prompting needed)
-- [ ] Track consecutive in-progress days per item in DB
-- [ ] Items in-progress for 3+ days flagged as "needs attention" in digest and report
-- [ ] Visual indicator in standup post (e.g., 🔄 Day 3)
 
 ### Dynamic Configuration
 - [ ] Hot-reload config changes without redeploying

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -154,16 +154,16 @@ See `requirements.md` and `architecture.md`
 
 ---
 
+### User Settings Pane ✅
+- [x] Max items shown per list (PRs, Linear tickets) — per-user `max_items` setting
+- [x] OOO management UI (set/clear from App Home via date picker modal)
+- [x] Per-Linear-team filter: `linear_team_filter` setting
+- [x] Stale PR threshold override: `stale_pr_days` setting (default 3)
+- [x] Consolidated all settings under "⚙️ Settings" section in App Home
+
+---
+
 ## Planned
-
-### User Settings Pane
-Per-user self-service configuration in App Home (consolidates existing toggles + new controls).
-
-- [ ] Max items shown per list (PRs, Linear tickets) — in modal and standup post
-- [ ] OOO management UI (set/clear from App Home, currently command-only)
-- [ ] Per-Linear-team filter: which teams' cycles to include
-- [ ] Stale PR threshold override (default 3 days)
-- [ ] Consolidate existing DM-copy opt-out toggle into Settings section
 
 ### In-Progress Item Tracking (Full)
 Build on the existing in-progress status to add smart carry-over and attention flagging.

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -274,10 +274,10 @@ See `requirements.md` and `architecture.md`
 - [x] Skip self-mentions and non-participants
 - [x] Today-mode only (no DMs for queued/tomorrow submissions)
 
-### Nudge Reminder
-- [ ] Per-daily `nudge_minutes_before` config (0 to disable, default 0)
-- [ ] DM participants who haven't submitted, N minutes before digest time
-- [ ] Respect OOO, paused dailies, non-workdays
+### Nudge Reminder ✅
+- [x] Per-daily `nudge_minutes_before` config (0 to disable, default 0)
+- [x] DM participants who haven't submitted, N minutes before digest time
+- [x] Respect OOO, paused dailies, non-workdays
 
 ### Standup Templates
 - [ ] Per-daily `sections` config: toggle `blockers` and `unplanned` on/off

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -226,7 +226,37 @@ See `requirements.md` and `architecture.md`
 
 ## Planned
 
-(No items currently planned)
+### App Home: Today's Tasks Management
+View and manage today's standup items directly from the App Home tab.
+
+- [ ] Show today's planned items as an editable list in App Home
+- [ ] Quick-add new items inline
+- [ ] Mark items done / in-progress / drop from App Home
+- [ ] Show integration context (linked PR status, Linear ticket state) alongside each item
+- [ ] Real-time sync: changes in App Home reflect in the standup post (and vice versa)
+
+### Linear Intelligence
+
+**Cross-Reference Plans vs Linear**
+- [ ] Match plan items to assigned Linear issues (fuzzy title match + issue ID)
+- [ ] Flag in digest: "Plans not in Linear" and "Linear items not in plans"
+- [ ] Weekly report: plan-to-Linear alignment score per user
+- [ ] Configurable strictness: `off` / `soft` / `strict`
+
+**Auto-Update Items from Linear Status**
+- [ ] Webhook or poll for Linear status changes on linked issues
+- [ ] Auto-mark standup items Done/In Progress based on Linear state
+- [ ] Notify user in DM when auto-updates happen
+
+**Priority Alignment Reporting**
+- [ ] Compare active standup items against Linear priority ordering
+- [ ] Digest: per-user alignment summary (on-track / off-track)
+- [ ] Individual DM: alignment report to off-track individuals
+
+### GitHub Work Alignment
+- [ ] Compare "today's plans" keywords to commit messages/PR titles
+- [ ] Surface misalignment: "You said X but worked on Y"
+- [ ] Auto-populate yesterday's work from commits
 
 ---
 
@@ -248,38 +278,6 @@ See `requirements.md` and `architecture.md`
 - [ ] DB-stored manager list (supplements config `managers`)
 - [ ] `digest_recipients` and `report_recipients` config arrays per daily (optional override)
 - [ ] Self-subscribe command: `/standup subscribe <daily> digest|report`
-
-### App Home: Today's Tasks Management
-View and manage today's standup items directly from the App Home tab.
-
-- [ ] Show today's planned items as an editable list in App Home
-- [ ] Quick-add new items inline
-- [ ] Mark items done / in-progress / drop from App Home
-- [ ] Show integration context (linked PR status, Linear ticket state) alongside each item
-- [ ] Real-time sync: changes in App Home reflect in the standup post (and vice versa)
-
-### GitHub Work Alignment
-- [ ] Compare "today's plans" keywords to commit messages/PR titles
-- [ ] Surface misalignment: "You said X but worked on Y"
-- [ ] Auto-populate yesterday's work from commits
-
-### Linear Intelligence
-
-**Cross-Reference Plans vs Linear**
-- [ ] Match plan items to assigned Linear issues (fuzzy title match + issue ID)
-- [ ] Flag in digest: "Plans not in Linear" and "Linear items not in plans"
-- [ ] Weekly report: plan-to-Linear alignment score per user
-- [ ] Configurable strictness: `off` / `soft` / `strict`
-
-**Auto-Update Items from Linear Status**
-- [ ] Webhook or poll for Linear status changes on linked issues
-- [ ] Auto-mark standup items Done/In Progress based on Linear state
-- [ ] Notify user in DM when auto-updates happen
-
-**Priority Alignment Reporting**
-- [ ] Compare active standup items against Linear priority ordering
-- [ ] Digest: per-user alignment summary (on-track / off-track)
-- [ ] Individual DM: alignment report to off-track individuals
 
 ---
 

--- a/schema.sql
+++ b/schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS submissions (
   slack_message_ts TEXT,      -- posted message ID
   yesterday_in_progress JSONB, -- ["item5"]
   posted BOOLEAN DEFAULT TRUE, -- false for scheduled (tomorrow) submissions
+  items_normalized BOOLEAN NOT NULL DEFAULT FALSE,
   UNIQUE(slack_user_id, daily_name, date)
 );
 
@@ -67,7 +68,21 @@ CREATE TABLE IF NOT EXISTS work_items (
   carry_count INTEGER NOT NULL DEFAULT 0,
   completed_date DATE,
   snoozed_until DATE,  -- null = not snoozed, date = hidden from bottlenecks until this date
-  submission_id INTEGER REFERENCES submissions(id) ON DELETE SET NULL
+  submission_id INTEGER REFERENCES submissions(id) ON DELETE SET NULL,
+  source TEXT NOT NULL DEFAULT 'manual',  -- manual, github_pr, linear_ticket
+  source_ref TEXT,   -- external ID: "repo#42", "ENG-123"
+  source_url TEXT,   -- full URL to external resource
+  item_type TEXT NOT NULL DEFAULT 'plan'  -- plan, unplanned
+);
+
+-- Link items to submissions with their role in that submission
+CREATE TABLE IF NOT EXISTS submission_items (
+  id SERIAL PRIMARY KEY,
+  submission_id INTEGER NOT NULL REFERENCES submissions(id) ON DELETE CASCADE,
+  work_item_id INTEGER NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+  role TEXT NOT NULL,  -- today_plan, unplanned, yesterday_completed, yesterday_incomplete, yesterday_in_progress, yesterday_dropped
+  position INTEGER NOT NULL DEFAULT 1,
+  UNIQUE(submission_id, work_item_id, role)
 );
 
 -- Channel reminder dedup log
@@ -86,6 +101,11 @@ CREATE TABLE IF NOT EXISTS reminder_log (
 -- ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS linear_user_id TEXT;
 -- ALTER TABLE submissions ADD COLUMN IF NOT EXISTS yesterday_in_progress JSONB;
 -- ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS dm_standup BOOLEAN DEFAULT TRUE;
+-- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'manual';
+-- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS source_ref TEXT;
+-- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS source_url TEXT;
+-- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS item_type TEXT NOT NULL DEFAULT 'plan';
+-- ALTER TABLE submissions ADD COLUMN IF NOT EXISTS items_normalized BOOLEAN NOT NULL DEFAULT FALSE;
 
 -- Out of Office periods
 CREATE TABLE IF NOT EXISTS ooo (
@@ -119,4 +139,8 @@ CREATE INDEX IF NOT EXISTS idx_slack_users_updated ON slack_users(updated_at);
 CREATE INDEX IF NOT EXISTS idx_work_items_user_daily ON work_items(slack_user_id, daily_name);
 CREATE INDEX IF NOT EXISTS idx_work_items_status ON work_items(status);
 CREATE INDEX IF NOT EXISTS idx_work_items_carry ON work_items(carry_count) WHERE carry_count >= 3;
+CREATE INDEX IF NOT EXISTS idx_work_items_source ON work_items(source) WHERE source <> 'manual';
+CREATE INDEX IF NOT EXISTS idx_work_items_source_ref ON work_items(source_ref) WHERE source_ref IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_submission_items_submission ON submission_items(submission_id);
+CREATE INDEX IF NOT EXISTS idx_submission_items_work_item ON submission_items(work_item_id);
 CREATE INDEX IF NOT EXISTS idx_ooo_lookup ON ooo(slack_user_id, daily_name, start_date, end_date);

--- a/schema.sql
+++ b/schema.sql
@@ -50,6 +50,9 @@ CREATE TABLE IF NOT EXISTS slack_users (
   github_username TEXT,  -- Optional: linked GitHub username for PR integration
   linear_user_id TEXT,   -- Optional: linked Linear user ID for ticket integration
   dm_standup BOOLEAN DEFAULT TRUE, -- Whether to send DM copy of standup posts
+  max_items INTEGER,               -- Max PRs/Linear tickets shown in modal & post (NULL = no limit)
+  stale_pr_days INTEGER,           -- Override stale PR threshold in days (NULL = use default 3)
+  linear_team_filter TEXT,         -- Comma-separated Linear team IDs to include (NULL = all)
   updated_at TIMESTAMP DEFAULT NOW()
 );
 

--- a/schema.sql
+++ b/schema.sql
@@ -94,18 +94,21 @@ CREATE TABLE IF NOT EXISTS reminder_log (
   UNIQUE(daily_name, date)
 );
 
--- Migration for existing databases:
--- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS snoozed_until DATE;
--- ALTER TABLE submissions ADD COLUMN IF NOT EXISTS posted BOOLEAN DEFAULT TRUE;
--- ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS github_username TEXT;
--- ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS linear_user_id TEXT;
--- ALTER TABLE submissions ADD COLUMN IF NOT EXISTS yesterday_in_progress JSONB;
--- ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS dm_standup BOOLEAN DEFAULT TRUE;
--- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'manual';
--- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS source_ref TEXT;
--- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS source_url TEXT;
--- ALTER TABLE work_items ADD COLUMN IF NOT EXISTS item_type TEXT NOT NULL DEFAULT 'plan';
--- ALTER TABLE submissions ADD COLUMN IF NOT EXISTS items_normalized BOOLEAN NOT NULL DEFAULT FALSE;
+-- Migrations (safe to re-run: all use IF NOT EXISTS)
+ALTER TABLE work_items ADD COLUMN IF NOT EXISTS snoozed_until DATE;
+ALTER TABLE submissions ADD COLUMN IF NOT EXISTS posted BOOLEAN DEFAULT TRUE;
+ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS github_username TEXT;
+ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS linear_user_id TEXT;
+ALTER TABLE submissions ADD COLUMN IF NOT EXISTS yesterday_in_progress JSONB;
+ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS dm_standup BOOLEAN DEFAULT TRUE;
+ALTER TABLE work_items ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'manual';
+ALTER TABLE work_items ADD COLUMN IF NOT EXISTS source_ref TEXT;
+ALTER TABLE work_items ADD COLUMN IF NOT EXISTS source_url TEXT;
+ALTER TABLE work_items ADD COLUMN IF NOT EXISTS item_type TEXT NOT NULL DEFAULT 'plan';
+ALTER TABLE submissions ADD COLUMN IF NOT EXISTS items_normalized BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS max_items INTEGER;
+ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS stale_pr_days INTEGER;
+ALTER TABLE slack_users ADD COLUMN IF NOT EXISTS linear_team_filter TEXT;
 
 -- Out of Office periods
 CREATE TABLE IF NOT EXISTS ooo (

--- a/schema.sql
+++ b/schema.sql
@@ -98,6 +98,17 @@ CREATE TABLE IF NOT EXISTS ooo (
   UNIQUE(slack_user_id, daily_name, start_date, end_date)
 );
 
+-- Config overrides (DB takes precedence over YAML)
+CREATE TABLE IF NOT EXISTS config_overrides (
+  id SERIAL PRIMARY KEY,
+  scope TEXT NOT NULL DEFAULT 'global',
+  key TEXT NOT NULL,
+  value JSONB NOT NULL,
+  updated_at TIMESTAMP DEFAULT NOW(),
+  updated_by TEXT,
+  UNIQUE(scope, key)
+);
+
 -- Indexes for common queries
 CREATE INDEX IF NOT EXISTS idx_participants_daily ON participants(daily_name);
 CREATE INDEX IF NOT EXISTS idx_submissions_date ON submissions(date);

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -10,7 +10,11 @@ vi.mock('../lib/config', () => ({
   getDaily: vi.fn(),
   getSchedule: vi.fn(),
   getDailies: vi.fn(),
+  getAllDailiesIncludingDisabled: vi.fn(),
+  isDailyEnabled: vi.fn(() => true),
   getConfigError: vi.fn(() => null),
+  clearConfigCache: vi.fn(),
+  loadConfigOverrides: vi.fn(() => Promise.resolve()),
 }));
 
 // Mock db module
@@ -29,6 +33,8 @@ vi.mock('../lib/db', () => ({
   setOOO: vi.fn(),
   clearOOO: vi.fn(),
   getUserOOO: vi.fn(() => []),
+  setConfigOverride: vi.fn(),
+  deleteConfigOverride: vi.fn(),
 }));
 
 // Mock slack module
@@ -66,8 +72,8 @@ import {
   CommandContext,
 } from '../lib/handlers/commands';
 
-import { isAdmin, getDaily, getSchedule, getDailies, getConfigError } from '../lib/config';
-import { addParticipant, removeParticipant, getParticipants, getSubmissionsInRange, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, setOOO, clearOOO, getUserOOO } from '../lib/db';
+import { isAdmin, getDaily, getSchedule, getDailies, getConfigError, getAllDailiesIncludingDisabled, isDailyEnabled, clearConfigCache, loadConfigOverrides } from '../lib/config';
+import { addParticipant, removeParticipant, getParticipants, getSubmissionsInRange, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, setOOO, clearOOO, getUserOOO, setConfigOverride, deleteConfigOverride } from '../lib/db';
 import { parseUserId, sendDM } from '../lib/slack';
 import { getUserTimezone, getUserDate, formatDate, sendPromptDM } from '../lib/prompt';
 import { formatManagerDigest } from '../lib/format';
@@ -183,7 +189,7 @@ describe('command handlers', () => {
 
   describe('handleList', () => {
     it('lists all dailies with participants when no name provided', async () => {
-      vi.mocked(getDailies).mockReturnValue([
+      vi.mocked(getAllDailiesIncludingDisabled).mockReturnValue([
         { name: 'daily-il', channel: '#il-standup' },
         { name: 'daily-us', channel: '#us-standup' },
       ] as any);
@@ -200,7 +206,7 @@ describe('command handlers', () => {
     });
 
     it('lists all dailies with participants when "all" provided', async () => {
-      vi.mocked(getDailies).mockReturnValue([
+      vi.mocked(getAllDailiesIncludingDisabled).mockReturnValue([
         { name: 'daily-il', channel: '#il-standup' },
       ] as any);
       vi.mocked(getParticipants).mockResolvedValue([{ slack_user_id: 'U111' }] as any);
@@ -493,7 +499,7 @@ describe('command handlers', () => {
     });
 
     it('routes list command', async () => {
-      vi.mocked(getDailies).mockReturnValue([]);
+      vi.mocked(getAllDailiesIncludingDisabled).mockReturnValue([]);
       const response = await handleCommand('list', createContext(['list']));
       expect(response.text).toContain('dailies');
     });
@@ -512,6 +518,93 @@ describe('command handlers', () => {
     it('routes week command (deprecated)', async () => {
       const response = await handleCommand('week', createContext(['week']));
       expect(response.text).toContain('deprecated');
+    });
+
+    it('routes config reload command', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getAllDailiesIncludingDisabled).mockReturnValue([
+        { name: 'daily-il' },
+      ] as any);
+      const response = await handleCommand('config', createContext(['config', 'reload']));
+      expect(response.text).toContain('Config reloaded');
+    });
+
+    it('routes pause command', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(isDailyEnabled).mockReturnValue(true);
+      const response = await handleCommand('pause', createContext(['pause', 'daily-il']));
+      expect(response.text).toContain('paused');
+      expect(setConfigOverride).toHaveBeenCalled();
+    });
+
+    it('routes resume command', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(isDailyEnabled).mockReturnValue(false);
+      const response = await handleCommand('resume', createContext(['resume', 'daily-il']));
+      expect(response.text).toContain('active');
+      expect(deleteConfigOverride).toHaveBeenCalled();
+    });
+  });
+
+  describe('dynamic configuration commands', () => {
+    it('config reload requires admin', async () => {
+      vi.mocked(isAdmin).mockReturnValue(false);
+      const response = await handleCommand('config', createContext(['config', 'reload']));
+      expect(response.text).toContain('admin');
+    });
+
+    it('pause requires admin', async () => {
+      vi.mocked(isAdmin).mockReturnValue(false);
+      const response = await handleCommand('pause', createContext(['pause', 'daily-il']));
+      expect(response.text).toContain('admin');
+    });
+
+    it('resume requires admin', async () => {
+      vi.mocked(isAdmin).mockReturnValue(false);
+      const response = await handleCommand('resume', createContext(['resume', 'daily-il']));
+      expect(response.text).toContain('admin');
+    });
+
+    it('pause requires daily name', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      const response = await handleCommand('pause', createContext(['pause']));
+      expect(response.text).toContain('Usage');
+    });
+
+    it('pause validates daily exists', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue(undefined);
+      const response = await handleCommand('pause', createContext(['pause', 'nonexistent']));
+      expect(response.text).toContain('Unknown daily');
+    });
+
+    it('pause shows message when already paused', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(isDailyEnabled).mockReturnValue(false);
+      const response = await handleCommand('pause', createContext(['pause', 'daily-il']));
+      expect(response.text).toContain('already paused');
+    });
+
+    it('resume shows message when already active', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(isDailyEnabled).mockReturnValue(true);
+      const response = await handleCommand('resume', createContext(['resume', 'daily-il']));
+      expect(response.text).toContain('already active');
+    });
+
+    it('list shows paused indicator', async () => {
+      vi.mocked(getAllDailiesIncludingDisabled).mockReturnValue([
+        { name: 'daily-il', channel: '#il-standup' },
+      ] as any);
+      vi.mocked(isDailyEnabled).mockReturnValue(false);
+      vi.mocked(getParticipants).mockResolvedValue([{ slack_user_id: 'U111' }] as any);
+
+      const response = await handleList(createContext(['list']));
+      expect(response.text).toContain('⏸️');
     });
   });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -624,6 +624,13 @@ describe('command handlers', () => {
       expect(response.text).toContain('Super-admins');
     });
 
+    it('admin list omits DB admins section when there are none', async () => {
+      vi.mocked(getAdmins).mockReturnValue({ superAdmins: ['U_SUPER'], dbAdmins: [] });
+      const response = await handleCommand('admin', createContext(['admin', 'list']));
+      expect(response.text).toContain('U_SUPER');
+      expect(response.text).not.toContain('Admins (added)');
+    });
+
     it('admin list works for non-super-admins', async () => {
       vi.mocked(getAdmins).mockReturnValue({ superAdmins: ['U_SUPER'], dbAdmins: [] });
       vi.mocked(isSuperAdmin).mockReturnValue(false);
@@ -651,6 +658,18 @@ describe('command handlers', () => {
       expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'global', 'admins', ['U_NEW'], 'U12345');
     });
 
+    it('admin add appends to existing DB admins list', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue('U_NEW');
+      vi.mocked(isAdmin).mockReturnValue(false);
+      vi.mocked(getOverride).mockReturnValue(['U_EXISTING_DB']);
+      vi.mocked(setConfigOverride).mockResolvedValue();
+      vi.mocked(loadConfigOverrides).mockResolvedValue();
+
+      await handleCommand('admin', createContext(['admin', 'add', '<@U_NEW>']));
+      expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'global', 'admins', ['U_EXISTING_DB', 'U_NEW'], 'U12345');
+    });
+
     it('admin add rejects if already admin', async () => {
       vi.mocked(isSuperAdmin).mockReturnValue(true);
       vi.mocked(parseUserId).mockReturnValue('U_EXISTING');
@@ -665,6 +684,14 @@ describe('command handlers', () => {
       vi.mocked(parseUserId).mockReturnValue(null);
 
       const response = await handleCommand('admin', createContext(['admin', 'add']));
+      expect(response.text).toContain('Usage');
+    });
+
+    it('admin remove requires user mention', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue(null);
+
+      const response = await handleCommand('admin', createContext(['admin', 'remove']));
       expect(response.text).toContain('Usage');
     });
 
@@ -696,6 +723,23 @@ describe('command handlers', () => {
       const response = await handleCommand('admin', createContext(['admin', 'remove', '<@U_UNKNOWN>']));
       expect(response.text).toContain('not a DB-added admin');
     });
+
+    it('admin remove rejects if override list is undefined (no DB admins ever added)', async () => {
+      vi.mocked(isSuperAdmin).mockImplementation((id) => id === 'U12345');
+      vi.mocked(parseUserId).mockReturnValue('U_UNKNOWN');
+      vi.mocked(getOverride).mockReturnValue(undefined);
+
+      const response = await handleCommand('admin', createContext(['admin', 'remove', '<@U_UNKNOWN>']));
+      expect(response.text).toContain('not a DB-added admin');
+    });
+
+    it('admin with unknown action returns usage', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(true);
+
+      const response = await handleCommand('admin', createContext(['admin', 'badaction']));
+      expect(response.text).toContain('Usage');
+      expect(response.text).toContain('admin');
+    });
   });
 
   describe('manager management', () => {
@@ -705,14 +749,14 @@ describe('command handlers', () => {
       expect(response.text).toContain('Only admins');
     });
 
-    it('manager list shows managers for a daily', async () => {
+    it('manager list shows managers for a daily as Slack mentions', async () => {
       vi.mocked(isAdmin).mockReturnValue(true);
       vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
       vi.mocked(getDailyManagers).mockReturnValue(['U_MGR1', 'U_MGR2']);
 
       const response = await handleCommand('manager', createContext(['manager', 'list', 'daily-il']));
-      expect(response.text).toContain('U_MGR1');
-      expect(response.text).toContain('U_MGR2');
+      expect(response.text).toContain('<@U_MGR1>');
+      expect(response.text).toContain('<@U_MGR2>');
     });
 
     it('manager list shows empty message', async () => {
@@ -751,6 +795,19 @@ describe('command handlers', () => {
       expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'daily-il', 'managers', ['U_NEW_MGR'], 'U12345');
     });
 
+    it('manager add appends to existing DB managers list', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockImplementation((text) => text.includes('<@') ? 'U_NEW_MGR' : null);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getDailyManagers).mockReturnValue(['U_YAML_MGR']);
+      vi.mocked(getOverride).mockReturnValue(['U_YAML_MGR']);
+      vi.mocked(setConfigOverride).mockResolvedValue();
+      vi.mocked(loadConfigOverrides).mockResolvedValue();
+
+      await handleCommand('manager', createContext(['manager', 'add', 'daily-il', '<@U_NEW_MGR>']));
+      expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'daily-il', 'managers', ['U_YAML_MGR', 'U_NEW_MGR'], 'U12345');
+    });
+
     it('manager add rejects duplicate', async () => {
       vi.mocked(isAdmin).mockReturnValue(true);
       vi.mocked(parseUserId).mockReturnValue('U_EXISTING_MGR');
@@ -759,6 +816,23 @@ describe('command handlers', () => {
 
       const response = await handleCommand('manager', createContext(['manager', 'add', 'daily-il', '<@U_EXISTING_MGR>']));
       expect(response.text).toContain('already a manager');
+    });
+
+    it('manager add requires daily name and user mention', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue(null);
+
+      const response = await handleCommand('manager', createContext(['manager', 'add']));
+      expect(response.text).toContain('Usage');
+    });
+
+    it('manager add validates daily exists', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockImplementation((text) => text.includes('<@') ? 'U_NEW_MGR' : null);
+      vi.mocked(getDaily).mockReturnValue(undefined);
+
+      const response = await handleCommand('manager', createContext(['manager', 'add', 'nonexistent', '<@U_NEW_MGR>']));
+      expect(response.text).toContain('not found');
     });
 
     it('manager remove succeeds', async () => {
@@ -784,9 +858,43 @@ describe('command handlers', () => {
       expect(response.text).toContain('not a DB-added manager');
     });
 
+    it('manager remove rejects YAML-only managers (override undefined)', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockImplementation((text) => text.includes('<@') ? 'U_YAML_MGR' : null);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getOverride).mockReturnValue(undefined);
+
+      const response = await handleCommand('manager', createContext(['manager', 'remove', 'daily-il', '<@U_YAML_MGR>']));
+      expect(response.text).toContain('not a DB-added manager');
+      expect(response.text).toContain('YAML managers must be removed from config');
+    });
+
+    it('manager remove requires daily name and user mention', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue(null);
+
+      const response = await handleCommand('manager', createContext(['manager', 'remove']));
+      expect(response.text).toContain('Usage');
+    });
+
+    it('manager remove validates daily exists', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockImplementation((text) => text.includes('<@') ? 'U_MGR1' : null);
+      vi.mocked(getDaily).mockReturnValue(undefined);
+
+      const response = await handleCommand('manager', createContext(['manager', 'remove', 'nonexistent', '<@U_MGR1>']));
+      expect(response.text).toContain('not found');
+    });
+
     it('manager with no action shows usage', async () => {
       vi.mocked(isAdmin).mockReturnValue(true);
       const response = await handleCommand('manager', createContext(['manager']));
+      expect(response.text).toContain('Usage');
+    });
+
+    it('manager with unknown action shows usage', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      const response = await handleCommand('manager', createContext(['manager', 'badaction', 'daily-il']));
       expect(response.text).toContain('Usage');
     });
   });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -39,6 +39,8 @@ vi.mock('../lib/db', () => ({
   getUserOOO: vi.fn(() => []),
   setConfigOverride: vi.fn(),
   deleteConfigOverride: vi.fn(),
+  getBlockerStreaks: vi.fn(() => []),
+  getUnplannedOverload: vi.fn(() => []),
 }));
 
 // Mock slack module

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -7,9 +7,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock config module
 vi.mock('../lib/config', () => ({
   isAdmin: vi.fn(),
+  isSuperAdmin: vi.fn(),
+  getAdmins: vi.fn(() => ({ superAdmins: [], dbAdmins: [] })),
+  getOverride: vi.fn(() => undefined),
   getDaily: vi.fn(),
   getSchedule: vi.fn(),
   getDailies: vi.fn(),
+  getDailyManagers: vi.fn(() => []),
   getAllDailiesIncludingDisabled: vi.fn(),
   isDailyEnabled: vi.fn(() => true),
   getConfigError: vi.fn(() => null),
@@ -73,7 +77,7 @@ import {
   CommandContext,
 } from '../lib/handlers/commands';
 
-import { isAdmin, getDaily, getSchedule, getDailies, getConfigError, getAllDailiesIncludingDisabled, isDailyEnabled, clearConfigCache, loadConfigOverrides } from '../lib/config';
+import { isAdmin, isSuperAdmin, getAdmins, getOverride, getDaily, getSchedule, getDailies, getDailyManagers, getConfigError, getAllDailiesIncludingDisabled, isDailyEnabled, clearConfigCache, loadConfigOverrides } from '../lib/config';
 import { addParticipant, removeParticipant, getParticipants, getSubmissionsInRange, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, setOOO, clearOOO, getUserOOO, setConfigOverride, deleteConfigOverride } from '../lib/db';
 import { parseUserId, sendDM, openModal } from '../lib/slack';
 import { getUserTimezone, getUserDate, formatDate, sendPromptDM } from '../lib/prompt';
@@ -606,6 +610,182 @@ describe('command handlers', () => {
 
       const response = await handleList(createContext(['list']));
       expect(response.text).toContain('⏸️');
+    });
+  });
+
+  describe('admin management', () => {
+    it('admin list shows super-admins and db admins', async () => {
+      vi.mocked(getAdmins).mockReturnValue({ superAdmins: ['U_SUPER'], dbAdmins: ['U_DB1'] });
+      const response = await handleCommand('admin', createContext(['admin', 'list']));
+      expect(response.text).toContain('U_SUPER');
+      expect(response.text).toContain('U_DB1');
+      expect(response.text).toContain('Super-admins');
+    });
+
+    it('admin list works for non-super-admins', async () => {
+      vi.mocked(getAdmins).mockReturnValue({ superAdmins: ['U_SUPER'], dbAdmins: [] });
+      vi.mocked(isSuperAdmin).mockReturnValue(false);
+      const response = await handleCommand('admin', createContext(['admin', 'list']));
+      expect(response.text).toContain('U_SUPER');
+    });
+
+    it('admin add requires super-admin', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(false);
+      vi.mocked(parseUserId).mockReturnValue('U_NEW');
+      const response = await handleCommand('admin', createContext(['admin', 'add', '<@U_NEW>']));
+      expect(response.text).toContain('super-admin');
+    });
+
+    it('admin add succeeds for super-admin', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue('U_NEW');
+      vi.mocked(isAdmin).mockReturnValue(false);
+      vi.mocked(getOverride).mockReturnValue(undefined);
+      vi.mocked(setConfigOverride).mockResolvedValue();
+      vi.mocked(loadConfigOverrides).mockResolvedValue();
+
+      const response = await handleCommand('admin', createContext(['admin', 'add', '<@U_NEW>']));
+      expect(response.text).toContain('now an admin');
+      expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'global', 'admins', ['U_NEW'], 'U12345');
+    });
+
+    it('admin add rejects if already admin', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue('U_EXISTING');
+      vi.mocked(isAdmin).mockReturnValue(true);
+
+      const response = await handleCommand('admin', createContext(['admin', 'add', '<@U_EXISTING>']));
+      expect(response.text).toContain('already an admin');
+    });
+
+    it('admin add requires user mention', async () => {
+      vi.mocked(isSuperAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue(null);
+
+      const response = await handleCommand('admin', createContext(['admin', 'add']));
+      expect(response.text).toContain('Usage');
+    });
+
+    it('admin remove succeeds', async () => {
+      vi.mocked(isSuperAdmin).mockImplementation((id) => id === 'U12345');
+      vi.mocked(parseUserId).mockReturnValue('U_DB1');
+      vi.mocked(getOverride).mockReturnValue(['U_DB1', 'U_DB2']);
+      vi.mocked(setConfigOverride).mockResolvedValue();
+      vi.mocked(loadConfigOverrides).mockResolvedValue();
+
+      const response = await handleCommand('admin', createContext(['admin', 'remove', '<@U_DB1>']));
+      expect(response.text).toContain('no longer an admin');
+      expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'global', 'admins', ['U_DB2'], 'U12345');
+    });
+
+    it('admin remove rejects super-admin removal', async () => {
+      vi.mocked(isSuperAdmin).mockImplementation((id) => id === 'U_SUPER' || id === 'U12345');
+      vi.mocked(parseUserId).mockReturnValue('U_SUPER');
+
+      const response = await handleCommand('admin', createContext(['admin', 'remove', '<@U_SUPER>']));
+      expect(response.text).toContain('Cannot remove a super-admin');
+    });
+
+    it('admin remove rejects if not a DB admin', async () => {
+      vi.mocked(isSuperAdmin).mockImplementation((id) => id === 'U12345');
+      vi.mocked(parseUserId).mockReturnValue('U_UNKNOWN');
+      vi.mocked(getOverride).mockReturnValue([]);
+
+      const response = await handleCommand('admin', createContext(['admin', 'remove', '<@U_UNKNOWN>']));
+      expect(response.text).toContain('not a DB-added admin');
+    });
+  });
+
+  describe('manager management', () => {
+    it('manager commands require admin', async () => {
+      vi.mocked(isAdmin).mockReturnValue(false);
+      const response = await handleCommand('manager', createContext(['manager', 'list', 'daily-il']));
+      expect(response.text).toContain('Only admins');
+    });
+
+    it('manager list shows managers for a daily', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getDailyManagers).mockReturnValue(['U_MGR1', 'U_MGR2']);
+
+      const response = await handleCommand('manager', createContext(['manager', 'list', 'daily-il']));
+      expect(response.text).toContain('U_MGR1');
+      expect(response.text).toContain('U_MGR2');
+    });
+
+    it('manager list shows empty message', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getDailyManagers).mockReturnValue([]);
+
+      const response = await handleCommand('manager', createContext(['manager', 'list', 'daily-il']));
+      expect(response.text).toContain('no managers');
+    });
+
+    it('manager list requires daily name', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      const response = await handleCommand('manager', createContext(['manager', 'list']));
+      expect(response.text).toContain('Usage');
+    });
+
+    it('manager list validates daily exists', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue(undefined);
+      const response = await handleCommand('manager', createContext(['manager', 'list', 'fake']));
+      expect(response.text).toContain('not found');
+    });
+
+    it('manager add succeeds', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockImplementation((text) => text.includes('<@') ? 'U_NEW_MGR' : null);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getDailyManagers).mockReturnValue([]);
+      vi.mocked(getOverride).mockReturnValue(undefined);
+      vi.mocked(setConfigOverride).mockResolvedValue();
+      vi.mocked(loadConfigOverrides).mockResolvedValue();
+
+      const response = await handleCommand('manager', createContext(['manager', 'add', 'daily-il', '<@U_NEW_MGR>']));
+      expect(response.text).toContain('now a manager');
+      expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'daily-il', 'managers', ['U_NEW_MGR'], 'U12345');
+    });
+
+    it('manager add rejects duplicate', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue('U_EXISTING_MGR');
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getDailyManagers).mockReturnValue(['U_EXISTING_MGR']);
+
+      const response = await handleCommand('manager', createContext(['manager', 'add', 'daily-il', '<@U_EXISTING_MGR>']));
+      expect(response.text).toContain('already a manager');
+    });
+
+    it('manager remove succeeds', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockImplementation((text) => text.includes('<@') ? 'U_MGR1' : null);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getOverride).mockReturnValue(['U_MGR1', 'U_MGR2']);
+      vi.mocked(setConfigOverride).mockResolvedValue();
+      vi.mocked(loadConfigOverrides).mockResolvedValue();
+
+      const response = await handleCommand('manager', createContext(['manager', 'remove', 'daily-il', '<@U_MGR1>']));
+      expect(response.text).toContain('no longer a manager');
+      expect(setConfigOverride).toHaveBeenCalledWith(mockDb, 'daily-il', 'managers', ['U_MGR2'], 'U12345');
+    });
+
+    it('manager remove rejects if not a DB manager', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(parseUserId).mockReturnValue('U_YAML_MGR');
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getOverride).mockReturnValue([]);
+
+      const response = await handleCommand('manager', createContext(['manager', 'remove', 'daily-il', '<@U_YAML_MGR>']));
+      expect(response.text).toContain('not a DB-added manager');
+    });
+
+    it('manager with no action shows usage', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      const response = await handleCommand('manager', createContext(['manager']));
+      expect(response.text).toContain('Usage');
     });
   });
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -42,6 +42,7 @@ vi.mock('../lib/slack', () => ({
   parseUserId: vi.fn(),
   ephemeralResponse: vi.fn((text: string) => ({ response_type: 'ephemeral', text })),
   sendDM: vi.fn(),
+  openModal: vi.fn(() => Promise.resolve(true)),
 }));
 
 // Mock prompt module
@@ -74,7 +75,7 @@ import {
 
 import { isAdmin, getDaily, getSchedule, getDailies, getConfigError, getAllDailiesIncludingDisabled, isDailyEnabled, clearConfigCache, loadConfigOverrides } from '../lib/config';
 import { addParticipant, removeParticipant, getParticipants, getSubmissionsInRange, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, setOOO, clearOOO, getUserOOO, setConfigOverride, deleteConfigOverride } from '../lib/db';
-import { parseUserId, sendDM } from '../lib/slack';
+import { parseUserId, sendDM, openModal } from '../lib/slack';
 import { getUserTimezone, getUserDate, formatDate, sendPromptDM } from '../lib/prompt';
 import { formatManagerDigest } from '../lib/format';
 
@@ -605,6 +606,65 @@ describe('command handlers', () => {
 
       const response = await handleList(createContext(['list']));
       expect(response.text).toContain('⏸️');
+    });
+  });
+
+  describe('mass prompt (prompt all <daily>)', () => {
+    const createContextWithTrigger = (args: string[]): CommandContext => ({
+      userId: 'U12345',
+      args,
+      db: mockDb,
+      slackToken: mockToken,
+      triggerId: 'test-trigger-id',
+    });
+
+    it('requires admin', async () => {
+      vi.mocked(isAdmin).mockReturnValue(false);
+      const response = await handlePrompt(createContextWithTrigger(['prompt', 'all', 'daily-il']));
+      expect(response.text).toContain('admin');
+    });
+
+    it('validates daily exists', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue(undefined);
+      const response = await handlePrompt(createContextWithTrigger(['prompt', 'all', 'nonexistent']));
+      expect(response.text).toContain('not found');
+    });
+
+    it('shows error when no participants', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getParticipants).mockResolvedValue([]);
+      const response = await handlePrompt(createContextWithTrigger(['prompt', 'all', 'daily-il']));
+      expect(response.text).toContain('No participants');
+    });
+
+    it('opens confirmation modal with participant count', async () => {
+      vi.mocked(isAdmin).mockReturnValue(true);
+      vi.mocked(getDaily).mockReturnValue({ name: 'daily-il' } as any);
+      vi.mocked(getParticipants).mockResolvedValue([
+        { slack_user_id: 'U111' },
+        { slack_user_id: 'U222' },
+        { slack_user_id: 'U333' },
+      ] as any);
+
+      const response = await handlePrompt(createContextWithTrigger(['prompt', 'all', 'daily-il']));
+
+      expect(openModal).toHaveBeenCalled();
+      const modalCall = vi.mocked(openModal).mock.calls[0];
+      const view = modalCall[2] as any;
+      expect(view.callback_id).toBe('mass_prompt_confirm');
+      expect(view.blocks[0].text.text).toContain('3 participants');
+    });
+
+    it('falls through to self-prompt when only `prompt all` (no daily name)', async () => {
+      vi.mocked(getUserDailies).mockResolvedValue([
+        { daily_name: 'daily-il' },
+      ] as any);
+      vi.mocked(sendPromptDM).mockResolvedValue(true);
+
+      const response = await handlePrompt(createContextWithTrigger(['prompt', 'all']));
+      expect(response.text).toContain('Sent prompts for 1 dailies');
     });
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { loadConfigOverrides, getOverride, isDailyEnabled, clearConfigCache, clearOverridesCache, getDailies, getAllDailiesIncludingDisabled, getDailySections } from '../lib/config';
+import { loadConfigOverrides, getOverride, isDailyEnabled, clearConfigCache, clearOverridesCache, getDailies, getAllDailiesIncludingDisabled, getDailySections, getWeeklyRecap } from '../lib/config';
 
 describe('config overrides', () => {
   beforeEach(() => {
@@ -115,5 +115,17 @@ describe('getDailySections', () => {
     const result = getDailySections(daily);
     expect(result.blockers).toBe(false);
     expect(result.unplanned).toBe(true);
+  });
+});
+
+describe('getWeeklyRecap', () => {
+  it('defaults to true when not configured', () => {
+    const daily = { name: 'test', channel: 'C1', schedule: 's' } as any;
+    expect(getWeeklyRecap(daily)).toBe(true);
+  });
+
+  it('returns configured value', () => {
+    const daily = { name: 'test', channel: 'C1', schedule: 's', weekly_recap: false } as any;
+    expect(getWeeklyRecap(daily)).toBe(false);
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for lib/config.ts - Config overrides and dynamic configuration
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadConfigOverrides, getOverride, isDailyEnabled, clearConfigCache, clearOverridesCache, getDailies, getAllDailiesIncludingDisabled } from '../lib/config';
+
+describe('config overrides', () => {
+  beforeEach(() => {
+    clearConfigCache();
+  });
+
+  it('returns undefined when overrides not loaded', () => {
+    clearOverridesCache();
+    expect(getOverride('global', 'some_key')).toBeUndefined();
+  });
+
+  it('loads overrides from DB and retrieves them', async () => {
+    const mockDb = {
+      query: async () => [
+        { scope: 'daily-test', key: 'enabled', value: false },
+        { scope: 'global', key: 'digest_time', value: '16:00' },
+      ],
+    };
+
+    await loadConfigOverrides(mockDb);
+
+    expect(getOverride('daily-test', 'enabled')).toBe(false);
+    expect(getOverride('global', 'digest_time')).toBe('16:00');
+    expect(getOverride('global', 'nonexistent')).toBeUndefined();
+  });
+
+  it('isDailyEnabled returns false when override is false', async () => {
+    const mockDb = {
+      query: async () => [
+        { scope: 'daily-test', key: 'enabled', value: false },
+      ],
+    };
+
+    await loadConfigOverrides(mockDb);
+
+    expect(isDailyEnabled('daily-test')).toBe(false);
+    expect(isDailyEnabled('other-daily')).toBe(true);
+  });
+
+  it('isDailyEnabled defaults to true when no override', async () => {
+    const mockDb = { query: async () => [] };
+    await loadConfigOverrides(mockDb);
+
+    expect(isDailyEnabled('daily-test')).toBe(true);
+  });
+
+  it('getDailies filters out disabled dailies', async () => {
+    const all = getAllDailiesIncludingDisabled();
+    expect(all.length).toBeGreaterThanOrEqual(1);
+
+    const dailyToDisable = all[0].name;
+
+    const mockDb = {
+      query: async () => [
+        { scope: dailyToDisable, key: 'enabled', value: false },
+      ],
+    };
+
+    await loadConfigOverrides(mockDb);
+
+    const enabled = getDailies();
+    expect(enabled.length).toBe(all.length - 1);
+    expect(enabled.find(d => d.name === dailyToDisable)).toBeUndefined();
+  });
+
+  it('getAllDailiesIncludingDisabled returns all dailies regardless of enabled state', async () => {
+    const allBefore = getAllDailiesIncludingDisabled();
+
+    const mockDb = {
+      query: async () => [
+        { scope: allBefore[0].name, key: 'enabled', value: false },
+      ],
+    };
+
+    await loadConfigOverrides(mockDb);
+
+    const allAfter = getAllDailiesIncludingDisabled();
+    expect(allAfter.length).toBe(allBefore.length);
+  });
+
+  it('clearConfigCache clears overrides too', async () => {
+    const mockDb = {
+      query: async () => [
+        { scope: 'global', key: 'test', value: 'hello' },
+      ],
+    };
+
+    await loadConfigOverrides(mockDb);
+    expect(getOverride('global', 'test')).toBe('hello');
+
+    clearConfigCache();
+    expect(getOverride('global', 'test')).toBeUndefined();
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { loadConfigOverrides, getOverride, isDailyEnabled, clearConfigCache, clearOverridesCache, getDailies, getAllDailiesIncludingDisabled } from '../lib/config';
+import { loadConfigOverrides, getOverride, isDailyEnabled, clearConfigCache, clearOverridesCache, getDailies, getAllDailiesIncludingDisabled, getDailySections } from '../lib/config';
 
 describe('config overrides', () => {
   beforeEach(() => {
@@ -96,5 +96,24 @@ describe('config overrides', () => {
 
     clearConfigCache();
     expect(getOverride('global', 'test')).toBeUndefined();
+  });
+});
+
+describe('getDailySections', () => {
+  it('defaults both to true when sections not configured', () => {
+    const daily = { name: 'test', channel: 'C1', schedule: 's' } as any;
+    expect(getDailySections(daily)).toEqual({ blockers: true, unplanned: true });
+  });
+
+  it('returns configured values', () => {
+    const daily = { name: 'test', channel: 'C1', schedule: 's', sections: { blockers: false, unplanned: true } } as any;
+    expect(getDailySections(daily)).toEqual({ blockers: false, unplanned: true });
+  });
+
+  it('defaults missing fields to true', () => {
+    const daily = { name: 'test', channel: 'C1', schedule: 's', sections: { blockers: false } } as any;
+    const result = getDailySections(daily);
+    expect(result.blockers).toBe(false);
+    expect(result.unplanned).toBe(true);
   });
 });

--- a/tests/db-stats.test.ts
+++ b/tests/db-stats.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for stats-related pure functions in lib/db.ts
+ * Covers computeBlockerStreaks and the TS filtering logic of getUnplannedOverload
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the neon driver so db.ts can be imported without a real DB connection
+vi.mock('@neondatabase/serverless', () => ({
+  neon: vi.fn(() => vi.fn()),
+}));
+
+import { computeBlockerStreaks } from '../lib/db';
+
+describe('computeBlockerStreaks', () => {
+  it('returns empty array for empty input', () => {
+    expect(computeBlockerStreaks([])).toEqual([]);
+  });
+
+  it('returns empty array when single user has no blockers', () => {
+    const rows = [
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: false },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: false },
+    ];
+    expect(computeBlockerStreaks(rows)).toEqual([]);
+  });
+
+  it('single user, all blockers — current_streak = max_streak = total_blocker_days = N', () => {
+    const rows = [
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-03', has_blocker: true },
+    ];
+    const result = computeBlockerStreaks(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slack_user_id: 'U1',
+      current_streak: 3,
+      max_streak: 3,
+      total_blocker_days: 3,
+    });
+  });
+
+  it('single user, gap in middle — current_streak is trailing run, max_streak is longest', () => {
+    // blocker, clear, blocker, blocker — trailing run is 2, max was also 2... let's make it asymmetric
+    // blocker, blocker, blocker, clear, blocker, blocker
+    const rows = [
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-03', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-04', has_blocker: false },
+      { slack_user_id: 'U1', date: '2025-12-05', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-06', has_blocker: true },
+    ];
+    const result = computeBlockerStreaks(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slack_user_id: 'U1',
+      current_streak: 2,  // trailing run: Dec 5-6
+      max_streak: 3,      // longest run: Dec 1-3
+      total_blocker_days: 5,
+    });
+  });
+
+  it('single user, blockers then clear — current_streak = 0, max_streak is the earlier run', () => {
+    const rows = [
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-03', has_blocker: false },
+    ];
+    const result = computeBlockerStreaks(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slack_user_id: 'U1',
+      current_streak: 0,
+      max_streak: 2,
+      total_blocker_days: 2,
+    });
+  });
+
+  it('single blocker day — current_streak = max_streak = total = 1', () => {
+    const rows = [
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: false },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: true },
+    ];
+    const result = computeBlockerStreaks(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slack_user_id: 'U1',
+      current_streak: 1,
+      max_streak: 1,
+      total_blocker_days: 1,
+    });
+  });
+
+  it('multiple users — each gets independent streaks', () => {
+    const rows = [
+      // U1: 3-day streak then clear
+      { slack_user_id: 'U1', date: '2025-12-01', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-02', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-03', has_blocker: true },
+      { slack_user_id: 'U1', date: '2025-12-04', has_blocker: false },
+      // U2: no blockers — should be excluded
+      { slack_user_id: 'U2', date: '2025-12-01', has_blocker: false },
+      { slack_user_id: 'U2', date: '2025-12-02', has_blocker: false },
+      // U3: 1 blocker day, trailing
+      { slack_user_id: 'U3', date: '2025-12-01', has_blocker: false },
+      { slack_user_id: 'U3', date: '2025-12-02', has_blocker: true },
+    ];
+
+    const result = computeBlockerStreaks(rows);
+
+    // U2 excluded (no blockers)
+    expect(result).toHaveLength(2);
+
+    const u1 = result.find(r => r.slack_user_id === 'U1');
+    expect(u1).toMatchObject({
+      current_streak: 0,  // last entry is false
+      max_streak: 3,
+      total_blocker_days: 3,
+    });
+
+    const u3 = result.find(r => r.slack_user_id === 'U3');
+    expect(u3).toMatchObject({
+      current_streak: 1,
+      max_streak: 1,
+      total_blocker_days: 1,
+    });
+  });
+
+  it('only returns users with at least one blocker day', () => {
+    const rows = [
+      { slack_user_id: 'U_CLEAN', date: '2025-12-01', has_blocker: false },
+      { slack_user_id: 'U_BLOCKED', date: '2025-12-01', has_blocker: true },
+    ];
+    const result = computeBlockerStreaks(rows);
+    expect(result.map(r => r.slack_user_id)).toEqual(['U_BLOCKED']);
+  });
+});

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -52,8 +52,8 @@ describe('format utilities', () => {
       });
 
       const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
-      expect(yesterdayBlock?.text?.text).toContain('☑️ Finished task A');
-      expect(yesterdayBlock?.text?.text).toContain('☑️ Completed task B');
+      expect(yesterdayBlock?.text?.text).toContain('✅ Finished task A');
+      expect(yesterdayBlock?.text?.text).toContain('✅ Completed task B');
     });
 
     it('marks unplanned items with unplanned label', () => {
@@ -67,7 +67,7 @@ describe('format utilities', () => {
       });
 
       const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
-      expect(yesterdayBlock?.text?.text).toContain('☑️ Fixed urgent bug _(unplanned)_');
+      expect(yesterdayBlock?.text?.text).toContain('⚡ Fixed urgent bug _(unplanned)_');
     });
 
     it('marks dropped items with red X in yesterday section', () => {
@@ -82,7 +82,7 @@ describe('format utilities', () => {
       });
 
       const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
-      expect(yesterdayBlock?.text?.text).toContain('☑️ Finished task');
+      expect(yesterdayBlock?.text?.text).toContain('✅ Finished task');
       expect(yesterdayBlock?.text?.text).toContain('❌ Cancelled task _(dropped)_');
       expect(yesterdayBlock?.text?.text).toContain('❌ No longer needed _(dropped)_');
     });
@@ -100,7 +100,7 @@ describe('format utilities', () => {
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
       expect(todayBlock?.text?.text).toContain('🔄 WIP task _(in progress)_');
-      expect(todayBlock?.text?.text).toContain('⬜ New task');
+      expect(todayBlock?.text?.text).toContain('🎯 New task');
     });
 
     it('shows ⚠️ for in-progress items with carry_count >= 3', () => {
@@ -150,8 +150,8 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('⬜ Ongoing work _(carried over)_');
-      expect(todayBlock?.text?.text).toContain('⬜ New task');
+      expect(todayBlock?.text?.text).toContain('➡️ Ongoing work _(carried over)_');
+      expect(todayBlock?.text?.text).toContain('🎯 New task');
     });
 
     it('adds separator between carried over and new items', () => {
@@ -447,7 +447,7 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('⬜ Ship the feature');
+      expect(todayBlock?.text?.text).toContain('🎯 Ship the feature');
       expect(todayBlock?.text?.text).not.toContain('<http');
     });
   });

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -21,6 +21,7 @@ import {
   formatMemberPRSummary,
   formatTeamSummary,
   formatFullReport,
+  formatPersonalWeeklyRecap,
 } from '../lib/format';
 import type { TeamPRData } from '../lib/github';
 import type { TeamLinearData, CycleProgress } from '../lib/linear';
@@ -1967,6 +1968,127 @@ describe('format utilities', () => {
 
       expect(result).not.toContain('In progress — needs attention');
       expect(result).toContain('Stuck items');
+    });
+  });
+
+  describe('formatPersonalWeeklyRecap', () => {
+    it('shows "no standups" message when submissions array is empty', () => {
+      const result = formatPersonalWeeklyRecap('daily-il', []);
+      expect(result).toContain('No standups submitted this week');
+      expect(result).toContain('daily-il');
+    });
+
+    it('includes completed items from submissions', () => {
+      const submissions = [
+        {
+          id: 1, slack_user_id: 'U1', daily_name: 'daily-il', date: '2026-05-04',
+          submitted_at: new Date(), yesterday_completed: ['Fix auth bug', 'Write tests'],
+          yesterday_incomplete: null, yesterday_in_progress: null, unplanned: null,
+          today_plans: ['Deploy'], blockers: null, custom_answers: null,
+          slack_message_ts: null, posted: true, items_normalized: true,
+        },
+      ];
+
+      const result = formatPersonalWeeklyRecap('daily-il', submissions as any);
+      expect(result).toContain('✅ *Completed* (2)');
+      expect(result).toContain('Fix auth bug');
+      expect(result).toContain('Write tests');
+    });
+
+    it('includes carried items', () => {
+      const submissions = [
+        {
+          id: 1, slack_user_id: 'U1', daily_name: 'daily-il', date: '2026-05-04',
+          submitted_at: new Date(), yesterday_completed: null,
+          yesterday_incomplete: ['Stuck task'], yesterday_in_progress: null,
+          unplanned: null, today_plans: ['Deploy'], blockers: null,
+          custom_answers: null, slack_message_ts: null, posted: true, items_normalized: true,
+        },
+      ];
+
+      const result = formatPersonalWeeklyRecap('daily-il', submissions as any);
+      expect(result).toContain('➡️ *Still carrying* (1)');
+      expect(result).toContain('Stuck task');
+    });
+
+    it('includes blockers', () => {
+      const submissions = [
+        {
+          id: 1, slack_user_id: 'U1', daily_name: 'daily-il', date: '2026-05-04',
+          submitted_at: new Date(), yesterday_completed: null,
+          yesterday_incomplete: null, yesterday_in_progress: null,
+          unplanned: null, today_plans: ['Deploy'], blockers: 'Waiting on API access',
+          custom_answers: null, slack_message_ts: null, posted: true, items_normalized: true,
+        },
+      ];
+
+      const result = formatPersonalWeeklyRecap('daily-il', submissions as any);
+      expect(result).toContain('🚧 *Blockers reported* (1)');
+      expect(result).toContain('Waiting on API access');
+    });
+
+    it('deduplicates items across multiple submissions', () => {
+      const submissions = [
+        {
+          id: 1, slack_user_id: 'U1', daily_name: 'daily-il', date: '2026-05-04',
+          submitted_at: new Date(), yesterday_completed: ['Task A'],
+          yesterday_incomplete: null, yesterday_in_progress: null, unplanned: null,
+          today_plans: null, blockers: null, custom_answers: null,
+          slack_message_ts: null, posted: true, items_normalized: true,
+        },
+        {
+          id: 2, slack_user_id: 'U1', daily_name: 'daily-il', date: '2026-05-05',
+          submitted_at: new Date(), yesterday_completed: ['Task A', 'Task B'],
+          yesterday_incomplete: null, yesterday_in_progress: null, unplanned: null,
+          today_plans: null, blockers: null, custom_answers: null,
+          slack_message_ts: null, posted: true, items_normalized: true,
+        },
+      ];
+
+      const result = formatPersonalWeeklyRecap('daily-il', submissions as any);
+      expect(result).toContain('✅ *Completed* (2)');
+    });
+
+    it('shows submission count in header', () => {
+      const submissions = [
+        {
+          id: 1, slack_user_id: 'U1', daily_name: 'daily-il', date: '2026-05-04',
+          submitted_at: new Date(), yesterday_completed: ['A'], yesterday_incomplete: null,
+          yesterday_in_progress: null, unplanned: null, today_plans: null, blockers: null,
+          custom_answers: null, slack_message_ts: null, posted: true, items_normalized: true,
+        },
+        {
+          id: 2, slack_user_id: 'U1', daily_name: 'daily-il', date: '2026-05-05',
+          submitted_at: new Date(), yesterday_completed: null, yesterday_incomplete: null,
+          yesterday_in_progress: null, unplanned: null, today_plans: null, blockers: null,
+          custom_answers: null, slack_message_ts: null, posted: true, items_normalized: true,
+        },
+        {
+          id: 3, slack_user_id: 'U1', daily_name: 'daily-il', date: '2026-05-06',
+          submitted_at: new Date(), yesterday_completed: null, yesterday_incomplete: null,
+          yesterday_in_progress: null, unplanned: null, today_plans: null, blockers: null,
+          custom_answers: null, slack_message_ts: null, posted: true, items_normalized: true,
+        },
+      ];
+
+      const result = formatPersonalWeeklyRecap('daily-il', submissions as any);
+      expect(result).toContain('3 standups submitted this week');
+    });
+
+    it('caps completed items at 10', () => {
+      const completed = Array.from({ length: 15 }, (_, i) => `Task ${i + 1}`);
+      const submissions = [
+        {
+          id: 1, slack_user_id: 'U1', daily_name: 'daily-il', date: '2026-05-04',
+          submitted_at: new Date(), yesterday_completed: completed,
+          yesterday_incomplete: null, yesterday_in_progress: null, unplanned: null,
+          today_plans: null, blockers: null, custom_answers: null,
+          slack_message_ts: null, posted: true, items_normalized: true,
+        },
+      ];
+
+      const result = formatPersonalWeeklyRecap('daily-il', submissions as any);
+      expect(result).toContain('…and 5 more');
     });
   });
 });

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -197,8 +197,9 @@ describe('format utilities', () => {
         customAnswers: {},
       });
 
-      const blockersBlock = blocks.find(b => b.text?.text?.includes('Blockers'));
-      expect(blockersBlock?.text?.text).toContain('Waiting on API access from <@U99999>');
+      const blockersBlock = blocks.find(b => b.text?.text?.includes('🚧'));
+      expect(blockersBlock).toBeDefined();
+      expect(blockersBlock!.text!.text).toBe('🚧 Waiting on API access from <@U99999>');
     });
 
     it('excludes blockers section when empty', () => {
@@ -213,6 +214,21 @@ describe('format utilities', () => {
 
       const blockersBlock = blocks.find(b => b.text?.text?.includes('Blockers'));
       expect(blockersBlock).toBeUndefined();
+    });
+
+    it('prefixes each blocker line with 🚧 emoji', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: [],
+        yesterdayIncomplete: [],
+        yesterdayDropped: [],
+        unplanned: [],
+        todayPlans: ['Task A'],
+        blockers: 'Issue A\nIssue B\n\nIssue C',
+        customAnswers: {},
+      });
+      const blockerBlock = blocks.find(b => b.text?.text?.includes('🚧'));
+      expect(blockerBlock).toBeDefined();
+      expect(blockerBlock!.text!.text).toBe('🚧 Issue A\n🚧 Issue B\n🚧 Issue C');
     });
 
     it('includes custom answers', () => {
@@ -301,7 +317,7 @@ describe('format utilities', () => {
       const yesterdayIdx = findIndex('Yesterday');
       const todayIdx = findIndex('Today:');
       const questionMiddleIdx = findIndex('Question in middle');
-      const blockersIdx = findIndex('Blockers:');
+      const blockersIdx = findIndex('🚧');
 
       // Verify order: header, question@5, yesterday@10, today@20, question@25, blockers@30
       expect(headerIdx).toBe(0);
@@ -371,7 +387,7 @@ describe('format utilities', () => {
         b.text?.text?.includes('PRs to review?')
       );
       const blockersIdx = sectionBlocks.findIndex(b =>
-        b.text?.text?.includes('Blockers:')
+        b.text?.text?.includes('🚧')
       );
 
       // Question with order 999 should appear after blockers (order 30)

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -402,6 +402,54 @@ describe('format utilities', () => {
       expect(footer.type).toBe('context');
       expect(footer.elements?.[0]?.text).toContain('daily-il standup');
     });
+
+    it('enriches PR items with clickable GitHub links', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: ['[my-repo#42] Fix typo'],
+        yesterdayIncomplete: [],
+        unplanned: [],
+        todayPlans: ['[other-repo#99] Add feature'],
+        blockers: '',
+        customAnswers: {},
+        githubOrg: 'thenvoi',
+      });
+
+      const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
+      expect(yesterdayBlock?.text?.text).toContain('<https://github.com/thenvoi/my-repo/pull/42|📦 my-repo#42>');
+
+      const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
+      expect(todayBlock?.text?.text).toContain('<https://github.com/thenvoi/other-repo/pull/99|📦 other-repo#99>');
+    });
+
+    it('enriches Linear items with clickable Linear links', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: [],
+        yesterdayIncomplete: [],
+        unplanned: [],
+        todayPlans: ['[ENG-123] Fix auth bug'],
+        blockers: '',
+        customAnswers: {},
+      });
+
+      const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
+      expect(todayBlock?.text?.text).toContain('<https://linear.app/issue/ENG-123|🎫 ENG-123>');
+      expect(todayBlock?.text?.text).toContain('Fix auth bug');
+    });
+
+    it('leaves manual items unchanged (no enrichment)', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: [],
+        yesterdayIncomplete: [],
+        unplanned: [],
+        todayPlans: ['Ship the feature'],
+        blockers: '',
+        customAnswers: {},
+      });
+
+      const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
+      expect(todayBlock?.text?.text).toContain('⬜ Ship the feature');
+      expect(todayBlock?.text?.text).not.toContain('<http');
+    });
   });
 
   describe('formatDailyDigest', () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -54,9 +54,9 @@ describe('format utilities', () => {
         customAnswers: {},
       });
 
-      const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
-      expect(yesterdayBlock?.text?.text).toContain('✅ Finished task A');
-      expect(yesterdayBlock?.text?.text).toContain('✅ Completed task B');
+      const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday'));
+      expect(yesterdayBlock?.text?.text).toContain('*Yesterday*');
+      expect(yesterdayBlock?.text?.text).toContain('2 done');
     });
 
     it('marks unplanned items with unplanned label', () => {
@@ -69,8 +69,8 @@ describe('format utilities', () => {
         customAnswers: {},
       });
 
-      const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
-      expect(yesterdayBlock?.text?.text).toContain('⚡ Fixed urgent bug _(unplanned)_');
+      const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday'));
+      expect(yesterdayBlock?.text?.text).toContain('1 unplanned');
     });
 
     it('marks dropped items with red X in yesterday section', () => {
@@ -84,10 +84,9 @@ describe('format utilities', () => {
         customAnswers: {},
       });
 
-      const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
-      expect(yesterdayBlock?.text?.text).toContain('✅ Finished task');
-      expect(yesterdayBlock?.text?.text).toContain('❌ Cancelled task _(dropped)_');
-      expect(yesterdayBlock?.text?.text).toContain('❌ No longer needed _(dropped)_');
+      const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday'));
+      expect(yesterdayBlock?.text?.text).toContain('1 done');
+      expect(yesterdayBlock?.text?.text).toContain('2 dropped');
     });
 
     it('shows in-progress items with 🔄 emoji in today section', () => {
@@ -298,7 +297,7 @@ describe('format utilities', () => {
 
       const headerIdx = findIndex('submitted their standup');
       const questionStartIdx = findIndex('Question at start');
-      const yesterdayIdx = findIndex('Yesterday:');
+      const yesterdayIdx = findIndex('Yesterday');
       const todayIdx = findIndex('Today:');
       const questionMiddleIdx = findIndex('Question in middle');
       const blockersIdx = findIndex('Blockers:');
@@ -337,7 +336,7 @@ describe('format utilities', () => {
         b.text?.text?.includes("How're you feeling?")
       );
       const yesterdayIdx = sectionBlocks.findIndex(b =>
-        b.text?.text?.includes('Yesterday:')
+        b.text?.text?.includes('Yesterday')
       );
 
       // Question with order 5 should appear before yesterday (order 10)
@@ -400,7 +399,7 @@ describe('format utilities', () => {
         b.text?.text?.includes('Early question')
       );
       const yesterdayIdx = sectionBlocks.findIndex(b =>
-        b.text?.text?.includes('Yesterday:')
+        b.text?.text?.includes('Yesterday')
       );
       const todayIdx = sectionBlocks.findIndex(b =>
         b.text?.text?.includes('Today:')
@@ -425,7 +424,7 @@ describe('format utilities', () => {
 
       const sectionBlocks = blocks.filter(b => b.type === 'section');
       const todayIdx = sectionBlocks.findIndex(b => b.text?.text?.includes('Today:'));
-      const yesterdayIdx = sectionBlocks.findIndex(b => b.text?.text?.includes('Yesterday:'));
+      const yesterdayIdx = sectionBlocks.findIndex(b => b.text?.text?.includes('Yesterday'));
 
       expect(todayIdx).toBeGreaterThan(-1);
       expect(yesterdayIdx).toBeGreaterThan(-1);
@@ -457,9 +456,6 @@ describe('format utilities', () => {
         customAnswers: {},
         githubOrg: 'thenvoi',
       });
-
-      const yesterdayBlock = blocks.find(b => b.text?.text?.includes('Yesterday:'));
-      expect(yesterdayBlock?.text?.text).toContain('<https://github.com/thenvoi/my-repo/pull/42|📦 my-repo#42>');
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
       expect(todayBlock?.text?.text).toContain('<https://github.com/thenvoi/other-repo/pull/99|📦 other-repo#99>');

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1690,6 +1690,221 @@ describe('format utilities', () => {
     });
   });
 
+  describe('formatManagerDigest - blocker streaks and unplanned overload', () => {
+    it('shows 🚧 in Needs Attention when current_streak >= 3', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        blockerStreaks: [
+          { slack_user_id: 'U111', current_streak: 3, max_streak: 3, total_blocker_days: 3 },
+        ],
+      });
+
+      expect(result).toContain('Needs Attention');
+      expect(result).toContain('🚧 <@U111>');
+      expect(result).toContain('blocked 3 consecutive days');
+    });
+
+    it('does NOT show 🚧 streak warning when current_streak < 3', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        blockerStreaks: [
+          { slack_user_id: 'U222', current_streak: 2, max_streak: 4, total_blocker_days: 6 },
+        ],
+      });
+
+      // No 🚧 streak warning in action items (current_streak is only 2)
+      expect(result).not.toContain('consecutive days');
+    });
+
+    it('shows ⚡ in Needs Attention for unplanned overloads with correct percentages', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        unplannedOverloads: [
+          { slack_user_id: 'U333', unplanned_count: 7, completed_count: 10, unplanned_pct: 70 },
+        ],
+      });
+
+      expect(result).toContain('Needs Attention');
+      expect(result).toContain('⚡ <@U333>');
+      expect(result).toContain('70% unplanned work');
+      expect(result).toContain('7/10 items');
+    });
+
+    it('no crash and no Needs Attention section when blockerStreaks and unplannedOverloads are absent', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        // no blockerStreaks, no unplannedOverloads
+      });
+
+      expect(result).not.toContain('Needs Attention');
+    });
+
+    it('no crash and no Needs Attention when arrays are empty', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        blockerStreaks: [],
+        unplannedOverloads: [],
+      });
+
+      expect(result).not.toContain('Needs Attention');
+    });
+  });
+
+  describe('formatFullReport - blocker streaks and unplanned overload', () => {
+    const baseOptions = {
+      dailyName: 'daily-il',
+      period: 'weekly' as const,
+      startDate: '2025-12-12',
+      endDate: '2025-12-18',
+      submissions: [],
+      stats: [
+        { slack_user_id: 'U111', submission_count: 5, total_completed: 10, total_planned: 12, total_blockers: 3, avg_items_per_day: 2.4 },
+      ],
+      totalWorkdays: 5,
+    };
+
+    it('shows per-user blocker streak line when current_streak >= 3', () => {
+      const result = formatFullReport({
+        ...baseOptions,
+        blockerStreaks: [
+          { slack_user_id: 'U111', current_streak: 4, max_streak: 4, total_blocker_days: 4 },
+        ],
+      });
+
+      expect(result).toContain('🚧 Current blocker streak: 4 days');
+    });
+
+    it('does NOT show blocker streak line when current_streak < 3', () => {
+      const result = formatFullReport({
+        ...baseOptions,
+        blockerStreaks: [
+          { slack_user_id: 'U111', current_streak: 2, max_streak: 5, total_blocker_days: 7 },
+        ],
+      });
+
+      expect(result).not.toContain('Current blocker streak');
+    });
+
+    it('shows per-user unplanned overload line', () => {
+      const result = formatFullReport({
+        ...baseOptions,
+        unplannedOverloads: [
+          { slack_user_id: 'U111', unplanned_count: 8, completed_count: 10, unplanned_pct: 80 },
+        ],
+      });
+
+      expect(result).toContain('⚡ Unplanned work: 80%');
+      expect(result).toContain('8/10 items');
+    });
+
+    it('does not show overload line for users not in unplannedOverloads', () => {
+      const result = formatFullReport({
+        ...baseOptions,
+        unplannedOverloads: [], // U111 not in the list
+      });
+
+      expect(result).not.toContain('Unplanned work');
+    });
+
+    it('trend section includes unplanned_rate when present', () => {
+      const result = formatFullReport({
+        ...baseOptions,
+        trends: {
+          current: {
+            participation_rate: 80,
+            completion_rate: 75,
+            blocker_rate: 10,
+            unplanned_rate: 35,
+            total_submissions: 5,
+            total_participants: 1,
+            total_items_completed: 10,
+            total_items_dropped: 3,
+            avg_items_per_day: 2.4,
+          },
+          previous: {
+            participation_rate: 70,
+            completion_rate: 65,
+            blocker_rate: 15,
+            unplanned_rate: 50,
+            total_submissions: 4,
+            total_participants: 1,
+            total_items_completed: 8,
+            total_items_dropped: 4,
+            avg_items_per_day: 2.0,
+          },
+        },
+      });
+
+      expect(result).toContain('Unplanned work');
+      expect(result).toContain('35%');
+    });
+
+    it('trend section omits unplanned_rate when it is 0 / undefined', () => {
+      // unplanned_rate = 0 is falsy, so the condition `!== undefined` matters
+      // The format.ts code checks: if (trends.current.unplanned_rate !== undefined)
+      const result = formatFullReport({
+        ...baseOptions,
+        trends: {
+          current: {
+            participation_rate: 80,
+            completion_rate: 75,
+            blocker_rate: 10,
+            unplanned_rate: 0,
+            total_submissions: 5,
+            total_participants: 1,
+            total_items_completed: 10,
+            total_items_dropped: 3,
+            avg_items_per_day: 2.4,
+          },
+          previous: {
+            participation_rate: 70,
+            completion_rate: 65,
+            blocker_rate: 15,
+            unplanned_rate: 0,
+            total_submissions: 4,
+            total_participants: 1,
+            total_items_completed: 8,
+            total_items_dropped: 4,
+            avg_items_per_day: 2.0,
+          },
+        },
+      });
+
+      // unplanned_rate is 0 (not undefined) so line should appear, showing "0%"
+      expect(result).toContain('Unplanned work');
+    });
+  });
+
   describe('formatFullReport - in-progress flagging', () => {
     it('shows in-progress needs-attention section per user', () => {
       const result = formatFullReport({

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -101,7 +101,8 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('🔄 WIP task _(in progress)_');
+      expect(todayBlock?.text?.text).toContain('🔄 WIP task');
+      expect(todayBlock?.text?.text).not.toContain('_(in progress)_');
       expect(todayBlock?.text?.text).toContain('🎯 New task');
     });
 
@@ -118,7 +119,7 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('⚠️ Stuck task _(Day 3 — needs attention)_');
+      expect(todayBlock?.text?.text).toContain('⚠️ Stuck task _(day 3)_');
     });
 
     it('shows 🔄 Day X for in-progress items with carry_count 1-2', () => {
@@ -134,7 +135,7 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('🔄 WIP task _(Day 2)_');
+      expect(todayBlock?.text?.text).toContain('🔄 WIP task _(day 2)_');
     });
 
     it('renders in-progress items before carried-over items', () => {
@@ -168,7 +169,8 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('➡️ Ongoing work _(carried over)_');
+      expect(todayBlock?.text?.text).toContain('➡️ Ongoing work');
+      expect(todayBlock?.text?.text).not.toContain('_(carried over)_');
       expect(todayBlock?.text?.text).toContain('🎯 New task');
     });
 

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -20,6 +20,7 @@ import {
   formatLinearDigestSection,
   formatMemberPRSummary,
   formatTeamSummary,
+  formatFullReport,
 } from '../lib/format';
 import type { TeamPRData } from '../lib/github';
 import type { TeamLinearData, CycleProgress } from '../lib/linear';
@@ -117,7 +118,23 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('⚠️ Stuck task _(in progress)_');
+      expect(todayBlock?.text?.text).toContain('⚠️ Stuck task _(Day 3 — needs attention)_');
+    });
+
+    it('shows 🔄 Day X for in-progress items with carry_count 1-2', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: [],
+        yesterdayIncomplete: [],
+        yesterdayInProgress: ['WIP task'],
+        unplanned: [],
+        todayPlans: [],
+        blockers: '',
+        customAnswers: {},
+        inProgressCarryCounts: { 'WIP task': 2 },
+      });
+
+      const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
+      expect(todayBlock?.text?.text).toContain('🔄 WIP task _(Day 2)_');
     });
 
     it('renders in-progress items before carried-over items', () => {
@@ -836,8 +853,8 @@ describe('format utilities', () => {
         stats: [],
         totalWorkdays: 5,
         bottlenecks: [
-          { id: 1, text: 'Fix auth timeout issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' },
-          { id: 2, text: 'Update API docs', slack_user_id: 'U67890', carry_count: 3, days_pending: 3, type: 'carry' },
+          { id: 1, text: 'Fix auth timeout issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry', status: 'carried' },
+          { id: 2, text: 'Update API docs', slack_user_id: 'U67890', carry_count: 3, days_pending: 3, type: 'carry', status: 'carried' },
         ],
       });
 
@@ -1130,7 +1147,7 @@ describe('format utilities', () => {
 
     it('creates header section for bottleneck items', () => {
       const bottlenecks = [
-        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const },
+        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const, status: 'carried' as const },
       ];
 
       const blocks = buildBottleneckBlocks(bottlenecks, 'daily-il');
@@ -1143,8 +1160,8 @@ describe('format utilities', () => {
 
     it('creates section for each bottleneck item with snooze button', () => {
       const bottlenecks = [
-        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const },
-        { id: 2, text: 'Update docs', slack_user_id: 'U67890', carry_count: 3, days_pending: 3, type: 'carry' as const },
+        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const, status: 'carried' as const },
+        { id: 2, text: 'Update docs', slack_user_id: 'U67890', carry_count: 3, days_pending: 3, type: 'carry' as const, status: 'carried' as const },
       ];
 
       const blocks = buildBottleneckBlocks(bottlenecks, 'daily-il');
@@ -1156,7 +1173,7 @@ describe('format utilities', () => {
 
     it('includes item text and user mention in section', () => {
       const bottlenecks = [
-        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const },
+        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const, status: 'carried' as const },
       ];
 
       const blocks = buildBottleneckBlocks(bottlenecks, 'daily-il');
@@ -1169,7 +1186,7 @@ describe('format utilities', () => {
 
     it('includes snooze button with correct action_id', () => {
       const bottlenecks = [
-        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const },
+        { id: 1, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const, status: 'carried' as const },
       ];
 
       const blocks = buildBottleneckBlocks(bottlenecks, 'daily-il');
@@ -1182,7 +1199,7 @@ describe('format utilities', () => {
 
     it('includes item id and daily name in button value', () => {
       const bottlenecks = [
-        { id: 42, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const },
+        { id: 42, text: 'Fix auth issue', slack_user_id: 'U12345', carry_count: 4, days_pending: 5, type: 'carry' as const, status: 'carried' as const },
       ];
 
       const blocks = buildBottleneckBlocks(bottlenecks, 'daily-il');
@@ -1627,6 +1644,114 @@ describe('format utilities', () => {
       });
 
       expect(result).toBe('');
+    });
+  });
+
+  describe('in-progress needs-attention in digest', () => {
+    it('shows 🔄 for in-progress bottleneck items in digest', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        bottlenecks: [
+          { id: 1, text: 'Long-running refactor', slack_user_id: 'U111', carry_count: 4, days_pending: 5, type: 'carry', status: 'in_progress' },
+        ],
+      });
+
+      expect(result).toContain('Needs Attention');
+      expect(result).toContain('🔄 <@U111>');
+      expect(result).toContain('in progress Day 4');
+      expect(result).not.toContain('stuck');
+    });
+
+    it('shows 🔥 for carried bottleneck items and 🔄 for in-progress in same digest', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        bottlenecks: [
+          { id: 1, text: 'Stuck task', slack_user_id: 'U111', carry_count: 3, days_pending: 4, type: 'carry', status: 'carried' },
+          { id: 2, text: 'WIP task', slack_user_id: 'U222', carry_count: 5, days_pending: 6, type: 'carry', status: 'in_progress' },
+        ],
+      });
+
+      expect(result).toContain('🔥 <@U111>');
+      expect(result).toContain('stuck 4 days');
+      expect(result).toContain('🔄 <@U222>');
+      expect(result).toContain('in progress Day 5');
+    });
+  });
+
+  describe('formatFullReport - in-progress flagging', () => {
+    it('shows in-progress needs-attention section per user', () => {
+      const result = formatFullReport({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [
+          { slack_user_id: 'U111', submission_count: 4, total_completed: 10, total_planned: 12, total_blockers: 0, avg_items_per_day: 3 },
+        ],
+        totalWorkdays: 5,
+        bottlenecks: [
+          { id: 1, text: 'Long-running migration', slack_user_id: 'U111', carry_count: 4, days_pending: 5, type: 'carry', status: 'in_progress' },
+        ],
+      });
+
+      expect(result).toContain('In progress — needs attention');
+      expect(result).toContain('🔄 "Long-running migration" (Day 4)');
+    });
+
+    it('separates in-progress and carried stuck items in report', () => {
+      const result = formatFullReport({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [
+          { slack_user_id: 'U111', submission_count: 4, total_completed: 10, total_planned: 12, total_blockers: 0, avg_items_per_day: 3 },
+        ],
+        totalWorkdays: 5,
+        bottlenecks: [
+          { id: 1, text: 'WIP refactor', slack_user_id: 'U111', carry_count: 4, days_pending: 5, type: 'carry', status: 'in_progress' },
+          { id: 2, text: 'Abandoned PR', slack_user_id: 'U111', carry_count: 3, days_pending: 4, type: 'carry', status: 'carried' },
+        ],
+      });
+
+      expect(result).toContain('In progress — needs attention');
+      expect(result).toContain('🔄 "WIP refactor" (Day 4)');
+      expect(result).toContain('Stuck items');
+      expect(result).toContain('🔥 "Abandoned PR" (4 days, carried 3x)');
+    });
+
+    it('does not show in-progress section when no in-progress bottlenecks', () => {
+      const result = formatFullReport({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [
+          { slack_user_id: 'U111', submission_count: 4, total_completed: 10, total_planned: 12, total_blockers: 0, avg_items_per_day: 3 },
+        ],
+        totalWorkdays: 5,
+        bottlenecks: [
+          { id: 1, text: 'Old task', slack_user_id: 'U111', carry_count: 3, days_pending: 4, type: 'carry', status: 'carried' },
+        ],
+      });
+
+      expect(result).not.toContain('In progress — needs attention');
+      expect(result).toContain('Stuck items');
     });
   });
 });

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -391,7 +391,7 @@ describe('format utilities', () => {
         questions: [
           { text: 'Early question', order: 5 },
         ],
-        // No fieldOrder - should use defaults (yesterday:10, today:20, blockers:30)
+        // No fieldOrder - should use defaults (today:10, yesterday:20, blockers:30)
       });
 
       const sectionBlocks = blocks.filter(b => b.type === 'section');
@@ -402,9 +402,34 @@ describe('format utilities', () => {
       const yesterdayIdx = sectionBlocks.findIndex(b =>
         b.text?.text?.includes('Yesterday:')
       );
+      const todayIdx = sectionBlocks.findIndex(b =>
+        b.text?.text?.includes('Today:')
+      );
 
-      // Question with order 5 should appear before yesterday (default order 10)
+      // Question with order 5 should appear before yesterday (default order 20)
       expect(questionIdx).toBeLessThan(yesterdayIdx);
+      // Today (default order 10) should appear before Yesterday (default order 20)
+      expect(todayIdx).toBeLessThan(yesterdayIdx);
+    });
+
+    it('renders Today section before Yesterday section by default', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: ['Done task'],
+        yesterdayIncomplete: [],
+        yesterdayDropped: [],
+        unplanned: [],
+        todayPlans: ['New task'],
+        blockers: '',
+        customAnswers: {},
+      });
+
+      const sectionBlocks = blocks.filter(b => b.type === 'section');
+      const todayIdx = sectionBlocks.findIndex(b => b.text?.text?.includes('Today:'));
+      const yesterdayIdx = sectionBlocks.findIndex(b => b.text?.text?.includes('Yesterday:'));
+
+      expect(todayIdx).toBeGreaterThan(-1);
+      expect(yesterdayIdx).toBeGreaterThan(-1);
+      expect(todayIdx).toBeLessThan(yesterdayIdx);
     });
 
     it('includes footer with daily name', () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -490,6 +490,27 @@ describe('format utilities', () => {
       expect(todayBlock?.text?.text).toContain('🎯 Ship the feature');
       expect(todayBlock?.text?.text).not.toContain('<http');
     });
+
+    it('shows PR status labels inline in Today section', () => {
+      const blocks = formatStandupBlocks('U12345', 'daily-il', {
+        yesterdayCompleted: [],
+        yesterdayIncomplete: [],
+        yesterdayDropped: [],
+        unplanned: [],
+        todayPlans: [
+          '[my-repo#42] Fix auth _(awaiting review)_',
+          '[other-repo#99] Add caching _(to review)_',
+          '[draft-repo#7] WIP feature _(draft)_',
+        ],
+        blockers: '',
+        customAnswers: {},
+        githubOrg: 'thenvoi',
+      });
+      const todayBlock = blocks.find(b => b.text?.text?.includes('Today'));
+      expect(todayBlock?.text?.text).toContain('_(awaiting review)_');
+      expect(todayBlock?.text?.text).toContain('_(to review)_');
+      expect(todayBlock?.text?.text).toContain('_(draft)_');
+    });
   });
 
   describe('formatDailyDigest', () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -40,8 +40,7 @@ describe('format utilities', () => {
 
       const header = blocks[0];
       expect(header.type).toBe('section');
-      expect(header.text?.text).toContain('<@U12345>');
-      expect(header.text?.text).toContain('submitted their standup');
+      expect(header.text?.text).toBe('*<@U12345>*');
     });
 
     it('formats completed items with checkbox emoji', () => {
@@ -174,7 +173,7 @@ describe('format utilities', () => {
       expect(todayBlock?.text?.text).toContain('🎯 New task');
     });
 
-    it('adds separator between carried over and new items', () => {
+    it('does not add separator between carried over and new items', () => {
       const blocks = formatStandupBlocks('U12345', 'daily-il', {
         yesterdayCompleted: [],
         yesterdayIncomplete: ['Carried task'],
@@ -185,7 +184,7 @@ describe('format utilities', () => {
       });
 
       const todayBlock = blocks.find(b => b.text?.text?.includes('Today:'));
-      expect(todayBlock?.text?.text).toContain('───');
+      expect(todayBlock?.text?.text).not.toContain('───');
     });
 
     it('includes blockers section when present', () => {
@@ -297,7 +296,7 @@ describe('format utilities', () => {
       const findIndex = (text: string) =>
         sectionBlocks.findIndex(b => b.text?.text?.includes(text));
 
-      const headerIdx = findIndex('submitted their standup');
+      const headerIdx = findIndex('<@U12345>');
       const questionStartIdx = findIndex('Question at start');
       const yesterdayIdx = findIndex('Yesterday');
       const todayIdx = findIndex('Today:');
@@ -433,7 +432,7 @@ describe('format utilities', () => {
       expect(todayIdx).toBeLessThan(yesterdayIdx);
     });
 
-    it('includes footer with daily name', () => {
+    it('does not include a context footer block', () => {
       const blocks = formatStandupBlocks('U12345', 'daily-il', {
         yesterdayCompleted: [],
         yesterdayIncomplete: [],
@@ -443,9 +442,8 @@ describe('format utilities', () => {
         customAnswers: {},
       });
 
-      const footer = blocks[blocks.length - 1];
-      expect(footer.type).toBe('context');
-      expect(footer.elements?.[0]?.text).toContain('daily-il standup');
+      const contextBlock = blocks.find(b => b.type === 'context');
+      expect(contextBlock).toBeUndefined();
     });
 
     it('enriches PR items with clickable GitHub links', () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1022,6 +1022,60 @@ describe('format utilities', () => {
 
       expect(result).not.toContain('Work Alignment');
     });
+
+    it('shows OOO users in daily digest', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'daily',
+        startDate: '2025-12-18',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 1,
+        oooToday: [
+          { slackUserId: 'U111', endDate: '2025-12-20' },
+          { slackUserId: 'U222', endDate: '2025-12-25' },
+        ],
+      });
+
+      expect(result).toContain('Out today');
+      expect(result).toContain('<@U111>');
+      expect(result).toContain('<@U222>');
+      expect(result).toContain('Dec 20');
+      expect(result).toContain('Dec 25');
+    });
+
+    it('does not show OOO section in weekly digest', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'weekly',
+        startDate: '2025-12-12',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 5,
+        oooToday: [
+          { slackUserId: 'U111', endDate: '2025-12-20' },
+        ],
+      });
+
+      expect(result).not.toContain('Out today');
+    });
+
+    it('does not show OOO section when no one is OOO', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'daily',
+        startDate: '2025-12-18',
+        endDate: '2025-12-18',
+        submissions: [],
+        stats: [],
+        totalWorkdays: 1,
+        oooToday: [],
+      });
+
+      expect(result).not.toContain('Out today');
+    });
   });
 
   describe('buildBottleneckBlocks', () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1076,6 +1076,49 @@ describe('format utilities', () => {
 
       expect(result).not.toContain('Out today');
     });
+
+    it('flags users who routinely over-plan when maxPlanItems is set', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'daily',
+        startDate: '2025-12-18',
+        endDate: '2025-12-18',
+        submissions: [
+          { slack_user_id: 'U111', today_plans: ['a', 'b', 'c', 'd', 'e', 'f'], yesterday_incomplete: [], yesterday_in_progress: [] } as any,
+          { slack_user_id: 'U222', today_plans: ['a', 'b'], yesterday_incomplete: [], yesterday_in_progress: [] } as any,
+        ],
+        stats: [
+          { slack_user_id: 'U111', submission_count: 1, total_completed: 2, avg_items_per_day: '6' } as any,
+          { slack_user_id: 'U222', submission_count: 1, total_completed: 1, avg_items_per_day: '2' } as any,
+        ],
+        totalWorkdays: 1,
+        maxPlanItems: 5,
+      });
+
+      expect(result).toContain('avg 6 plans');
+      // U222 appears in team but without over-plan flag
+      expect(result).toContain('<@U222>');
+      const u222Line = result.split('\n').find((l: string) => l.includes('U222'));
+      expect(u222Line).not.toContain('avg');
+    });
+
+    it('does not flag over-plan when maxPlanItems is not set', () => {
+      const result = formatManagerDigest({
+        dailyName: 'daily-il',
+        period: 'daily',
+        startDate: '2025-12-18',
+        endDate: '2025-12-18',
+        submissions: [
+          { slack_user_id: 'U111', today_plans: ['a', 'b', 'c', 'd', 'e', 'f'], yesterday_incomplete: [], yesterday_in_progress: [] } as any,
+        ],
+        stats: [
+          { slack_user_id: 'U111', submission_count: 1, total_completed: 2, avg_items_per_day: '6' } as any,
+        ],
+        totalWorkdays: 1,
+      });
+
+      expect(result).not.toContain('avg');
+    });
   });
 
   describe('buildBottleneckBlocks', () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -19,6 +19,7 @@ import {
   formatPRDigestSection,
   formatLinearDigestSection,
   formatMemberPRSummary,
+  formatTeamSummary,
 } from '../lib/format';
 import type { TeamPRData } from '../lib/github';
 import type { TeamLinearData, CycleProgress } from '../lib/linear';
@@ -1570,6 +1571,62 @@ describe('format utilities', () => {
       const result = formatMemberPRSummary(prData);
 
       expect(result).toBe('3 draft');
+    });
+  });
+
+  describe('formatTeamSummary', () => {
+    it('shows one line per person with top plan items', () => {
+      const result = formatTeamSummary({
+        dailyName: 'daily-il',
+        channel: 'C123',
+        submissions: [
+          { slack_user_id: 'U111', today_plans: ['Ship auth', 'Fix tests'], blockers: null, slack_message_ts: null } as any,
+          { slack_user_id: 'U222', today_plans: ['Review PR'], blockers: null, slack_message_ts: null } as any,
+        ],
+      });
+
+      expect(result).toContain('daily-il — Team Summary');
+      expect(result).toContain('<@U111>');
+      expect(result).toContain('Ship auth');
+      expect(result).toContain('Fix tests');
+      expect(result).toContain('<@U222>');
+      expect(result).toContain('Review PR');
+    });
+
+    it('shows blockers in a separate section', () => {
+      const result = formatTeamSummary({
+        dailyName: 'daily-il',
+        channel: 'C123',
+        submissions: [
+          { slack_user_id: 'U111', today_plans: ['Ship auth'], blockers: 'Waiting on API key', slack_message_ts: null } as any,
+        ],
+      });
+
+      expect(result).toContain('Blockers');
+      expect(result).toContain('<@U111>: Waiting on API key');
+    });
+
+    it('includes message permalink when slack_message_ts is present', () => {
+      const result = formatTeamSummary({
+        dailyName: 'daily-il',
+        channel: 'C123',
+        submissions: [
+          { slack_user_id: 'U111', today_plans: ['Ship auth'], blockers: null, slack_message_ts: '1234567890.123456' } as any,
+        ],
+      });
+
+      expect(result).toContain('slack.com/archives/C123/p1234567890123456');
+      expect(result).toContain('↗');
+    });
+
+    it('returns empty string when no submissions', () => {
+      const result = formatTeamSummary({
+        dailyName: 'daily-il',
+        channel: 'C123',
+        submissions: [],
+      });
+
+      expect(result).toBe('');
     });
   });
 });

--- a/tests/github-intelligence.test.ts
+++ b/tests/github-intelligence.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for lib/github-intelligence.ts
+ * Pure functions — no mocks required.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeForMatching,
+  matchPlanToMergedPR,
+  computeGitHubAlignment,
+} from '../lib/github-intelligence';
+import type { WorkItem } from '../lib/db';
+import type { MergedPR } from '../lib/github';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 1,
+    slack_user_id: 'U123',
+    daily_name: 'eng-daily',
+    text: 'Work on something',
+    created_date: '2026-05-07',
+    status: 'pending',
+    carry_count: 0,
+    completed_date: null,
+    snoozed_until: null,
+    submission_id: null,
+    source: 'manual',
+    source_ref: null,
+    source_url: null,
+    item_type: 'plan',
+    ...overrides,
+  };
+}
+
+function makeMergedPR(overrides: Partial<MergedPR> = {}): MergedPR {
+  return {
+    number: 42,
+    title: 'Add user authentication flow',
+    repo: 'backend',
+    url: 'https://github.com/org/backend/pull/42',
+    mergedAt: '2026-05-07T14:00:00Z',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// normalizeForMatching
+// ============================================================================
+
+describe('normalizeForMatching', () => {
+  it('lowercases and splits on whitespace', () => {
+    expect(normalizeForMatching('User Authentication Flow')).toEqual([
+      'user', 'authentication', 'flow',
+    ]);
+  });
+
+  it('removes stop words', () => {
+    const result = normalizeForMatching('fix the broken auth for users');
+    expect(result).not.toContain('fix');
+    expect(result).not.toContain('the');
+    expect(result).not.toContain('for');
+    expect(result).toContain('broken');
+    expect(result).toContain('auth');
+    expect(result).toContain('users');
+  });
+
+  it('removes words shorter than 3 characters', () => {
+    const result = normalizeForMatching('do an API db fix');
+    expect(result).not.toContain('do');
+    expect(result).not.toContain('an');
+    expect(result).toContain('api');
+  });
+
+  it('strips punctuation and special characters', () => {
+    const result = normalizeForMatching('[backend] user-auth (v2)');
+    expect(result).toContain('backend');
+    expect(result).toContain('user');
+    expect(result).toContain('auth');
+  });
+
+  it('deduplicates words', () => {
+    const result = normalizeForMatching('auth auth auth');
+    expect(result).toEqual(['auth']);
+  });
+
+  it('returns empty array for all-stop-words input', () => {
+    expect(normalizeForMatching('fix the add')).toEqual([]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(normalizeForMatching('')).toEqual([]);
+  });
+});
+
+// ============================================================================
+// matchPlanToMergedPR
+// ============================================================================
+
+describe('matchPlanToMergedPR', () => {
+  it('matches github_pr item by exact source_ref', () => {
+    const item = makeWorkItem({
+      source: 'github_pr',
+      source_ref: 'backend#42',
+      text: 'something unrelated',
+    });
+    const pr = makeMergedPR({ repo: 'backend', number: 42 });
+
+    expect(matchPlanToMergedPR(item, [pr])).toEqual(pr);
+  });
+
+  it('excludes linear_ticket items entirely', () => {
+    const item = makeWorkItem({
+      source: 'linear_ticket',
+      source_ref: 'ENG-123',
+      text: 'User authentication flow',
+    });
+    const pr = makeMergedPR({ title: 'User authentication flow' });
+
+    expect(matchPlanToMergedPR(item, [pr])).toBeNull();
+  });
+
+  it('matches manual item by keyword overlap ≥50%', () => {
+    const item = makeWorkItem({ text: 'user authentication flow' });
+    const pr = makeMergedPR({ title: 'Add user authentication flow' });
+
+    expect(matchPlanToMergedPR(item, [pr])).toEqual(pr);
+  });
+
+  it('rejects manual item when keyword overlap <50%', () => {
+    const item = makeWorkItem({ text: 'user authentication flow redesign' });
+    const pr = makeMergedPR({ title: 'Fix database connection pooling' });
+
+    expect(matchPlanToMergedPR(item, [pr])).toBeNull();
+  });
+
+  it('picks best match when multiple PRs qualify', () => {
+    const item = makeWorkItem({ text: 'user authentication login flow' });
+    const weakPR = makeMergedPR({ number: 10, title: 'Update user profile page' });
+    const strongPR = makeMergedPR({ number: 11, title: 'User authentication login endpoint' });
+
+    expect(matchPlanToMergedPR(item, [weakPR, strongPR])).toEqual(strongPR);
+  });
+
+  it('returns null when item text produces no keywords', () => {
+    const item = makeWorkItem({ text: 'fix the add' }); // all stop words
+    const pr = makeMergedPR();
+
+    expect(matchPlanToMergedPR(item, [pr])).toBeNull();
+  });
+
+  it('falls back to keyword match when github_pr source_ref does not match', () => {
+    const item = makeWorkItem({
+      source: 'github_pr',
+      source_ref: 'frontend#99',
+      text: 'user authentication flow',
+    });
+    const pr = makeMergedPR({ repo: 'backend', number: 42, title: 'User authentication flow handler' });
+
+    expect(matchPlanToMergedPR(item, [pr])).toEqual(pr);
+  });
+
+  it('returns null for empty mergedPRs array', () => {
+    const item = makeWorkItem({ text: 'user authentication flow' });
+    expect(matchPlanToMergedPR(item, [])).toBeNull();
+  });
+});
+
+// ============================================================================
+// computeGitHubAlignment
+// ============================================================================
+
+describe('computeGitHubAlignment', () => {
+  it('returns aligned when all plans match PRs and vice versa', () => {
+    const items = [
+      makeWorkItem({ text: 'user authentication flow' }),
+    ];
+    const prs = [
+      makeMergedPR({ title: 'Add user authentication flow' }),
+    ];
+
+    const result = computeGitHubAlignment('U123', items, prs);
+
+    expect(result.alignmentStatus).toBe('aligned');
+    expect(result.plansWithoutWork).toEqual([]);
+    expect(result.workWithoutPlans).toEqual([]);
+  });
+
+  it('detects plans without matching PRs', () => {
+    const items = [
+      makeWorkItem({ text: 'database migration script' }),
+    ];
+    const prs = [
+      makeMergedPR({ title: 'Fix CSS layout issue' }),
+    ];
+
+    const result = computeGitHubAlignment('U123', items, prs);
+
+    expect(result.alignmentStatus).toBe('misaligned');
+    expect(result.plansWithoutWork).toContain('database migration script');
+  });
+
+  it('detects merged PRs without matching plans', () => {
+    const items = [
+      makeWorkItem({ text: 'user authentication flow' }),
+    ];
+    const prs = [
+      makeMergedPR({ title: 'Add user authentication flow' }),
+      makeMergedPR({ number: 99, title: 'Emergency hotfix for payment processing' }),
+    ];
+
+    const result = computeGitHubAlignment('U123', items, prs);
+
+    expect(result.alignmentStatus).toBe('misaligned');
+    expect(result.workWithoutPlans).toHaveLength(1);
+    expect(result.workWithoutPlans[0].number).toBe(99);
+  });
+
+  it('excludes linear_ticket items from plansWithoutWork', () => {
+    const items = [
+      makeWorkItem({ source: 'linear_ticket', source_ref: 'ENG-100', text: 'Linear issue work' }),
+    ];
+    const prs: MergedPR[] = [];
+
+    const result = computeGitHubAlignment('U123', items, prs);
+
+    expect(result.plansWithoutWork).toEqual([]);
+  });
+
+  it('includes github_pr items in matching (reduces workWithoutPlans)', () => {
+    const items = [
+      makeWorkItem({ source: 'github_pr', source_ref: 'backend#42', text: 'PR work' }),
+    ];
+    const prs = [
+      makeMergedPR({ repo: 'backend', number: 42 }),
+    ];
+
+    const result = computeGitHubAlignment('U123', items, prs);
+
+    expect(result.alignmentStatus).toBe('aligned');
+    expect(result.workWithoutPlans).toEqual([]);
+  });
+
+  it('returns aligned for empty inputs', () => {
+    const result = computeGitHubAlignment('U123', [], []);
+
+    expect(result.alignmentStatus).toBe('aligned');
+    expect(result.plansWithoutWork).toEqual([]);
+    expect(result.workWithoutPlans).toEqual([]);
+  });
+
+  it('sets slackUserId on the result', () => {
+    const result = computeGitHubAlignment('U999', [], []);
+    expect(result.slackUserId).toBe('U999');
+  });
+
+  it('handles mixed sources correctly', () => {
+    const items = [
+      makeWorkItem({ id: 1, text: 'user authentication flow' }),
+      makeWorkItem({ id: 2, source: 'linear_ticket', source_ref: 'ENG-50', text: 'linear work' }),
+      makeWorkItem({ id: 3, source: 'github_pr', source_ref: 'api#10', text: 'API cleanup' }),
+      makeWorkItem({ id: 4, text: 'unrelated documentation task' }),
+    ];
+    const prs = [
+      makeMergedPR({ title: 'User authentication flow handler' }),
+      makeMergedPR({ number: 10, repo: 'api', title: 'API cleanup refactor' }),
+      makeMergedPR({ number: 77, title: 'Surprise hotfix nobody planned' }),
+    ];
+
+    const result = computeGitHubAlignment('U123', items, prs);
+
+    expect(result.plansWithoutWork).toEqual(['unrelated documentation task']);
+    expect(result.workWithoutPlans).toHaveLength(1);
+    expect(result.workWithoutPlans[0].number).toBe(77);
+    expect(result.alignmentStatus).toBe('misaligned');
+  });
+});

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -16,7 +16,9 @@ import {
   fetchUserPRData,
   extractPRSlug,
   formatPRRef,
+  filterReviewRequests,
   GitHubPR,
+  GitHubReview,
 } from '../lib/github';
 
 describe('github client', () => {
@@ -604,20 +606,21 @@ describe('github client', () => {
       };
 
       const mockReviews789 = [
-        { user: { login: 'alice' }, submitted_at: '2025-01-16T10:00:00Z' },
+        { user: { login: 'alice' }, submitted_at: '2025-01-16T10:00:00Z', state: 'COMMENTED', body: 'looks good' },
       ];
       const mockReviews790 = [
-        { user: { login: 'alice' }, submitted_at: '2025-01-16T10:00:00Z' },
+        { user: { login: 'alice' }, submitted_at: '2025-01-16T10:00:00Z', state: 'COMMENTED', body: 'lgtm' },
       ];
 
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({ ok: true, json: async () => emptyResponse }) // drafts
         .mockResolvedValueOnce({ ok: true, json: async () => emptyResponse }) // approved
         .mockResolvedValueOnce({ ok: true, json: async () => emptyResponse }) // awaiting
-        .mockResolvedValueOnce({ ok: true, json: async () => mockReviews }) // review requests
+        .mockResolvedValueOnce({ ok: true, json: async () => mockReviews }) // review requests search
         .mockResolvedValueOnce({ ok: true, json: async () => mockReReviewSearch }) // re-review search
-        .mockResolvedValueOnce({ ok: true, json: async () => mockReviews789 }) // reviews for #789
-        .mockResolvedValueOnce({ ok: true, json: async () => mockReviews790 }); // reviews for #790
+        .mockResolvedValueOnce({ ok: true, json: async () => mockReviews789 }) // reviews for #789 (filter step)
+        .mockResolvedValueOnce({ ok: true, json: async () => mockReviews789 }) // reviews for #789 (re-review)
+        .mockResolvedValueOnce({ ok: true, json: async () => mockReviews790 }); // reviews for #790 (re-review)
 
       const result = await fetchUserPRData('token', 'alice', 'myorg');
 
@@ -695,6 +698,200 @@ describe('github client', () => {
       };
 
       expect(formatPRRef(pr)).toBe('#456');
+    });
+  });
+
+  // ============================================================================
+  // filterReviewRequests
+  // ============================================================================
+
+  describe('filterReviewRequests', () => {
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    function makePR(overrides: Partial<GitHubPR> & { number: number }): GitHubPR {
+      return {
+        title: `PR #${overrides.number}`,
+        url: `https://github.com/myorg/repo/pull/${overrides.number}`,
+        author: 'bob',
+        reviewsNeeded: 0,
+        requestedReviewers: ['alice'],
+        createdAt: '2025-01-10T00:00:00Z',
+        updatedAt: '2025-01-15T12:00:00Z',
+        draft: false,
+        ...overrides,
+      };
+    }
+
+    function makeReview(
+      login: string,
+      state: GitHubReview['state'],
+      submitted_at: string,
+      body = ''
+    ): GitHubReview {
+      return {
+        user: { login },
+        submitted_at,
+        state,
+        body,
+      };
+    }
+
+    function makeMap(entries: [number, GitHubReview[]][]): Map<number, GitHubReview[]> {
+      return new Map(entries);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test cases
+    // ---------------------------------------------------------------------------
+
+    it('keeps PR when reviewer has no reviews', () => {
+      const pr = makePR({ number: 1, updatedAt: '2025-01-15T12:00:00Z' });
+      const reviewsMap = makeMap([[1, []]]);
+
+      const result = filterReviewRequests([pr], reviewsMap, 'alice');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].number).toBe(1);
+    });
+
+    it('hides PR when reviewer already commented and PR not updated since', () => {
+      const pr = makePR({ number: 2, updatedAt: '2025-01-15T12:00:00Z' });
+      // Comment submitted AFTER (or at same time as) the PR's updatedAt — no author response
+      const reviewsMap = makeMap([
+        [2, [makeReview('alice', 'COMMENTED', '2025-01-15T13:00:00Z')]],
+      ]);
+
+      const result = filterReviewRequests([pr], reviewsMap, 'alice');
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('hides PR when reviewer left CHANGES_REQUESTED and PR not updated since', () => {
+      const pr = makePR({ number: 3, updatedAt: '2025-01-15T12:00:00Z' });
+      const reviewsMap = makeMap([
+        [3, [makeReview('alice', 'CHANGES_REQUESTED', '2025-01-15T13:00:00Z')]],
+      ]);
+
+      const result = filterReviewRequests([pr], reviewsMap, 'alice');
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('keeps PR when reviewer commented but PR was updated after', () => {
+      // Reviewer commented, then author pushed → updatedAt is newer than last review
+      const pr = makePR({ number: 4, updatedAt: '2025-01-16T10:00:00Z' });
+      const reviewsMap = makeMap([
+        [4, [makeReview('alice', 'COMMENTED', '2025-01-15T09:00:00Z')]],
+      ]);
+
+      const result = filterReviewRequests([pr], reviewsMap, 'alice');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].number).toBe(4);
+    });
+
+    it('hides PR when already approved by someone else', () => {
+      // A non-author reviewer has approved and there's no subsequent CHANGES_REQUESTED
+      const pr = makePR({ number: 5, author: 'bob', updatedAt: '2025-01-15T12:00:00Z' });
+      const reviewsMap = makeMap([
+        [5, [makeReview('charlie', 'APPROVED', '2025-01-15T11:00:00Z')]],
+      ]);
+
+      const result = filterReviewRequests([pr], reviewsMap, 'alice');
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('keeps PR when approved then changes requested after', () => {
+      // reviewer-A approved, then reviewer-B requested changes — still needs work
+      const pr = makePR({ number: 6, author: 'bob', updatedAt: '2025-01-15T08:00:00Z' });
+      const reviewsMap = makeMap([
+        [
+          6,
+          [
+            makeReview('reviewerA', 'APPROVED', '2025-01-15T09:00:00Z'),
+            makeReview('reviewerB', 'CHANGES_REQUESTED', '2025-01-15T10:00:00Z'),
+          ],
+        ],
+      ]);
+
+      const result = filterReviewRequests([pr], reviewsMap, 'alice');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].number).toBe(6);
+    });
+
+    it("hides PR when reviewer's last review is newer than PR update", () => {
+      // General heuristic: reviewer's latest submitted_at >= updatedAt → nothing new to review
+      const pr = makePR({ number: 7, updatedAt: '2025-01-14T00:00:00Z' });
+      const reviewsMap = makeMap([
+        [7, [makeReview('alice', 'COMMENTED', '2025-01-15T00:00:00Z')]],
+      ]);
+
+      const result = filterReviewRequests([pr], reviewsMap, 'alice');
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("keeps PR when PR updated after reviewer's last review", () => {
+      const pr = makePR({ number: 8, updatedAt: '2025-01-16T00:00:00Z' });
+      const reviewsMap = makeMap([
+        [8, [makeReview('alice', 'CHANGES_REQUESTED', '2025-01-14T00:00:00Z')]],
+      ]);
+
+      const result = filterReviewRequests([pr], reviewsMap, 'alice');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].number).toBe(8);
+    });
+
+    it('ignores PENDING reviews', () => {
+      // PENDING means the reviewer opened a review but hasn't submitted it yet — treated as no review
+      const pr = makePR({ number: 9, updatedAt: '2025-01-15T12:00:00Z' });
+      const reviewsMap = makeMap([
+        [9, [makeReview('alice', 'PENDING', '2025-01-15T13:00:00Z')]],
+      ]);
+
+      const result = filterReviewRequests([pr], reviewsMap, 'alice');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].number).toBe(9);
+    });
+
+    it('ignores reviews from PR author', () => {
+      // Author self-reviewed (edge case) — should not count as an approval/block
+      const pr = makePR({ number: 10, author: 'bob', updatedAt: '2025-01-15T12:00:00Z' });
+      const reviewsMap = makeMap([
+        [10, [makeReview('bob', 'APPROVED', '2025-01-15T13:00:00Z')]],
+      ]);
+
+      const result = filterReviewRequests([pr], reviewsMap, 'alice');
+
+      // Author's self-review doesn't count → reviewer still needs to act → PR kept
+      expect(result).toHaveLength(1);
+      expect(result[0].number).toBe(10);
+    });
+
+    it('handles multiple PRs with mixed filtering', () => {
+      // PR 11: no reviews → keep
+      // PR 12: reviewer already commented after last update → hide
+      // PR 13: non-author approved → hide
+      const pr11 = makePR({ number: 11, updatedAt: '2025-01-15T12:00:00Z' });
+      const pr12 = makePR({ number: 12, updatedAt: '2025-01-15T12:00:00Z' });
+      const pr13 = makePR({ number: 13, author: 'bob', updatedAt: '2025-01-15T12:00:00Z' });
+
+      const reviewsMap = makeMap([
+        [11, []],
+        [12, [makeReview('alice', 'COMMENTED', '2025-01-15T14:00:00Z')]],
+        [13, [makeReview('charlie', 'APPROVED', '2025-01-15T11:00:00Z')]],
+      ]);
+
+      const result = filterReviewRequests([pr11, pr12, pr13], reviewsMap, 'alice');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].number).toBe(11);
     });
   });
 });

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -154,7 +154,7 @@ describe('buildHomeView - Today\'s Plans section', () => {
     const text = (planBlock as any).elements[0].text;
     expect(text).toContain('✅ ~Fix auth bug~');
     expect(text).toContain('🔄 Refactor DB layer');
-    expect(text).toContain('⬜ Deploy to staging');
+    expect(text).toContain('🎯 Deploy to staging');
     expect(text).toContain('➡️ Old task _(carried)_');
     expect(text).toContain('❌ ~Abandoned idea~');
   });
@@ -192,7 +192,7 @@ describe('buildHomeView - Today\'s Plans section', () => {
 
     // No context block with plan items
     const planBlocks = view.blocks.filter(
-      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('⬜')
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('🎯')
     );
     expect(planBlocks).toHaveLength(0);
   });
@@ -275,7 +275,7 @@ describe('handleAppHomeOpened - Today\'s Plans from submission', () => {
     const text = (planBlock as any).elements[0].text;
     expect(text).toContain('🔄 WIP task');
     expect(text).toContain('➡️ Carried task');
-    expect(text).toContain('⬜ New plan');
+    expect(text).toContain('🎯 New plan');
     expect(text).toContain('✅ ~Done task~');
   });
 });

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -16,6 +16,7 @@ vi.mock('../lib/db', () => ({
   getDmStandupPreference: vi.fn(() => Promise.resolve(false)),
   getUserSettings: vi.fn(() => Promise.resolve({ dmStandup: false, maxItems: null, stalePrDays: null, linearTeamFilter: null })),
   getActiveOOO: vi.fn(() => Promise.resolve(null)),
+  getActiveWorkItems: vi.fn(() => Promise.resolve([])),
 }));
 
 // Mock the config module
@@ -52,7 +53,7 @@ vi.mock('../lib/linear', () => ({
 }));
 
 import { buildHomeView, LinkedAccounts, handleAppHomeOpened, HomeContext, AppHomeOpenedEvent } from '../lib/handlers/home';
-import { getGitHubUsername, getLinearUserId, getUserDailies, getSubmissionForDate, getPreviousSubmission } from '../lib/db';
+import { getGitHubUsername, getLinearUserId, getUserDailies, getSubmissionForDate, getPreviousSubmission, getActiveWorkItems } from '../lib/db';
 import { publishHomeView } from '../lib/slack';
 
 describe('buildHomeView - linked accounts section', () => {
@@ -223,18 +224,36 @@ describe('buildHomeView - Today\'s Plans section', () => {
     }];
     const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
 
-    // Find context block with plan items
-    const planBlock = view.blocks.find(
-      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('Fix auth bug')
+    // Each plan item is now a section block with the text directly in the block
+    const doneBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Fix auth bug')
     );
-    expect(planBlock).toBeDefined();
+    expect(doneBlock).toBeDefined();
+    expect((doneBlock as any).text.text).toContain('✅ ~Fix auth bug~');
 
-    const text = (planBlock as any).elements[0].text;
-    expect(text).toContain('✅ ~Fix auth bug~');
-    expect(text).toContain('🔄 Refactor DB layer');
-    expect(text).toContain('🎯 Deploy to staging');
-    expect(text).toContain('➡️ Old task _(carried)_');
-    expect(text).toContain('❌ ~Abandoned idea~');
+    const inProgressBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Refactor DB layer')
+    );
+    expect(inProgressBlock).toBeDefined();
+    expect((inProgressBlock as any).text.text).toContain('🔄 Refactor DB layer');
+
+    const plannedBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Deploy to staging')
+    );
+    expect(plannedBlock).toBeDefined();
+    expect((plannedBlock as any).text.text).toContain('🎯 Deploy to staging');
+
+    const carriedBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Old task')
+    );
+    expect(carriedBlock).toBeDefined();
+    expect((carriedBlock as any).text.text).toContain('➡️ Old task _(carried)_');
+
+    const droppedBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Abandoned idea')
+    );
+    expect(droppedBlock).toBeDefined();
+    expect((droppedBlock as any).text.text).toContain('❌ ~Abandoned idea~');
   });
 
   it('shows source tags for integration items', () => {
@@ -250,14 +269,24 @@ describe('buildHomeView - Today\'s Plans section', () => {
     }];
     const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
 
-    const planBlock = view.blocks.find(
-      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('LIN-123')
+    // Each item is now its own section block
+    const linBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('LIN-123')
     );
-    expect(planBlock).toBeDefined();
-    const text = (planBlock as any).elements[0].text;
-    expect(text).toContain('· _LIN-123_');
-    expect(text).toContain('· _repo#45_');
-    expect(text).not.toContain('Manual task · _');
+    expect(linBlock).toBeDefined();
+    expect((linBlock as any).text.text).toContain('· _LIN-123_');
+
+    const repoBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('repo#45')
+    );
+    expect(repoBlock).toBeDefined();
+    expect((repoBlock as any).text.text).toContain('· _repo#45_');
+
+    const manualBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Manual task')
+    );
+    expect(manualBlock).toBeDefined();
+    expect((manualBlock as any).text.text).not.toContain(' · _');
   });
 
   it('does not show plan section when no submission', () => {
@@ -332,9 +361,12 @@ describe('handleAppHomeOpened - Today\'s Plans from submission', () => {
       custom_answers: null,
       slack_message_ts: null,
       posted: true,
+      items_normalized: true,
     });
     // No previous submission (so no dropped items)
     vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+    // No work_items (triggers JSONB fallback path)
+    vi.mocked(getActiveWorkItems).mockResolvedValueOnce([]);
     vi.mocked(publishHomeView).mockResolvedValueOnce(true);
 
     const event: AppHomeOpenedEvent = { type: 'app_home_opened', user: 'U12345', tab: 'home' };
@@ -345,15 +377,29 @@ describe('handleAppHomeOpened - Today\'s Plans from submission', () => {
     const publishCall = vi.mocked(publishHomeView).mock.calls[0];
     const view = publishCall[2] as { blocks: Array<Record<string, unknown>> };
 
-    // Find the context block with plan items
-    const planBlock = view.blocks.find(
-      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('New plan')
+    // Items are now individual section blocks (JSONB fallback — no IDs, so no overflow menus)
+    const wipBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('WIP task')
     );
-    expect(planBlock).toBeDefined();
-    const text = (planBlock as any).elements[0].text;
-    expect(text).toContain('🔄 WIP task');
-    expect(text).toContain('➡️ Carried task');
-    expect(text).toContain('🎯 New plan');
-    expect(text).toContain('✅ ~Done task~');
+    expect(wipBlock).toBeDefined();
+    expect((wipBlock as any).text.text).toContain('🔄 WIP task');
+
+    const carriedBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Carried task')
+    );
+    expect(carriedBlock).toBeDefined();
+    expect((carriedBlock as any).text.text).toContain('➡️ Carried task');
+
+    const newPlanBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('New plan')
+    );
+    expect(newPlanBlock).toBeDefined();
+    expect((newPlanBlock as any).text.text).toContain('🎯 New plan');
+
+    const doneBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Done task')
+    );
+    expect(doneBlock).toBeDefined();
+    expect((doneBlock as any).text.text).toContain('✅ ~Done task~');
   });
 });

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -14,6 +14,8 @@ vi.mock('../lib/db', () => ({
   setGitHubUsername: vi.fn(),
   setLinearUserId: vi.fn(),
   getDmStandupPreference: vi.fn(() => Promise.resolve(false)),
+  getUserSettings: vi.fn(() => Promise.resolve({ dmStandup: false, maxItems: null, stalePrDays: null, linearTeamFilter: null })),
+  getActiveOOO: vi.fn(() => Promise.resolve(null)),
 }));
 
 // Mock the config module
@@ -55,7 +57,7 @@ import { publishHomeView } from '../lib/slack';
 
 describe('buildHomeView - linked accounts section', () => {
   it('shows Link buttons when accounts are not linked', () => {
-    const linkedAccounts: LinkedAccounts = { github: null, linear: null, dmStandup: true };
+    const linkedAccounts: LinkedAccounts = { github: null, linear: null, dmStandup: true, maxItems: null, stalePrDays: null, linearTeamFilter: null };
     const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
 
     // Find linked accounts header
@@ -82,7 +84,7 @@ describe('buildHomeView - linked accounts section', () => {
   });
 
   it('shows Unlink buttons when accounts are linked', () => {
-    const linkedAccounts: LinkedAccounts = { github: 'octocat', linear: 'lin-user-123', dmStandup: true };
+    const linkedAccounts: LinkedAccounts = { github: 'octocat', linear: 'lin-user-123', dmStandup: true, maxItems: null, stalePrDays: null, linearTeamFilter: null };
     const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
 
     // Find GitHub linked section
@@ -103,7 +105,7 @@ describe('buildHomeView - linked accounts section', () => {
   });
 
   it('shows mixed state (one linked, one not)', () => {
-    const linkedAccounts: LinkedAccounts = { github: 'myuser', linear: null, dmStandup: true };
+    const linkedAccounts: LinkedAccounts = { github: 'myuser', linear: null, dmStandup: true, maxItems: null, stalePrDays: null, linearTeamFilter: null };
     const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
 
     const githubSection = view.blocks.find(
@@ -126,6 +128,82 @@ describe('buildHomeView - linked accounts section', () => {
       (b: any) => b.type === 'header' && b.text?.text === '🔗 Linked Accounts'
     );
     expect(header).toBeUndefined();
+  });
+});
+
+describe('buildHomeView - Settings section', () => {
+  it('shows OOO status with clear button when OOO is active', () => {
+    const linkedAccounts: LinkedAccounts = {
+      github: null, linear: null, dmStandup: false,
+      maxItems: null, stalePrDays: null, linearTeamFilter: null,
+      oooStatus: { startDate: '2025-12-22', endDate: '2025-12-25' },
+    };
+    const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
+
+    const oooBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Out of Office')
+    );
+    expect(oooBlock).toBeDefined();
+    expect((oooBlock as any).text.text).toContain('Dec 22');
+    expect((oooBlock as any).text.text).toContain('Dec 25');
+    expect((oooBlock as any).accessory.action_id).toBe('home_clear_ooo');
+  });
+
+  it('shows Set OOO button when not OOO', () => {
+    const linkedAccounts: LinkedAccounts = {
+      github: null, linear: null, dmStandup: false,
+      maxItems: null, stalePrDays: null, linearTeamFilter: null,
+    };
+    const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
+
+    const oooBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Out of Office')
+    );
+    expect(oooBlock).toBeDefined();
+    expect((oooBlock as any).text.text).toContain('Not set');
+    expect((oooBlock as any).accessory.action_id).toBe('home_set_ooo');
+  });
+
+  it('shows max items setting with current value', () => {
+    const linkedAccounts: LinkedAccounts = {
+      github: null, linear: null, dmStandup: false,
+      maxItems: 5, stalePrDays: null, linearTeamFilter: null,
+    };
+    const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
+
+    const maxItemsBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Max items')
+    );
+    expect(maxItemsBlock).toBeDefined();
+    expect((maxItemsBlock as any).text.text).toContain('5 items');
+  });
+
+  it('shows stale PR days with custom value', () => {
+    const linkedAccounts: LinkedAccounts = {
+      github: null, linear: null, dmStandup: false,
+      maxItems: null, stalePrDays: 7, linearTeamFilter: null,
+    };
+    const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
+
+    const stalePrBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Stale PR')
+    );
+    expect(stalePrBlock).toBeDefined();
+    expect((stalePrBlock as any).text.text).toContain('7 days');
+  });
+
+  it('shows Linear team filter', () => {
+    const linkedAccounts: LinkedAccounts = {
+      github: null, linear: null, dmStandup: false,
+      maxItems: null, stalePrDays: null, linearTeamFilter: ['ENG', 'PLATFORM'],
+    };
+    const view = buildHomeView([], linkedAccounts) as { blocks: Array<Record<string, unknown>> };
+
+    const linearBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Linear teams')
+    );
+    expect(linearBlock).toBeDefined();
+    expect((linearBlock as any).text.text).toContain('ENG, PLATFORM');
   });
 });
 

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -8,11 +8,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../lib/db', () => ({
   getUserDailies: vi.fn(() => Promise.resolve([])),
   getSubmissionForDate: vi.fn(() => Promise.resolve(null)),
+  getPreviousSubmission: vi.fn(() => Promise.resolve(null)),
   getGitHubUsername: vi.fn(() => Promise.resolve(null)),
   getLinearUserId: vi.fn(() => Promise.resolve(null)),
   setGitHubUsername: vi.fn(),
   setLinearUserId: vi.fn(),
-  getDmStandupPreference: vi.fn(() => Promise.resolve(true)),
+  getDmStandupPreference: vi.fn(() => Promise.resolve(false)),
 }));
 
 // Mock the config module
@@ -49,7 +50,7 @@ vi.mock('../lib/linear', () => ({
 }));
 
 import { buildHomeView, LinkedAccounts, handleAppHomeOpened, HomeContext, AppHomeOpenedEvent } from '../lib/handlers/home';
-import { getGitHubUsername, getLinearUserId } from '../lib/db';
+import { getGitHubUsername, getLinearUserId, getUserDailies, getSubmissionForDate, getPreviousSubmission } from '../lib/db';
 import { publishHomeView } from '../lib/slack';
 
 describe('buildHomeView - linked accounts section', () => {
@@ -128,6 +129,75 @@ describe('buildHomeView - linked accounts section', () => {
   });
 });
 
+describe('buildHomeView - Today\'s Plans section', () => {
+  it('shows plan items grouped by status', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: true,
+      tomorrowScheduled: false,
+      planItems: [
+        { text: 'Fix auth bug', status: 'done' as const },
+        { text: 'Refactor DB layer', status: 'in_progress' as const },
+        { text: 'Deploy to staging', status: 'planned' as const },
+        { text: 'Old task', status: 'carried' as const },
+        { text: 'Abandoned idea', status: 'dropped' as const },
+      ],
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    // Find context block with plan items
+    const planBlock = view.blocks.find(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('Fix auth bug')
+    );
+    expect(planBlock).toBeDefined();
+
+    const text = (planBlock as any).elements[0].text;
+    expect(text).toContain('✅ ~Fix auth bug~');
+    expect(text).toContain('🔄 Refactor DB layer');
+    expect(text).toContain('⬜ Deploy to staging');
+    expect(text).toContain('➡️ Old task _(carried)_');
+    expect(text).toContain('❌ ~Abandoned idea~');
+  });
+
+  it('shows source tags for integration items', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: true,
+      tomorrowScheduled: false,
+      planItems: [
+        { text: '[LIN-123] Fix auth', status: 'planned' as const, source: 'LIN-123' },
+        { text: '[repo#45] Add tests', status: 'done' as const, source: 'repo#45' },
+        { text: 'Manual task', status: 'planned' as const },
+      ],
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    const planBlock = view.blocks.find(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('LIN-123')
+    );
+    expect(planBlock).toBeDefined();
+    const text = (planBlock as any).elements[0].text;
+    expect(text).toContain('· _LIN-123_');
+    expect(text).toContain('· _repo#45_');
+    expect(text).not.toContain('Manual task · _');
+  });
+
+  it('does not show plan section when no submission', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: false,
+      tomorrowScheduled: false,
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    // No context block with plan items
+    const planBlocks = view.blocks.filter(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('⬜')
+    );
+    expect(planBlocks).toHaveLength(0);
+  });
+});
+
 describe('handleAppHomeOpened - fetches linked accounts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -155,5 +225,57 @@ describe('handleAppHomeOpened - fetches linked accounts', () => {
       (b: any) => b.type === 'section' && b.text?.text?.includes('@octocat')
     );
     expect(githubSection).toBeDefined();
+  });
+});
+
+describe('handleAppHomeOpened - Today\'s Plans from submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds plan items from today\'s submission', async () => {
+    // User is part of a daily
+    vi.mocked(getUserDailies).mockResolvedValueOnce([
+      { id: 1, slack_user_id: 'U12345', daily_name: 'daily-test', schedule_name: 'il-team', time_override: null, created_at: new Date() },
+    ]);
+    // Today's submission exists
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce({
+      id: 1,
+      slack_user_id: 'U12345',
+      daily_name: 'daily-test',
+      date: '2025-12-22',
+      submitted_at: new Date(),
+      yesterday_completed: ['Done task'],
+      yesterday_incomplete: ['Carried task'],
+      yesterday_in_progress: ['WIP task'],
+      unplanned: null,
+      today_plans: ['New plan'],
+      blockers: null,
+      custom_answers: null,
+      slack_message_ts: null,
+      posted: true,
+    });
+    // No previous submission (so no dropped items)
+    vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+    vi.mocked(publishHomeView).mockResolvedValueOnce(true);
+
+    const event: AppHomeOpenedEvent = { type: 'app_home_opened', user: 'U12345', tab: 'home' };
+    const ctx: HomeContext = { db: {} as any, slackToken: 'xoxb-test' };
+
+    await handleAppHomeOpened(event, ctx);
+
+    const publishCall = vi.mocked(publishHomeView).mock.calls[0];
+    const view = publishCall[2] as { blocks: Array<Record<string, unknown>> };
+
+    // Find the context block with plan items
+    const planBlock = view.blocks.find(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('New plan')
+    );
+    expect(planBlock).toBeDefined();
+    const text = (planBlock as any).elements[0].text;
+    expect(text).toContain('🔄 WIP task');
+    expect(text).toContain('➡️ Carried task');
+    expect(text).toContain('⬜ New plan');
+    expect(text).toContain('✅ ~Done task~');
   });
 });

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -335,6 +335,180 @@ describe('handleAppHomeOpened - fetches linked accounts', () => {
   });
 });
 
+describe('buildHomeView - Interactive task management', () => {
+  it('renders active items with overflow menus when plan items have ids', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: true,
+      tomorrowScheduled: false,
+      planItems: [
+        { id: 10, text: 'Fix bug', status: 'planned' as const },
+        { id: 11, text: 'Write tests', status: 'in_progress' as const },
+        { id: 12, text: 'Old task', status: 'carried' as const },
+      ],
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    const bugBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Fix bug')
+    );
+    expect(bugBlock).toBeDefined();
+    expect((bugBlock as any).accessory?.type).toBe('overflow');
+    expect((bugBlock as any).accessory?.action_id).toBe('task_action');
+
+    // Verify the overflow options encode itemId, dailyName, and action
+    const options = (bugBlock as any).accessory?.options as Array<{ value: string }>;
+    expect(options).toHaveLength(3);
+    const doneValue = JSON.parse(options[0].value);
+    expect(doneValue.itemId).toBe(10);
+    expect(doneValue.dailyName).toBe('daily-test');
+    expect(doneValue.action).toBe('done');
+
+    const inProgressValue = JSON.parse(options[1].value);
+    expect(inProgressValue.action).toBe('in_progress');
+
+    const dropValue = JSON.parse(options[2].value);
+    expect(dropValue.action).toBe('drop');
+  });
+
+  it('renders terminal items (done/dropped) without overflow menus', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: true,
+      tomorrowScheduled: false,
+      planItems: [
+        { id: 20, text: 'Completed thing', status: 'done' as const },
+        { id: 21, text: 'Abandoned thing', status: 'dropped' as const },
+      ],
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    const doneBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Completed thing')
+    );
+    expect(doneBlock).toBeDefined();
+    expect((doneBlock as any).accessory).toBeUndefined();
+
+    const droppedBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Abandoned thing')
+    );
+    expect(droppedBlock).toBeDefined();
+    expect((droppedBlock as any).accessory).toBeUndefined();
+  });
+
+  it('renders Add Item button after each daily\'s task list', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-il',
+      todaySubmitted: true,
+      tomorrowScheduled: false,
+      planItems: [
+        { id: 30, text: 'Some task', status: 'planned' as const },
+      ],
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    const addBlock = view.blocks.find(
+      (b: any) => b.type === 'actions' &&
+        b.elements?.[0]?.action_id === 'task_add'
+    );
+    expect(addBlock).toBeDefined();
+    expect((addBlock as any).elements[0].value).toBe('daily-il');
+    expect((addBlock as any).elements[0].text?.text).toContain('Add Item');
+  });
+
+  it('renders correct overflow menus for mixed active and terminal items', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: true,
+      tomorrowScheduled: false,
+      planItems: [
+        { id: 40, text: 'Active task', status: 'planned' as const },
+        { id: 41, text: 'Done task', status: 'done' as const },
+        { id: 42, text: 'WIP task', status: 'in_progress' as const },
+        { id: 43, text: 'Dropped task', status: 'dropped' as const },
+      ],
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    const activeBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Active task')
+    );
+    expect((activeBlock as any).accessory?.type).toBe('overflow');
+
+    const wipBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('WIP task')
+    );
+    expect((wipBlock as any).accessory?.type).toBe('overflow');
+
+    const doneBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Done task')
+    );
+    expect((doneBlock as any).accessory).toBeUndefined();
+
+    const droppedBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Dropped task')
+    );
+    expect((droppedBlock as any).accessory).toBeUndefined();
+  });
+
+  it('renders plan items without IDs as plain sections (backward compat)', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: true,
+      tomorrowScheduled: false,
+      planItems: [
+        // No `id` field — legacy JSONB fallback items
+        { text: 'Legacy active task', status: 'planned' as const },
+        { text: 'Legacy carried task', status: 'carried' as const },
+      ],
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    const legacyActive = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Legacy active task')
+    );
+    expect(legacyActive).toBeDefined();
+    // No overflow accessory because there is no id
+    expect((legacyActive as any).accessory).toBeUndefined();
+
+    const legacyCarried = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Legacy carried task')
+    );
+    expect(legacyCarried).toBeDefined();
+    expect((legacyCarried as any).accessory).toBeUndefined();
+  });
+
+  it('does not render Add Item button when planItems is empty or absent', () => {
+    // No planItems at all
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: false,
+      tomorrowScheduled: false,
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    const addBlock = view.blocks.find(
+      (b: any) => b.type === 'actions' && b.elements?.[0]?.action_id === 'task_add'
+    );
+    expect(addBlock).toBeUndefined();
+  });
+
+  it('does not render Add Item button when planItems array is empty', () => {
+    const dailyStatuses = [{
+      dailyName: 'daily-test',
+      todaySubmitted: true,
+      tomorrowScheduled: false,
+      planItems: [], // submitted but nothing to show
+    }];
+    const view = buildHomeView(dailyStatuses) as { blocks: Array<Record<string, unknown>> };
+
+    const addBlock = view.blocks.find(
+      (b: any) => b.type === 'actions' && b.elements?.[0]?.action_id === 'task_add'
+    );
+    expect(addBlock).toBeUndefined();
+  });
+});
+
 describe('handleAppHomeOpened - Today\'s Plans from submission', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -401,5 +575,82 @@ describe('handleAppHomeOpened - Today\'s Plans from submission', () => {
     );
     expect(doneBlock).toBeDefined();
     expect((doneBlock as any).text.text).toContain('✅ ~Done task~');
+
+    // JSONB fallback items have no IDs, so none should have overflow menus
+    const blocksWithOverflow = view.blocks.filter(
+      (b: any) => b.type === 'section' && b.accessory?.type === 'overflow'
+    );
+    expect(blocksWithOverflow).toHaveLength(0);
+  });
+
+  it('uses work_items rows (primary path) when they exist and renders overflow menus', async () => {
+    vi.mocked(getUserDailies).mockResolvedValueOnce([
+      { id: 1, slack_user_id: 'U12345', daily_name: 'daily-test', schedule_name: 'il-team', time_override: null, created_at: new Date() },
+    ]);
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce({
+      id: 5,
+      slack_user_id: 'U12345',
+      daily_name: 'daily-test',
+      date: '2025-12-22',
+      submitted_at: new Date(),
+      yesterday_completed: [],
+      yesterday_incomplete: [],
+      yesterday_in_progress: [],
+      unplanned: null,
+      today_plans: ['Plan from DB'],
+      blockers: null,
+      custom_answers: null,
+      slack_message_ts: 'ts-abc',
+      posted: true,
+      items_normalized: true,
+    });
+    vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+    // Return work_items with IDs — triggers primary path
+    vi.mocked(getActiveWorkItems).mockResolvedValueOnce([
+      {
+        id: 99,
+        slack_user_id: 'U12345',
+        daily_name: 'daily-test',
+        text: 'Plan from DB',
+        created_date: '2025-12-22',
+        status: 'pending',
+        carry_count: 0,
+        completed_date: null,
+        snoozed_until: null,
+        submission_id: 5,
+        source: 'manual',
+        source_ref: null,
+        source_url: null,
+        item_type: 'plan',
+      },
+    ]);
+    vi.mocked(publishHomeView).mockResolvedValueOnce(true);
+
+    const event: AppHomeOpenedEvent = { type: 'app_home_opened', user: 'U12345', tab: 'home' };
+    const ctx: HomeContext = { db: {} as any, slackToken: 'xoxb-test' };
+
+    await handleAppHomeOpened(event, ctx);
+
+    const publishCall = vi.mocked(publishHomeView).mock.calls[0];
+    const view = publishCall[2] as { blocks: Array<Record<string, unknown>> };
+
+    // The item should be rendered with an overflow menu because it has an id
+    const itemBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Plan from DB')
+    );
+    expect(itemBlock).toBeDefined();
+    expect((itemBlock as any).accessory?.type).toBe('overflow');
+    expect((itemBlock as any).accessory?.action_id).toBe('task_action');
+
+    const options = (itemBlock as any).accessory?.options as Array<{ value: string }>;
+    const doneOption = JSON.parse(options[0].value);
+    expect(doneOption.itemId).toBe(99);
+    expect(doneOption.action).toBe('done');
+
+    // Add Item button should be present
+    const addBlock = view.blocks.find(
+      (b: any) => b.type === 'actions' && b.elements?.[0]?.action_id === 'task_add'
+    );
+    expect(addBlock).toBeDefined();
   });
 });

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -1,0 +1,647 @@
+/**
+ * Integration tests for the HTTP handler (api/index.ts).
+ *
+ * These exercise the full fetch() entry point with properly-signed Slack
+ * requests, mocking only the DB layer and outgoing Slack API calls.
+ * Signature verification runs for real.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must appear before any import that touches the mocked modules
+// ---------------------------------------------------------------------------
+
+vi.mock('../lib/db', () => ({
+  getDb: vi.fn(() => ({ query: vi.fn(() => Promise.resolve([])) })),
+  getUserDailies: vi.fn(() => Promise.resolve([])),
+  getSubmissionForDate: vi.fn(() => Promise.resolve(null)),
+  getPreviousSubmission: vi.fn(() => Promise.resolve(null)),
+  getSubmissionsForDate: vi.fn(() => Promise.resolve([])),
+  getSubmissionsInRange: vi.fn(() => Promise.resolve([])),
+  saveSubmission: vi.fn(() => Promise.resolve({ id: 1, slack_message_ts: null })),
+  markPromptSubmitted: vi.fn(() => Promise.resolve()),
+  updateSubmissionMessageTs: vi.fn(() => Promise.resolve()),
+  markItemsDone: vi.fn(() => Promise.resolve()),
+  markItemsDropped: vi.fn(() => Promise.resolve()),
+  incrementCarryCount: vi.fn(() => Promise.resolve()),
+  markItemsInProgress: vi.fn(() => Promise.resolve()),
+  getInProgressCarryCounts: vi.fn(() => Promise.resolve({})),
+  createWorkItems: vi.fn(() => Promise.resolve()),
+  linkItemsToSubmission: vi.fn(() => Promise.resolve()),
+  addParticipant: vi.fn(() => Promise.resolve()),
+  removeParticipant: vi.fn(() => Promise.resolve()),
+  getParticipants: vi.fn(() => Promise.resolve([])),
+  getParticipationStats: vi.fn(() => Promise.resolve([])),
+  getTeamStats: vi.fn(() => Promise.resolve([])),
+  getMissingSubmissions: vi.fn(() => Promise.resolve([])),
+  countWorkdays: vi.fn(() => Promise.resolve(0)),
+  getActiveOOOForDaily: vi.fn(() => Promise.resolve([])),
+  setOOO: vi.fn(() => Promise.resolve()),
+  clearOOO: vi.fn(() => Promise.resolve()),
+  getUserOOO: vi.fn(() => Promise.resolve([])),
+  getGitHubUsername: vi.fn(() => Promise.resolve(null)),
+  setGitHubUsername: vi.fn(() => Promise.resolve()),
+  getLinearUserId: vi.fn(() => Promise.resolve(null)),
+  setLinearUserId: vi.fn(() => Promise.resolve()),
+  getRecentlyDoneLinearItems: vi.fn(() => Promise.resolve([])),
+  getDmStandupPreference: vi.fn(() => Promise.resolve(false)),
+  getActiveWorkItems: vi.fn(() => Promise.resolve([])),
+  getActiveWorkItemsBySourceRef: vi.fn(() => Promise.resolve([])),
+  getActiveLinearWorkItems: vi.fn(() => Promise.resolve([])),
+  updateWorkItemStatus: vi.fn(() => Promise.resolve()),
+  addWorkItem: vi.fn(() => Promise.resolve()),
+  updateSubmissionArrays: vi.fn(() => Promise.resolve()),
+  getUsersWithGitHubLinks: vi.fn(() => Promise.resolve([])),
+  getUsersWithLinearLinks: vi.fn(() => Promise.resolve([])),
+  getBottleneckItems: vi.fn(() => Promise.resolve([])),
+  getHighDropUsers: vi.fn(() => Promise.resolve([])),
+  getPeriodStats: vi.fn(() => Promise.resolve([])),
+  getTeamRankings: vi.fn(() => Promise.resolve([])),
+  deleteOldSubmissions: vi.fn(() => Promise.resolve()),
+  deleteOldPrompts: vi.fn(() => Promise.resolve()),
+  setConfigOverride: vi.fn(() => Promise.resolve()),
+  deleteConfigOverride: vi.fn(() => Promise.resolve()),
+  getAllConfigOverrides: vi.fn(() => Promise.resolve([])),
+  getBlockerStreaks: vi.fn(() => Promise.resolve([])),
+  getUnplannedOverload: vi.fn(() => Promise.resolve([])),
+  getOOOStartingOnDate: vi.fn(() => Promise.resolve([])),
+  getOrCreatePrompt: vi.fn(() => Promise.resolve({ id: 1, sent: false, submitted: false })),
+  updatePromptSent: vi.fn(() => Promise.resolve()),
+  getAllParticipants: vi.fn(() => Promise.resolve([])),
+  getUnpostedSubmissions: vi.fn(() => Promise.resolve([])),
+  markSubmissionPosted: vi.fn(() => Promise.resolve()),
+  healthCheck: vi.fn(() => Promise.resolve(true)),
+  getCachedUser: vi.fn(() => Promise.resolve(null)),
+  upsertCachedUser: vi.fn(() => Promise.resolve()),
+  getStaleUsers: vi.fn(() => Promise.resolve([])),
+  getUserSettings: vi.fn(() => Promise.resolve({ dmStandup: false, maxItems: null, stalePrDays: null, linearTeamFilter: null })),
+  updateUserSetting: vi.fn(() => Promise.resolve()),
+  getHighCarryItems: vi.fn(() => Promise.resolve([])),
+  getPendingItems: vi.fn(() => Promise.resolve([])),
+  wasReminderSent: vi.fn(() => Promise.resolve(false)),
+  recordReminderSent: vi.fn(() => Promise.resolve()),
+  snoozeItem: vi.fn(() => Promise.resolve()),
+  clearSnooze: vi.fn(() => Promise.resolve()),
+  getActiveOOO: vi.fn(() => Promise.resolve(null)),
+}));
+
+// Keep real: verifySlackSignature, parseCommandPayload, ephemeralResponse, parseRichText
+// Mock: openModal, publishHomeView, sendDM, postMessage, updateMessage, sendDMWithBlocks
+vi.mock('../lib/slack', async (importActual) => {
+  const real = await importActual<typeof import('../lib/slack')>();
+  return {
+    ...real,
+    openModal: vi.fn(() => Promise.resolve(true)),
+    publishHomeView: vi.fn(() => Promise.resolve(true)),
+    sendDM: vi.fn(() => Promise.resolve(true)),
+    sendDMWithBlocks: vi.fn(() => Promise.resolve(true)),
+    postMessage: vi.fn(() => Promise.resolve('ts.123')),
+    updateMessage: vi.fn(() => Promise.resolve(true)),
+  };
+});
+
+vi.mock('../lib/config', async (importActual) => {
+  const real = await importActual<typeof import('../lib/config')>();
+  return {
+    ...real,
+    loadConfigOverrides: vi.fn(() => Promise.resolve()),
+  };
+});
+
+vi.mock('../lib/prompt', async (importActual) => {
+  const real = await importActual<typeof import('../lib/prompt')>();
+  return {
+    ...real,
+    getUserTimezone: vi.fn(() => Promise.resolve({ tz: 'UTC', tz_offset: 0 })),
+    sendPromptDM: vi.fn(() => Promise.resolve(true)),
+    hasScheduledTimePassed: vi.fn(() => true),
+  };
+});
+
+vi.mock('../lib/format', async (importActual) => {
+  const real = await importActual<typeof import('../lib/format')>();
+  return {
+    ...real,
+    postStandupToChannel: vi.fn(() => Promise.resolve('ts.999')),
+    sendStandupDM: vi.fn(() => Promise.resolve()),
+  };
+});
+
+vi.mock('../lib/github', () => ({
+  fetchUserPRData: vi.fn(() => Promise.resolve({ reviewRequests: [], myPRs: [], prData: null })),
+  fetchMergedPRs: vi.fn(() => Promise.resolve([])),
+  fetchTeamPRData: vi.fn(() => Promise.resolve({})),
+  fetchTeamMergedPRs: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock('../lib/linear', () => ({
+  fetchUserAssignedIssues: vi.fn(() => Promise.resolve([])),
+  fetchUserLinearData: vi.fn(() => Promise.resolve(null)),
+  extractLinearReferences: vi.fn(() => []),
+  fetchWorkflowStates: vi.fn(() => Promise.resolve(new Map())),
+  markIssuesInProgress: vi.fn(() => Promise.resolve({ updated: 0, skipped: 0 })),
+  commentOnIssue: vi.fn(() => Promise.resolve()),
+  resolveIdentifiers: vi.fn(() => Promise.resolve(new Map())),
+  fetchTeamCycleData: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock('../lib/linear-intelligence', () => ({
+  computeLinearAlignment: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('../lib/github-intelligence', () => ({
+  computeGitHubAlignment: vi.fn(() => Promise.resolve([])),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import worker from '../api/index';
+import type { Env } from '../api/index';
+import { vi as _vi } from 'vitest';
+import { openModal, publishHomeView, sendDM } from '../lib/slack';
+import { getUserDailies, getSubmissionForDate, saveSubmission, getPreviousSubmission } from '../lib/db';
+import { sendPromptDM, hasScheduledTimePassed } from '../lib/prompt';
+import { postStandupToChannel } from '../lib/format';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_SIGNING_SECRET = 'test-signing-secret-abc123';
+const TEST_BOT_TOKEN = 'xoxb-test-token';
+const TEST_USER_ID = 'UTEST123';
+const DAILY_NAME = 'daily-test';
+
+function makeEnv(): Env {
+  return {
+    SLACK_BOT_TOKEN: TEST_BOT_TOKEN,
+    SLACK_SIGNING_SECRET: TEST_SIGNING_SECRET,
+    DATABASE_URL: 'postgres://test-not-real',
+  };
+}
+
+let waitUntilPromises: Promise<unknown>[] = [];
+
+function makeCtx(): ExecutionContext {
+  waitUntilPromises = [];
+  return {
+    waitUntil: (p: Promise<unknown>) => { waitUntilPromises.push(p); },
+    passThroughOnException: () => {},
+  } as unknown as ExecutionContext;
+}
+
+async function flushWaitUntil() {
+  await Promise.allSettled(waitUntilPromises);
+}
+
+async function signBody(body: string, timestamp: string): Promise<string> {
+  const sigBasestring = `v0:${timestamp}:${body}`;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(TEST_SIGNING_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(sigBasestring));
+  const hex = Array.from(new Uint8Array(sig))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `v0=${hex}`;
+}
+
+function freshTimestamp(): string {
+  return String(Math.floor(Date.now() / 1000));
+}
+
+async function commandRequest(fields: Record<string, string>): Promise<Request> {
+  const params = new URLSearchParams(fields);
+  const body = params.toString();
+  const ts = freshTimestamp();
+  const sig = await signBody(body, ts);
+  return new Request('https://bot.example.com/api/slack/commands', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'x-slack-request-timestamp': ts,
+      'x-slack-signature': sig,
+    },
+    body,
+  });
+}
+
+async function interactRequest(payload: object): Promise<Request> {
+  const body = `payload=${encodeURIComponent(JSON.stringify(payload))}`;
+  const ts = freshTimestamp();
+  const sig = await signBody(body, ts);
+  return new Request('https://bot.example.com/api/slack/interact', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'x-slack-request-timestamp': ts,
+      'x-slack-signature': sig,
+    },
+    body,
+  });
+}
+
+async function eventsRequest(payload: object): Promise<Request> {
+  const body = JSON.stringify(payload);
+  const ts = freshTimestamp();
+  const sig = await signBody(body, ts);
+  return new Request('https://bot.example.com/api/slack/events', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-slack-request-timestamp': ts,
+      'x-slack-signature': sig,
+    },
+    body,
+  });
+}
+
+function commandFields(overrides: Partial<Record<string, string>> = {}): Record<string, string> {
+  return {
+    command: '/standup',
+    text: 'help',
+    user_id: TEST_USER_ID,
+    user_name: 'testuser',
+    channel_id: 'C123',
+    channel_name: 'general',
+    team_id: 'T123',
+    response_url: 'https://hooks.slack.com/commands/T123/test',
+    trigger_id: 'tr.123.abc',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HTTP handler integration', () => {
+  const env = makeEnv();
+  let ctx: ExecutionContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = makeCtx();
+  });
+
+  // =========================================================================
+  // Health check
+  // =========================================================================
+
+  it('GET /api/health returns 200', async () => {
+    const req = new Request('https://bot.example.com/api/health');
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  // =========================================================================
+  // Signature verification
+  // =========================================================================
+
+  it('rejects requests with invalid signature', async () => {
+    const body = new URLSearchParams(commandFields()).toString();
+    const req = new Request('https://bot.example.com/api/slack/commands', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'x-slack-request-timestamp': freshTimestamp(),
+        'x-slack-signature': 'v0=0000000000000000000000000000000000000000000000000000000000000000',
+      },
+      body,
+    });
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects requests with missing signature', async () => {
+    const body = new URLSearchParams(commandFields()).toString();
+    const req = new Request('https://bot.example.com/api/slack/commands', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  // =========================================================================
+  // /standup help
+  // =========================================================================
+
+  it('/standup help returns help text', async () => {
+    const req = await commandRequest(commandFields({ text: 'help' }));
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json() as { text: string };
+    expect(json.text).toContain('/standup help');
+    expect(vi.mocked(openModal)).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // /standup prompt <daily>
+  // =========================================================================
+
+  it('/standup prompt sends a DM', async () => {
+    vi.mocked(getUserDailies).mockResolvedValueOnce([
+      { daily_name: DAILY_NAME, slack_user_id: TEST_USER_ID },
+    ] as any);
+    vi.mocked(sendPromptDM).mockResolvedValueOnce(true);
+
+    const req = await commandRequest(commandFields({ text: `prompt ${DAILY_NAME}` }));
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json() as { text: string };
+    expect(json.text).toContain('Sent');
+    expect(vi.mocked(sendPromptDM)).toHaveBeenCalledWith(
+      TEST_BOT_TOKEN, TEST_USER_ID, DAILY_NAME
+    );
+  });
+
+  // =========================================================================
+  // /daily command → openModal
+  // =========================================================================
+
+  it('/daily opens the standup modal', async () => {
+    vi.mocked(getUserDailies).mockResolvedValueOnce([
+      { daily_name: DAILY_NAME, slack_user_id: TEST_USER_ID },
+    ] as any);
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce(null);
+    vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+
+    const req = await commandRequest(commandFields({
+      command: '/daily',
+      text: '',
+    }));
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+
+    expect(vi.mocked(openModal)).toHaveBeenCalledTimes(1);
+    const [token, triggerId, modal] = vi.mocked(openModal).mock.calls[0];
+    expect(token).toBe(TEST_BOT_TOKEN);
+    expect(triggerId).toBe('tr.123.abc');
+    expect((modal as any).callback_id).toBe('standup_submission');
+    expect((modal as any).type).toBe('modal');
+  });
+
+  it('/daily with specific daily name opens modal for that daily', async () => {
+    vi.mocked(getUserDailies).mockResolvedValueOnce([
+      { daily_name: DAILY_NAME, slack_user_id: TEST_USER_ID },
+    ] as any);
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce(null);
+    vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+
+    const req = await commandRequest(commandFields({
+      command: '/daily',
+      text: DAILY_NAME,
+    }));
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(openModal)).toHaveBeenCalledTimes(1);
+
+    const modal = vi.mocked(openModal).mock.calls[0][2] as any;
+    const metadata = JSON.parse(modal.private_metadata);
+    expect(metadata.dailyName).toBe(DAILY_NAME);
+  });
+
+  it('/daily without trigger_id returns error', async () => {
+    const req = await commandRequest(commandFields({
+      command: '/daily',
+      text: '',
+      trigger_id: '',
+    }));
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json() as { text: string };
+    expect(json.text).toContain('Unable to open modal');
+  });
+
+  it('/daily for user not in any daily returns error', async () => {
+    vi.mocked(getUserDailies).mockResolvedValueOnce([]);
+
+    const req = await commandRequest(commandFields({
+      command: '/daily',
+      text: '',
+    }));
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json() as { text: string };
+    expect(json.text).toContain("not part of any dailies");
+  });
+
+  // =========================================================================
+  // Modal submission (view_submission)
+  // =========================================================================
+
+  it('standup submission saves to DB and posts to channel', async () => {
+    vi.mocked(saveSubmission).mockResolvedValueOnce({ id: 42, slack_message_ts: null } as any);
+    vi.mocked(hasScheduledTimePassed).mockReturnValue(true);
+    vi.mocked(postStandupToChannel).mockResolvedValueOnce('ts.posted');
+
+    const payload = {
+      type: 'view_submission',
+      user: { id: TEST_USER_ID },
+      view: {
+        callback_id: 'standup_submission',
+        private_metadata: JSON.stringify({
+          dailyName: DAILY_NAME,
+          mode: 'today',
+          targetDate: '2026-05-09',
+        }),
+        state: {
+          values: {
+            today_plans: { plans_input: { value: 'Build feature X\nFix bug Y' } },
+          },
+        },
+      },
+    };
+
+    const req = await interactRequest(payload);
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+
+    await flushWaitUntil();
+
+    expect(vi.mocked(saveSubmission)).toHaveBeenCalledTimes(1);
+    const saveCall = vi.mocked(saveSubmission).mock.calls[0];
+    expect(saveCall[1]).toMatchObject({
+      slackUserId: TEST_USER_ID,
+      dailyName: DAILY_NAME,
+      todayPlans: ['Build feature X', 'Fix bug Y'],
+    });
+
+    expect(vi.mocked(postStandupToChannel)).toHaveBeenCalledTimes(1);
+  });
+
+  it('standup submission returns validation error when no plans', async () => {
+    const payload = {
+      type: 'view_submission',
+      user: { id: TEST_USER_ID },
+      view: {
+        callback_id: 'standup_submission',
+        private_metadata: JSON.stringify({
+          dailyName: DAILY_NAME,
+          mode: 'today',
+          targetDate: '2026-05-09',
+        }),
+        state: {
+          values: {
+            today_plans: { plans_input: { value: '' } },
+          },
+        },
+      },
+    };
+
+    const req = await interactRequest(payload);
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+
+    const json = await res.json() as { response_action?: string; errors?: Record<string, string> };
+    expect(json.response_action).toBe('errors');
+    expect(json.errors?.today_plans).toBeDefined();
+  });
+
+  it('re-submit updates existing channel post instead of posting new', async () => {
+    vi.mocked(saveSubmission).mockResolvedValueOnce({
+      id: 42,
+      slack_message_ts: 'existing.ts.123',
+    } as any);
+    vi.mocked(hasScheduledTimePassed).mockReturnValue(true);
+
+    const payload = {
+      type: 'view_submission',
+      user: { id: TEST_USER_ID },
+      view: {
+        callback_id: 'standup_submission',
+        private_metadata: JSON.stringify({
+          dailyName: DAILY_NAME,
+          mode: 'today',
+          targetDate: '2026-05-09',
+        }),
+        state: {
+          values: {
+            today_plans: { plans_input: { value: 'Updated plan' } },
+          },
+        },
+      },
+    };
+
+    const req = await interactRequest(payload);
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+
+    await flushWaitUntil();
+
+    // Should NOT post a new message
+    expect(vi.mocked(postStandupToChannel)).not.toHaveBeenCalled();
+    // Should update the existing one
+    const { updateMessage } = await import('../lib/slack');
+    expect(vi.mocked(updateMessage)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(updateMessage).mock.calls[0][2]).toBe('existing.ts.123');
+  });
+
+  // =========================================================================
+  // Edit standup button (block_actions)
+  // =========================================================================
+
+  it('home_edit_standup button opens modal with prefill', async () => {
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce({
+      id: 99,
+      slack_user_id: TEST_USER_ID,
+      daily_name: DAILY_NAME,
+      date: '2026-05-09',
+      today_plans: ['Fix bug'],
+      unplanned: [],
+      blockers: '',
+      custom_answers: {},
+      yesterday_completed: [],
+      yesterday_incomplete: [],
+      yesterday_in_progress: [],
+      yesterday_dropped: [],
+      slack_message_ts: 'ts.existing',
+      posted: true,
+    } as any);
+    vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+
+    const payload = {
+      type: 'block_actions',
+      user: { id: TEST_USER_ID },
+      trigger_id: 'tr.edit.123',
+      actions: [{ action_id: 'home_edit_standup', value: DAILY_NAME }],
+    };
+
+    const req = await interactRequest(payload);
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+
+    expect(vi.mocked(openModal)).toHaveBeenCalledTimes(1);
+    const [token, triggerId, modal] = vi.mocked(openModal).mock.calls[0];
+    expect(token).toBe(TEST_BOT_TOKEN);
+    expect(triggerId).toBe('tr.edit.123');
+    expect((modal as any).callback_id).toBe('standup_submission');
+  });
+
+  // =========================================================================
+  // App Home opened event
+  // =========================================================================
+
+  it('app_home_opened publishes home view', async () => {
+    vi.mocked(getUserDailies).mockResolvedValueOnce([
+      { daily_name: DAILY_NAME, slack_user_id: TEST_USER_ID },
+    ] as any);
+
+    const payload = {
+      type: 'event_callback',
+      event: {
+        type: 'app_home_opened',
+        user: TEST_USER_ID,
+        tab: 'home',
+      },
+    };
+
+    const req = await eventsRequest(payload);
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+
+    expect(vi.mocked(publishHomeView)).toHaveBeenCalledTimes(1);
+    const [token, userId] = vi.mocked(publishHomeView).mock.calls[0];
+    expect(token).toBe(TEST_BOT_TOKEN);
+    expect(userId).toBe(TEST_USER_ID);
+  });
+
+  it('url_verification challenge returns the challenge token', async () => {
+    const payload = {
+      type: 'url_verification',
+      challenge: 'test-challenge-token-xyz',
+    };
+
+    const req = await eventsRequest(payload);
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toBe('test-challenge-token-xyz');
+  });
+
+  // =========================================================================
+  // Route validation
+  // =========================================================================
+
+  it('unknown path returns 404', async () => {
+    const req = new Request('https://bot.example.com/api/nonexistent');
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it('GET on /api/slack/commands returns 405', async () => {
+    const req = new Request('https://bot.example.com/api/slack/commands');
+    const res = await worker.fetch(req, env, ctx);
+    expect(res.status).toBe(405);
+  });
+});

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -45,6 +45,7 @@ vi.mock('../lib/config', () => ({
   getSchedule: vi.fn(() => ({ default_time: '10:00' })),
   getGitHubConfig: vi.fn(() => null), // No GitHub integration by default
   getGitHubUsernameFromConfig: vi.fn(() => null),
+  getGitHubIntelligenceConfig: vi.fn(() => null), // No GitHub intelligence by default
   getLinearConfig: vi.fn(() => null), // No Linear integration by default
   getLinearUserIdFromConfig: vi.fn(() => null),
   getLinearTeamIdForUser: vi.fn(() => null),

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -28,6 +28,10 @@ vi.mock('../lib/db', () => ({
   getRecentlyDoneLinearItems: vi.fn(() => Promise.resolve([])),
   getDmStandupPreference: vi.fn(() => Promise.resolve(true)),
   setDmStandupPreference: vi.fn(),
+  // New task management functions
+  updateWorkItemStatus: vi.fn(() => Promise.resolve(true)),
+  addWorkItem: vi.fn(() => Promise.resolve({ id: 1, text: 'New item', status: 'pending' })),
+  updateSubmissionArrays: vi.fn(() => Promise.resolve()),
 }));
 
 // Mock the config module
@@ -53,6 +57,7 @@ vi.mock('../lib/slack', () => ({
   postMessage: vi.fn(),
   parseRichText: vi.fn(() => ''),
   sendDM: vi.fn(),
+  updateMessage: vi.fn(() => Promise.resolve(true)),
 }));
 
 // Mock the prompt module
@@ -68,6 +73,7 @@ vi.mock('../lib/prompt', () => ({
 vi.mock('../lib/format', () => ({
   postStandupToChannel: vi.fn(),
   sendStandupDM: vi.fn(),
+  formatStandupBlocks: vi.fn(() => []),
 }));
 
 // Mock the home module (imported by interactions for refreshHome)
@@ -76,8 +82,8 @@ vi.mock('../lib/handlers/home', () => ({
 }));
 
 import { handleSnoozeBottleneck, handleInteraction, handleOpenStandup, handleStandupSubmission, InteractionPayload, ValidationErrorResponse } from '../lib/handlers/interactions';
-import { snoozeItem, getPreviousSubmission, saveSubmission, markItemsInProgress, getInProgressCarryCounts } from '../lib/db';
-import { openModal, sendDM } from '../lib/slack';
+import { snoozeItem, getPreviousSubmission, saveSubmission, markItemsInProgress, getInProgressCarryCounts, updateWorkItemStatus, addWorkItem, updateSubmissionArrays, getSubmissionForDate } from '../lib/db';
+import { openModal, sendDM, updateMessage } from '../lib/slack';
 import { getMaxPlanItems } from '../lib/config';
 
 describe('interaction handlers', () => {
@@ -723,5 +729,346 @@ describe('interaction handlers', () => {
       // In-progress items should come first, then carried, then new plans
       expect(metadata.yesterdayPlans).toEqual(['WIP task', 'Carried task', 'New task']);
     });
+  });
+});
+
+// ============================================================================
+// Task management: handleTaskAction
+// ============================================================================
+
+describe('handleInteraction - task_action (overflow menu)', () => {
+  const makeTaskActionPayload = (action: string, itemId = 55): InteractionPayload => ({
+    type: 'block_actions',
+    trigger_id: 'trigger-task',
+    user: { id: 'U12345' },
+    actions: [{
+      action_id: 'task_action',
+      value: '',
+      selected_option: {
+        value: JSON.stringify({ itemId, dailyName: 'daily-il', action }),
+      },
+    }],
+  });
+
+  const ctx = { db: {} as any, slackToken: 'xoxb-test' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: submission exists and is posted
+    vi.mocked(getSubmissionForDate).mockResolvedValue({
+      id: 1,
+      slack_user_id: 'U12345',
+      daily_name: 'daily-il',
+      date: '2025-12-22',
+      submitted_at: new Date(),
+      yesterday_completed: [],
+      yesterday_incomplete: [],
+      yesterday_in_progress: [],
+      unplanned: null,
+      today_plans: ['Some task'],
+      blockers: null,
+      custom_answers: null,
+      slack_message_ts: 'ts-111',
+      posted: true,
+      items_normalized: true,
+    });
+  });
+
+  it('mark done: calls updateWorkItemStatus with "done" and syncs arrays', async () => {
+    const result = await handleInteraction(makeTaskActionPayload('done', 55), ctx);
+
+    expect(result).toBe(true);
+    expect(updateWorkItemStatus).toHaveBeenCalledWith(
+      {},
+      55,
+      'done',
+      '2025-12-22' // today's date (mocked formatDate)
+    );
+    expect(updateSubmissionArrays).toHaveBeenCalledWith({}, 1, 'U12345', 'daily-il', '2025-12-22');
+  });
+
+  it('mark in_progress: calls updateWorkItemStatus with "in_progress" without completedDate', async () => {
+    const result = await handleInteraction(makeTaskActionPayload('in_progress', 55), ctx);
+
+    expect(result).toBe(true);
+    expect(updateWorkItemStatus).toHaveBeenCalledWith(
+      {},
+      55,
+      'in_progress',
+      undefined
+    );
+  });
+
+  it('drop: maps "drop" action to "dropped" status in db call', async () => {
+    const result = await handleInteraction(makeTaskActionPayload('drop', 55), ctx);
+
+    expect(result).toBe(true);
+    expect(updateWorkItemStatus).toHaveBeenCalledWith(
+      {},
+      55,
+      'dropped',
+      undefined
+    );
+  });
+
+  it('returns false when selected_option is missing', async () => {
+    const payload: InteractionPayload = {
+      type: 'block_actions',
+      trigger_id: 'trigger-task',
+      user: { id: 'U12345' },
+      actions: [{
+        action_id: 'task_action',
+        value: '',
+        // no selected_option
+      }],
+    };
+
+    const result = await handleInteraction(payload, ctx);
+    expect(result).toBe(false);
+    expect(updateWorkItemStatus).not.toHaveBeenCalled();
+  });
+
+  it('refreshes App Home after status update', async () => {
+    const { handleAppHomeOpened } = await import('../lib/handlers/home');
+    const result = await handleInteraction(makeTaskActionPayload('done', 55), ctx);
+
+    expect(result).toBe(true);
+    expect(handleAppHomeOpened).toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Task management: handleTaskAdd (Add Item button)
+// ============================================================================
+
+describe('handleInteraction - task_add (Add Item button)', () => {
+  const makeTaskAddPayload = (dailyName = 'daily-il'): InteractionPayload => ({
+    type: 'block_actions',
+    trigger_id: 'trigger-add',
+    user: { id: 'U12345' },
+    actions: [{ action_id: 'task_add', value: dailyName }],
+  });
+
+  const ctx = { db: {} as any, slackToken: 'xoxb-test' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens Add Item modal when submission exists', async () => {
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce({
+      id: 7,
+      slack_user_id: 'U12345',
+      daily_name: 'daily-il',
+      date: '2025-12-22',
+      submitted_at: new Date(),
+      yesterday_completed: [],
+      yesterday_incomplete: [],
+      yesterday_in_progress: [],
+      unplanned: null,
+      today_plans: [],
+      blockers: null,
+      custom_answers: null,
+      slack_message_ts: null,
+      posted: false,
+      items_normalized: true,
+    });
+    vi.mocked(openModal).mockResolvedValueOnce(true);
+
+    const result = await handleInteraction(makeTaskAddPayload(), ctx);
+
+    expect(result).toBe(true);
+    expect(openModal).toHaveBeenCalled();
+
+    const modalArg = vi.mocked(openModal).mock.calls[0][2];
+    expect(modalArg.callback_id).toBe('task_add_submission');
+
+    const metadata = JSON.parse(modalArg.private_metadata);
+    expect(metadata.dailyName).toBe('daily-il');
+    expect(metadata.submissionId).toBe(7);
+  });
+
+  it('sends DM error and does not open modal when no submission exists', async () => {
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce(null);
+
+    const result = await handleInteraction(makeTaskAddPayload(), ctx);
+
+    expect(result).toBe(true); // handler returns true to acknowledge the action
+    expect(openModal).not.toHaveBeenCalled();
+    expect(sendDM).toHaveBeenCalledWith(
+      'xoxb-test',
+      'U12345',
+      expect.stringContaining('submit your')
+    );
+  });
+});
+
+// ============================================================================
+// Task management: handleTaskAddSubmission (modal submit)
+// ============================================================================
+
+describe('handleInteraction - task_add_submission (modal)', () => {
+  const makeTaskAddSubmissionPayload = (text: string, submissionId = 7): InteractionPayload => ({
+    type: 'view_submission',
+    trigger_id: 'trigger-add-sub',
+    user: { id: 'U12345' },
+    view: {
+      callback_id: 'task_add_submission',
+      private_metadata: JSON.stringify({ dailyName: 'daily-il', date: '2025-12-22', submissionId }),
+      state: {
+        values: {
+          task_text: {
+            task_text_input: { value: text },
+          },
+        },
+      },
+    },
+  });
+
+  const ctx = { db: {} as any, slackToken: 'xoxb-test' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSubmissionForDate).mockResolvedValue(null); // syncStandupPost will no-op
+  });
+
+  it('creates work item and syncs submission arrays on valid submission', async () => {
+    const result = await handleInteraction(makeTaskAddSubmissionPayload('New task item'), ctx);
+
+    expect(result).toBe(true);
+    expect(addWorkItem).toHaveBeenCalledWith(
+      {},
+      'U12345',
+      'daily-il',
+      'New task item',
+      '2025-12-22',
+      7
+    );
+    expect(updateSubmissionArrays).toHaveBeenCalledWith({}, 7, 'U12345', 'daily-il', '2025-12-22');
+  });
+
+  it('refreshes App Home after adding item', async () => {
+    const { handleAppHomeOpened } = await import('../lib/handlers/home');
+    await handleInteraction(makeTaskAddSubmissionPayload('Another task'), ctx);
+
+    expect(handleAppHomeOpened).toHaveBeenCalled();
+  });
+
+  it('returns validation error when item text is empty', async () => {
+    const result = await handleInteraction(makeTaskAddSubmissionPayload(''), ctx);
+
+    expect(result).toEqual({
+      response_action: 'errors',
+      errors: { task_text: 'Please enter an item' },
+    });
+    expect(addWorkItem).not.toHaveBeenCalled();
+  });
+
+  it('returns validation error when item text is whitespace only', async () => {
+    const result = await handleInteraction(makeTaskAddSubmissionPayload('   '), ctx);
+
+    expect(result).toEqual({
+      response_action: 'errors',
+      errors: { task_text: 'Please enter an item' },
+    });
+    expect(addWorkItem).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// syncStandupPost (via handleTaskAction) — skips when submission conditions not met
+// ============================================================================
+
+describe('syncStandupPost — skip conditions (exercised via handleTaskAction)', () => {
+  const makeTaskActionPayload = (action: string): InteractionPayload => ({
+    type: 'block_actions',
+    trigger_id: 'trigger-task',
+    user: { id: 'U12345' },
+    actions: [{
+      action_id: 'task_action',
+      value: '',
+      selected_option: {
+        value: JSON.stringify({ itemId: 1, dailyName: 'daily-il', action }),
+      },
+    }],
+  });
+
+  const ctx = { db: {} as any, slackToken: 'xoxb-test' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips channel update when no submission exists for today', async () => {
+    vi.mocked(getSubmissionForDate).mockResolvedValue(null);
+
+    await handleInteraction(makeTaskActionPayload('done'), ctx);
+
+    // updateMessage should not be called because syncStandupPost returns early
+    expect(updateMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips channel update when submission exists but not yet posted', async () => {
+    vi.mocked(getSubmissionForDate).mockResolvedValue({
+      id: 2,
+      slack_user_id: 'U12345',
+      daily_name: 'daily-il',
+      date: '2025-12-22',
+      submitted_at: new Date(),
+      yesterday_completed: [],
+      yesterday_incomplete: [],
+      yesterday_in_progress: [],
+      unplanned: null,
+      today_plans: [],
+      blockers: null,
+      custom_answers: null,
+      slack_message_ts: null, // no ts → no update
+      posted: false,          // not posted → no update
+      items_normalized: true,
+    });
+
+    await handleInteraction(makeTaskActionPayload('done'), ctx);
+
+    expect(updateMessage).not.toHaveBeenCalled();
+  });
+
+  it('calls updateMessage when submission is posted with a message ts', async () => {
+    vi.mocked(getSubmissionForDate).mockResolvedValue({
+      id: 3,
+      slack_user_id: 'U12345',
+      daily_name: 'daily-il',
+      date: '2025-12-22',
+      submitted_at: new Date(),
+      yesterday_completed: [],
+      yesterday_incomplete: [],
+      yesterday_in_progress: [],
+      unplanned: null,
+      today_plans: ['Task one'],
+      blockers: null,
+      custom_answers: null,
+      slack_message_ts: 'ts-posted-999',
+      posted: true,
+      items_normalized: true,
+    });
+
+    // handleTaskAction uses ctx.waitUntil?.(syncPromise) — provide a waitUntil
+    // that actually awaits the promise so we can assert on updateMessage.
+    const backgroundPromises: Promise<unknown>[] = [];
+    const ctxWithWaitUntil = {
+      ...ctx,
+      waitUntil: (p: Promise<unknown>) => { backgroundPromises.push(p); },
+    };
+
+    await handleInteraction(makeTaskActionPayload('done'), ctxWithWaitUntil);
+    // Drain the background work
+    await Promise.all(backgroundPromises);
+
+    expect(updateMessage).toHaveBeenCalledWith(
+      'xoxb-test',
+      'C123', // daily channel from mocked getDaily
+      'ts-posted-999',
+      expect.any(String),
+      expect.any(Array)
+    );
   });
 });

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -17,6 +17,7 @@ vi.mock('../lib/db', () => ({
   markItemsInProgress: vi.fn(),
   getInProgressCarryCounts: vi.fn(() => Promise.resolve({})),
   createWorkItems: vi.fn(),
+  linkItemsToSubmission: vi.fn(),
   getGitHubUsername: vi.fn(() => Promise.resolve(null)),
   getLinearUserId: vi.fn(() => Promise.resolve(null)),
   setGitHubUsername: vi.fn(),

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -85,7 +85,7 @@ vi.mock('../lib/handlers/home', () => ({
   handleAppHomeOpened: vi.fn(() => Promise.resolve(true)),
 }));
 
-import { handleSnoozeBottleneck, handleInteraction, handleOpenStandup, handleStandupSubmission, InteractionPayload, ValidationErrorResponse } from '../lib/handlers/interactions';
+import { handleSnoozeBottleneck, handleInteraction, handleOpenStandup, handleStandupSubmission, handleEditStandup, InteractionPayload, ValidationErrorResponse } from '../lib/handlers/interactions';
 import { snoozeItem, getPreviousSubmission, saveSubmission, markItemsInProgress, getInProgressCarryCounts, updateWorkItemStatus, addWorkItem, updateSubmissionArrays, getSubmissionForDate, getParticipants } from '../lib/db';
 import { openModal, sendDM, updateMessage, extractMentionedUserIds, parseRichText } from '../lib/slack';
 import { getMaxPlanItems, getDaily, getSchedule, getConfigError } from '../lib/config';
@@ -1266,5 +1266,162 @@ describe('blocker @-mention DMs', () => {
       'U_OUTSIDE',
       expect.anything()
     );
+  });
+});
+
+// ============================================================================
+// Edit After Submit
+// ============================================================================
+
+describe('handleEditStandup', () => {
+  const makeEditPayload = (dailyName = 'daily-il'): InteractionPayload => ({
+    type: 'block_actions',
+    trigger_id: 'trigger-edit',
+    user: { id: 'U12345' },
+    actions: [{ action_id: 'home_edit_standup', value: dailyName }],
+  });
+
+  const ctx = { db: {} as any, slackToken: 'xoxb-test' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDaily).mockReturnValue({ name: 'daily-il', channel: 'C123', questions: [] } as any);
+    vi.mocked(getConfigError).mockReturnValue(null);
+  });
+
+  it('opens modal with prefill from today submission', async () => {
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce({
+      id: 10,
+      slack_user_id: 'U12345',
+      daily_name: 'daily-il',
+      date: '2025-12-22',
+      submitted_at: new Date(),
+      yesterday_completed: [],
+      yesterday_incomplete: [],
+      yesterday_in_progress: [],
+      unplanned: ['Fixed urgent bug'],
+      today_plans: ['Deploy feature', 'Code review'],
+      blockers: 'Waiting on QA',
+      custom_answers: null,
+      slack_message_ts: 'ts-orig',
+      posted: true,
+      items_normalized: true,
+    });
+    vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+    vi.mocked(openModal).mockResolvedValueOnce(true);
+
+    const result = await handleEditStandup(makeEditPayload(), ctx);
+
+    expect(result).toBe(true);
+    expect(openModal).toHaveBeenCalled();
+
+    const modalArg = vi.mocked(openModal).mock.calls[0][2];
+    const metadata = JSON.parse(modalArg.private_metadata);
+    expect(metadata.dailyName).toBe('daily-il');
+    expect(metadata.mode).toBe('today');
+  });
+
+  it('sends DM when no submission exists for today', async () => {
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce(null);
+
+    const result = await handleEditStandup(makeEditPayload(), ctx);
+
+    expect(result).toBe(true);
+    expect(openModal).not.toHaveBeenCalled();
+    expect(sendDM).toHaveBeenCalledWith(
+      'xoxb-test',
+      'U12345',
+      expect.stringContaining('No standup found')
+    );
+  });
+
+  it('routes home_edit_standup action correctly', async () => {
+    vi.mocked(getSubmissionForDate).mockResolvedValueOnce({
+      id: 10, slack_user_id: 'U12345', daily_name: 'daily-il', date: '2025-12-22',
+      submitted_at: new Date(), yesterday_completed: [], yesterday_incomplete: [],
+      yesterday_in_progress: [], unplanned: null, today_plans: ['Task'],
+      blockers: null, custom_answers: null, slack_message_ts: null,
+      posted: true, items_normalized: true,
+    });
+    vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+    vi.mocked(openModal).mockResolvedValueOnce(true);
+
+    const result = await handleInteraction(makeEditPayload(), ctx);
+    expect(result).toBe(true);
+    expect(openModal).toHaveBeenCalled();
+  });
+});
+
+describe('handleStandupSubmission - re-submit updates existing post', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDaily).mockReturnValue({ name: 'daily-il', channel: 'C123', questions: [] } as any);
+    vi.mocked(getSchedule).mockReturnValue({ default_time: '10:00' } as any);
+    vi.mocked(getConfigError).mockReturnValue(null);
+    vi.mocked(getMaxPlanItems).mockReturnValue(0);
+    vi.mocked(formatDate).mockReturnValue('2025-12-22');
+    vi.mocked(getDateInTimezone).mockReturnValue(new Date('2025-12-22T12:00:00'));
+    vi.mocked(hasScheduledTimePassed).mockReturnValue(true);
+    vi.mocked(postStandupToChannel).mockResolvedValue('ts-new' as any);
+  });
+
+  it('updates existing channel message when submission has slack_message_ts', async () => {
+    vi.mocked(saveSubmission).mockResolvedValueOnce({
+      id: 10,
+      slack_message_ts: 'ts-existing-123',
+    } as any);
+
+    const payload: InteractionPayload = {
+      type: 'view_submission',
+      trigger_id: 'trigger123',
+      user: { id: 'U12345' },
+      view: {
+        callback_id: 'standup_submission',
+        private_metadata: JSON.stringify({ dailyName: 'daily-il', yesterdayPlans: [], mode: 'today' }),
+        state: {
+          values: {
+            today_plans: { plans_input: { value: 'Updated plan' } },
+          },
+        },
+      },
+    };
+
+    await handleStandupSubmission(payload, { db: {} as any, slackToken: 'xoxb-test' });
+
+    expect(updateMessage).toHaveBeenCalledWith(
+      'xoxb-test',
+      'C123',
+      'ts-existing-123',
+      expect.any(String),
+      expect.any(Array)
+    );
+    expect(postStandupToChannel).not.toHaveBeenCalled();
+  });
+
+  it('posts new message when submission has no slack_message_ts', async () => {
+    vi.mocked(saveSubmission).mockResolvedValueOnce({
+      id: 11,
+      slack_message_ts: null,
+    } as any);
+
+    const payload: InteractionPayload = {
+      type: 'view_submission',
+      trigger_id: 'trigger123',
+      user: { id: 'U12345' },
+      view: {
+        callback_id: 'standup_submission',
+        private_metadata: JSON.stringify({ dailyName: 'daily-il', yesterdayPlans: [], mode: 'today' }),
+        state: {
+          values: {
+            today_plans: { plans_input: { value: 'New plan' } },
+          },
+        },
+      },
+    };
+
+    await handleStandupSubmission(payload, { db: {} as any, slackToken: 'xoxb-test' });
+
+    expect(postStandupToChannel).toHaveBeenCalled();
+    expect(updateMessage).not.toHaveBeenCalled();
   });
 });

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -51,6 +51,7 @@ vi.mock('../lib/config', () => ({
   getLinearUserIdFromConfig: vi.fn(() => null),
   getLinearTeamIdForUser: vi.fn(() => null),
   getMaxPlanItems: vi.fn(() => 0), // Disabled by default in tests
+  getDailySections: vi.fn(() => ({ blockers: true, unplanned: true })),
 }));
 
 // Mock the slack module
@@ -1075,6 +1076,102 @@ describe('syncStandupPost — skip conditions (exercised via handleTaskAction)',
       expect.any(String),
       expect.any(Array)
     );
+  });
+});
+
+describe('standup template sections - submission parsing', () => {
+  const makePayload = (opts: {
+    sections?: { blockers: boolean; unplanned: boolean };
+    blockerRichText?: object;
+    unplannedText?: string;
+  }): InteractionPayload => {
+    const values: Record<string, Record<string, any>> = {
+      today_plans: { plans_input: { value: 'some plan' } },
+    };
+    if (opts.unplannedText) {
+      values.unplanned = { unplanned_input: { value: opts.unplannedText } };
+    }
+    if (opts.blockerRichText) {
+      values.blockers = { blockers_input: { rich_text_value: opts.blockerRichText } };
+    }
+
+    return {
+      type: 'view_submission',
+      trigger_id: 'trigger123',
+      user: { id: 'U12345' },
+      view: {
+        callback_id: 'standup_submission',
+        private_metadata: JSON.stringify({
+          dailyName: 'daily-il',
+          yesterdayPlans: [],
+          mode: 'today',
+          ...(opts.sections ? { sections: opts.sections } : {}),
+        }),
+        state: { values },
+      },
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(saveSubmission).mockResolvedValue({ id: 1 } as any);
+    vi.mocked(getMaxPlanItems).mockReturnValue(0);
+    vi.mocked(parseRichText).mockReturnValue('some blocker text');
+  });
+
+  it('ignores unplanned input when sections.unplanned is false', async () => {
+    const payload = makePayload({
+      sections: { blockers: true, unplanned: false },
+      unplannedText: 'Fixed a bug',
+    });
+
+    await handleStandupSubmission(payload, { db: {} as any, slackToken: 'xoxb-test' });
+
+    const saveCall = vi.mocked(saveSubmission).mock.calls[0][1];
+    expect(saveCall.unplanned).toEqual([]);
+  });
+
+  it('ignores blockers input when sections.blockers is false', async () => {
+    const payload = makePayload({
+      sections: { blockers: false, unplanned: true },
+      blockerRichText: { type: 'rich_text', elements: [] },
+    });
+
+    await handleStandupSubmission(payload, { db: {} as any, slackToken: 'xoxb-test' });
+
+    const saveCall = vi.mocked(saveSubmission).mock.calls[0][1];
+    expect(saveCall.blockers).toBe('');
+  });
+
+  it('parses both when sections are both true', async () => {
+    vi.mocked(parseRichText).mockReturnValue('blocker text');
+
+    const payload = makePayload({
+      sections: { blockers: true, unplanned: true },
+      unplannedText: 'Fixed a bug',
+      blockerRichText: { type: 'rich_text', elements: [] },
+    });
+
+    await handleStandupSubmission(payload, { db: {} as any, slackToken: 'xoxb-test' });
+
+    const saveCall = vi.mocked(saveSubmission).mock.calls[0][1];
+    expect(saveCall.unplanned).toEqual(['Fixed a bug']);
+    expect(saveCall.blockers).toBe('blocker text');
+  });
+
+  it('defaults to parsing both when sections not in metadata', async () => {
+    vi.mocked(parseRichText).mockReturnValue('blocker text');
+
+    const payload = makePayload({
+      unplannedText: 'Fixed a bug',
+      blockerRichText: { type: 'rich_text', elements: [] },
+    });
+
+    await handleStandupSubmission(payload, { db: {} as any, slackToken: 'xoxb-test' });
+
+    const saveCall = vi.mocked(saveSubmission).mock.calls[0][1];
+    expect(saveCall.unplanned).toEqual(['Fixed a bug']);
+    expect(saveCall.blockers).toBe('blocker text');
   });
 });
 

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -32,6 +32,7 @@ vi.mock('../lib/db', () => ({
   updateWorkItemStatus: vi.fn(() => Promise.resolve(true)),
   addWorkItem: vi.fn(() => Promise.resolve({ id: 1, text: 'New item', status: 'pending' })),
   updateSubmissionArrays: vi.fn(() => Promise.resolve()),
+  getParticipants: vi.fn(() => Promise.resolve([])),
 }));
 
 // Mock the config module
@@ -59,6 +60,7 @@ vi.mock('../lib/slack', () => ({
   parseRichText: vi.fn(() => ''),
   sendDM: vi.fn(),
   updateMessage: vi.fn(() => Promise.resolve(true)),
+  extractMentionedUserIds: vi.fn(() => []),
 }));
 
 // Mock the prompt module
@@ -83,9 +85,11 @@ vi.mock('../lib/handlers/home', () => ({
 }));
 
 import { handleSnoozeBottleneck, handleInteraction, handleOpenStandup, handleStandupSubmission, InteractionPayload, ValidationErrorResponse } from '../lib/handlers/interactions';
-import { snoozeItem, getPreviousSubmission, saveSubmission, markItemsInProgress, getInProgressCarryCounts, updateWorkItemStatus, addWorkItem, updateSubmissionArrays, getSubmissionForDate } from '../lib/db';
-import { openModal, sendDM, updateMessage } from '../lib/slack';
-import { getMaxPlanItems } from '../lib/config';
+import { snoozeItem, getPreviousSubmission, saveSubmission, markItemsInProgress, getInProgressCarryCounts, updateWorkItemStatus, addWorkItem, updateSubmissionArrays, getSubmissionForDate, getParticipants } from '../lib/db';
+import { openModal, sendDM, updateMessage, extractMentionedUserIds, parseRichText } from '../lib/slack';
+import { getMaxPlanItems, getDaily, getSchedule, getConfigError } from '../lib/config';
+import { postStandupToChannel } from '../lib/format';
+import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed } from '../lib/prompt';
 
 describe('interaction handlers', () => {
   beforeEach(() => {
@@ -1070,6 +1074,100 @@ describe('syncStandupPost — skip conditions (exercised via handleTaskAction)',
       'ts-posted-999',
       expect.any(String),
       expect.any(Array)
+    );
+  });
+});
+
+describe('blocker @-mention DMs', () => {
+  const makeSubmissionPayload = (blockerText: string): InteractionPayload => ({
+    type: 'view_submission',
+    user: { id: 'U_SUBMITTER' },
+    view: {
+      callback_id: 'standup_submission',
+      private_metadata: JSON.stringify({ dailyName: 'daily-il', yesterdayPlans: [], mode: 'today' }),
+      state: {
+        values: {
+          today_plans: { plans_input: { value: 'some plan' } },
+          blockers: { blockers_input: { rich_text_value: {} } },
+        },
+      },
+    },
+  });
+
+  const ctx = {
+    slackToken: 'xoxb-test',
+    db: {},
+    waitUntil: (p: Promise<unknown>) => { p.catch(() => {}); },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(extractMentionedUserIds).mockReturnValue([]);
+    vi.mocked(parseRichText).mockReturnValue('');
+    vi.mocked(saveSubmission).mockResolvedValue({ id: 1 } as any);
+    vi.mocked(getInProgressCarryCounts).mockResolvedValue({});
+    vi.mocked(getParticipants).mockResolvedValue([]);
+    vi.mocked(getDaily).mockReturnValue({ name: 'daily-il', channel: 'C123', questions: [] } as any);
+    vi.mocked(getSchedule).mockReturnValue({ default_time: '10:00' } as any);
+    vi.mocked(getConfigError).mockReturnValue(null);
+    vi.mocked(getMaxPlanItems).mockReturnValue(0);
+    vi.mocked(formatDate).mockReturnValue('2025-12-22');
+    vi.mocked(getDateInTimezone).mockReturnValue(new Date('2025-12-22T12:00:00'));
+    vi.mocked(getUserDate).mockReturnValue(new Date('2025-12-22T12:00:00'));
+    vi.mocked(getUserTimezone).mockResolvedValue({ tz: 'UTC', tz_offset: 0 } as any);
+    vi.mocked(hasScheduledTimePassed).mockReturnValue(true);
+    vi.mocked(postStandupToChannel).mockResolvedValue(undefined as any);
+  });
+
+  it('sends DM to mentioned participant', async () => {
+    vi.mocked(parseRichText).mockReturnValue('waiting on <@U_OTHER> for review');
+    vi.mocked(extractMentionedUserIds).mockReturnValue(['U_OTHER']);
+    vi.mocked(getParticipants).mockResolvedValue([
+      { slack_user_id: 'U_SUBMITTER' } as any,
+      { slack_user_id: 'U_OTHER' } as any,
+    ]);
+
+    await handleInteraction(makeSubmissionPayload('waiting on <@U_OTHER>'), ctx as any);
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(sendDM).toHaveBeenCalledWith(
+      'xoxb-test',
+      'U_OTHER',
+      expect.stringContaining('flagged you in a blocker')
+    );
+  });
+
+  it('does not DM self-mentions', async () => {
+    vi.mocked(parseRichText).mockReturnValue('I <@U_SUBMITTER> am blocked');
+    vi.mocked(extractMentionedUserIds).mockReturnValue(['U_SUBMITTER']);
+    vi.mocked(getParticipants).mockResolvedValue([
+      { slack_user_id: 'U_SUBMITTER' } as any,
+    ]);
+
+    await handleInteraction(makeSubmissionPayload('I <@U_SUBMITTER> am blocked'), ctx as any);
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(sendDM).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'U_SUBMITTER',
+      expect.stringContaining('flagged you in a blocker')
+    );
+  });
+
+  it('does not DM non-participants', async () => {
+    vi.mocked(parseRichText).mockReturnValue('need <@U_OUTSIDE> to help');
+    vi.mocked(extractMentionedUserIds).mockReturnValue(['U_OUTSIDE']);
+    vi.mocked(getParticipants).mockResolvedValue([
+      { slack_user_id: 'U_SUBMITTER' } as any,
+    ]);
+
+    await handleInteraction(makeSubmissionPayload('need <@U_OUTSIDE>'), ctx as any);
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(sendDM).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'U_OUTSIDE',
+      expect.anything()
     );
   });
 });

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -571,12 +571,12 @@ describe('interaction handlers', () => {
       expect(sendDM).toHaveBeenCalledWith(
         'xoxb-test',
         'U12345',
-        expect.stringContaining('planning 5 items today')
+        expect.stringContaining('planning 5 items')
       );
       expect(sendDM).toHaveBeenCalledWith(
         'xoxb-test',
         'U12345',
-        expect.stringContaining('under 5')
+        expect.stringContaining('3 new + 2 carried')
       );
     });
 
@@ -624,7 +624,12 @@ describe('interaction handlers', () => {
       expect(sendDM).toHaveBeenCalledWith(
         'xoxb-test',
         'U12345',
-        expect.stringContaining('planning 3 items today')
+        expect.stringContaining('planning 3 items')
+      );
+      expect(sendDM).toHaveBeenCalledWith(
+        'xoxb-test',
+        'U12345',
+        expect.stringContaining('1 new + 2 carried')
       );
     });
 

--- a/tests/linear-intelligence.test.ts
+++ b/tests/linear-intelligence.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for lib/linear-intelligence.ts
+ * Pure functions — no mocks required.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  matchItemToIssue,
+  computePriorityAlignment,
+  computeLinearAlignment,
+} from '../lib/linear-intelligence';
+import type { WorkItem } from '../lib/db';
+import type { LinearIssue } from '../lib/linear';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 1,
+    slack_user_id: 'U123',
+    daily_name: 'eng-daily',
+    text: 'Work on something',
+    created_date: '2026-05-07',
+    status: 'pending',
+    carry_count: 0,
+    completed_date: null,
+    snoozed_until: null,
+    submission_id: null,
+    source: 'manual',
+    source_ref: null,
+    source_url: null,
+    item_type: 'plan',
+    ...overrides,
+  };
+}
+
+function makeLinearIssue(overrides: Partial<LinearIssue> = {}): LinearIssue {
+  return {
+    id: 'issue-uuid-1',
+    identifier: 'ENG-100',
+    title: 'Default issue',
+    state: { name: 'In Progress', type: 'started' },
+    priority: 3,
+    url: 'https://linear.app/team/issue/ENG-100',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// matchItemToIssue
+// ============================================================================
+
+describe('matchItemToIssue', () => {
+  it('matches linear_ticket source by source_ref to issue identifier', () => {
+    const item = makeWorkItem({ source: 'linear_ticket', source_ref: 'ENG-123' });
+    const issue = makeLinearIssue({ identifier: 'ENG-123' });
+
+    const result = matchItemToIssue(item, [issue]);
+
+    expect(result).not.toBeNull();
+    expect(result!.identifier).toBe('ENG-123');
+  });
+
+  it('matches manual source via extractLinearReferences from text', () => {
+    const item = makeWorkItem({ source: 'manual', text: 'Fix ENG-123 bug in auth flow' });
+    const issue = makeLinearIssue({ identifier: 'ENG-123' });
+
+    const result = matchItemToIssue(item, [issue]);
+
+    expect(result).not.toBeNull();
+    expect(result!.identifier).toBe('ENG-123');
+  });
+
+  it('returns null for github_pr items (excluded from matching)', () => {
+    const item = makeWorkItem({ source: 'github_pr', source_ref: 'ENG-123' });
+    const issue = makeLinearIssue({ identifier: 'ENG-123' });
+
+    const result = matchItemToIssue(item, [issue]);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no issue matches the source_ref', () => {
+    const item = makeWorkItem({ source: 'linear_ticket', source_ref: 'ENG-999' });
+    const issue = makeLinearIssue({ identifier: 'ENG-123' });
+
+    const result = matchItemToIssue(item, [issue]);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for manual items without any Linear identifier in text', () => {
+    const item = makeWorkItem({ source: 'manual', text: 'Fix the login bug and update docs' });
+    const issue = makeLinearIssue({ identifier: 'ENG-123' });
+
+    const result = matchItemToIssue(item, [issue]);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for linear_ticket items with null source_ref', () => {
+    const item = makeWorkItem({ source: 'linear_ticket', source_ref: null });
+    const issue = makeLinearIssue({ identifier: 'ENG-123' });
+
+    const result = matchItemToIssue(item, [issue]);
+
+    expect(result).toBeNull();
+  });
+});
+
+// ============================================================================
+// computePriorityAlignment
+// ============================================================================
+
+describe('computePriorityAlignment', () => {
+  it('returns on-track when all high-priority (1-2) items are covered by work items', () => {
+    const workItems = [
+      makeWorkItem({ source: 'linear_ticket', source_ref: 'ENG-1' }),
+      makeWorkItem({ source: 'linear_ticket', source_ref: 'ENG-2' }),
+    ];
+    const issues = [
+      makeLinearIssue({ identifier: 'ENG-1', priority: 1 }), // Urgent
+      makeLinearIssue({ identifier: 'ENG-2', priority: 2 }), // High
+    ];
+
+    const { status, missedHighPriority } = computePriorityAlignment(workItems, issues);
+
+    expect(status).toBe('on-track');
+    expect(missedHighPriority).toHaveLength(0);
+  });
+
+  it('returns off-track when urgent (priority 1) items are missing from plans', () => {
+    const workItems = [
+      makeWorkItem({ source: 'linear_ticket', source_ref: 'ENG-2' }),
+    ];
+    const issues = [
+      makeLinearIssue({ identifier: 'ENG-1', priority: 1 }), // Urgent — not in plans
+      makeLinearIssue({ identifier: 'ENG-2', priority: 2 }), // High — covered
+    ];
+
+    const { status, missedHighPriority } = computePriorityAlignment(workItems, issues);
+
+    expect(status).toBe('off-track');
+    expect(missedHighPriority).toHaveLength(1);
+    expect(missedHighPriority[0].identifier).toBe('ENG-1');
+  });
+
+  it('returns on-track when no high-priority items exist (all low priority)', () => {
+    const workItems: WorkItem[] = [];
+    const issues = [
+      makeLinearIssue({ identifier: 'ENG-1', priority: 3 }), // Medium
+      makeLinearIssue({ identifier: 'ENG-2', priority: 4 }), // Low
+    ];
+
+    const { status, missedHighPriority } = computePriorityAlignment(workItems, issues);
+
+    expect(status).toBe('on-track');
+    expect(missedHighPriority).toHaveLength(0);
+  });
+
+  it('treats priority 0 (No priority) as NOT high priority', () => {
+    const workItems: WorkItem[] = [];
+    const issues = [
+      makeLinearIssue({ identifier: 'ENG-1', priority: 0 }), // No priority
+    ];
+
+    const { status, missedHighPriority } = computePriorityAlignment(workItems, issues);
+
+    expect(status).toBe('on-track');
+    expect(missedHighPriority).toHaveLength(0);
+  });
+
+  it('returns on-track with empty issues list', () => {
+    const workItems = [makeWorkItem({ source: 'linear_ticket', source_ref: 'ENG-1' })];
+    const issues: LinearIssue[] = [];
+
+    const { status, missedHighPriority } = computePriorityAlignment(workItems, issues);
+
+    expect(status).toBe('on-track');
+    expect(missedHighPriority).toHaveLength(0);
+  });
+
+  it('returns off-track with one High (priority 2) item missing from plans', () => {
+    const workItems: WorkItem[] = [
+      makeWorkItem({ source: 'linear_ticket', source_ref: 'ENG-10' }),
+    ];
+    const issues = [
+      makeLinearIssue({ identifier: 'ENG-10', priority: 3 }), // Medium — covered
+      makeLinearIssue({ identifier: 'ENG-11', priority: 2 }), // High — NOT covered
+    ];
+
+    const { status, missedHighPriority } = computePriorityAlignment(workItems, issues);
+
+    expect(status).toBe('off-track');
+    expect(missedHighPriority).toHaveLength(1);
+    expect(missedHighPriority[0].identifier).toBe('ENG-11');
+  });
+});
+
+// ============================================================================
+// computeLinearAlignment
+// ============================================================================
+
+describe('computeLinearAlignment', () => {
+  it('full alignment: all Linear items in plans, all manual items reference Linear', () => {
+    const workItems = [
+      makeWorkItem({ source: 'linear_ticket', source_ref: 'ENG-1' }),
+      makeWorkItem({ source: 'linear_ticket', source_ref: 'ENG-2' }),
+    ];
+    const issues = [
+      makeLinearIssue({ identifier: 'ENG-1', priority: 3 }),
+      makeLinearIssue({ identifier: 'ENG-2', priority: 4 }),
+    ];
+
+    const result = computeLinearAlignment('U123', workItems, issues);
+
+    expect(result.slackUserId).toBe('U123');
+    expect(result.plansNotInLinear).toHaveLength(0);
+    expect(result.linearNotInPlans).toHaveLength(0);
+    expect(result.priorityAlignment).toBe('on-track');
+    expect(result.missedHighPriority).toHaveLength(0);
+  });
+
+  it('partial alignment: some plans not in Linear, some Linear not in plans', () => {
+    const workItems = [
+      makeWorkItem({ id: 1, source: 'linear_ticket', source_ref: 'ENG-1' }),
+      makeWorkItem({ id: 2, source: 'manual', text: 'Write docs — no Linear ticket' }),
+    ];
+    const issues = [
+      makeLinearIssue({ identifier: 'ENG-1', priority: 3 }), // covered
+      makeLinearIssue({ identifier: 'ENG-2', priority: 3 }), // NOT in plans
+    ];
+
+    const result = computeLinearAlignment('U123', workItems, issues);
+
+    expect(result.plansNotInLinear).toHaveLength(1);
+    expect(result.plansNotInLinear[0]).toBe('Write docs — no Linear ticket');
+    expect(result.linearNotInPlans).toHaveLength(1);
+    expect(result.linearNotInPlans[0].identifier).toBe('ENG-2');
+  });
+
+  it('empty work items: all Linear issues flagged as not in plans', () => {
+    const workItems: WorkItem[] = [];
+    const issues = [
+      makeLinearIssue({ identifier: 'ENG-1', priority: 1 }),
+      makeLinearIssue({ identifier: 'ENG-2', priority: 2 }),
+    ];
+
+    const result = computeLinearAlignment('U456', workItems, issues);
+
+    expect(result.plansNotInLinear).toHaveLength(0);
+    expect(result.linearNotInPlans).toHaveLength(2);
+    // Priority off-track because urgent/high items are unaccounted
+    expect(result.priorityAlignment).toBe('off-track');
+    expect(result.missedHighPriority).toHaveLength(2);
+  });
+
+  it('empty Linear issues: manual items flagged as not in Linear', () => {
+    const workItems = [
+      makeWorkItem({ source: 'manual', text: 'Refactor auth module' }),
+      makeWorkItem({ source: 'manual', text: 'Update README' }),
+    ];
+    const issues: LinearIssue[] = [];
+
+    const result = computeLinearAlignment('U789', workItems, issues);
+
+    expect(result.plansNotInLinear).toHaveLength(2);
+    expect(result.plansNotInLinear).toContain('Refactor auth module');
+    expect(result.plansNotInLinear).toContain('Update README');
+    expect(result.linearNotInPlans).toHaveLength(0);
+    expect(result.priorityAlignment).toBe('on-track');
+  });
+
+  it('GitHub PR items excluded from plans not in Linear', () => {
+    const workItems = [
+      makeWorkItem({ source: 'github_pr', source_ref: 'pr-42', text: 'PR: fix login' }),
+      makeWorkItem({ source: 'manual', text: 'Deploy hotfix' }),
+    ];
+    const issues: LinearIssue[] = [];
+
+    const result = computeLinearAlignment('U123', workItems, issues);
+
+    // github_pr is not manual so it's excluded from plansNotInLinear
+    expect(result.plansNotInLinear).toHaveLength(1);
+    expect(result.plansNotInLinear[0]).toBe('Deploy hotfix');
+    // github_pr also can't match any issue — no linearNotInPlans since issues is empty
+    expect(result.linearNotInPlans).toHaveLength(0);
+  });
+
+  it('combined: cross-reference and priority alignment both computed correctly', () => {
+    const workItems = [
+      makeWorkItem({ id: 1, source: 'linear_ticket', source_ref: 'ENG-1' }),
+      makeWorkItem({ id: 2, source: 'manual', text: 'Fix ENG-3 crash on iOS' }),
+      makeWorkItem({ id: 3, source: 'manual', text: 'Team meeting prep' }),
+    ];
+    const issues = [
+      makeLinearIssue({ identifier: 'ENG-1', priority: 1 }), // Urgent — covered by linear_ticket
+      makeLinearIssue({ identifier: 'ENG-2', priority: 2 }), // High — NOT in plans (off-track)
+      makeLinearIssue({ identifier: 'ENG-3', priority: 3 }), // Medium — covered by manual mention
+    ];
+
+    const result = computeLinearAlignment('U123', workItems, issues);
+
+    // ENG-2 is assigned but not in any work item
+    expect(result.linearNotInPlans).toHaveLength(1);
+    expect(result.linearNotInPlans[0].identifier).toBe('ENG-2');
+
+    // "Team meeting prep" doesn't reference any Linear issue
+    expect(result.plansNotInLinear).toHaveLength(1);
+    expect(result.plansNotInLinear[0]).toBe('Team meeting prep');
+
+    // ENG-2 is High priority and missing
+    expect(result.priorityAlignment).toBe('off-track');
+    expect(result.missedHighPriority).toHaveLength(1);
+    expect(result.missedHighPriority[0].identifier).toBe('ENG-2');
+  });
+});

--- a/tests/linear.test.ts
+++ b/tests/linear.test.ts
@@ -12,6 +12,11 @@ import {
   fetchUserAssignedIssues,
   fetchUserLinearData,
   fetchTeamCycleData,
+  extractLinearReferences,
+  fetchWorkflowStates,
+  markIssuesInProgress,
+  commentOnIssue,
+  resolveIdentifiers,
 } from '../lib/linear';
 
 describe('linear client', () => {
@@ -853,6 +858,384 @@ describe('linear client', () => {
       expect(result.teamData).toHaveLength(1);
       expect(result.teamData[0].data.issues).toEqual([]);
       expect(result.cycleProgress).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // extractLinearReferences
+  // ============================================================================
+
+  describe('extractLinearReferences', () => {
+    it('finds a single reference', () => {
+      expect(extractLinearReferences('Blocked by ENG-123')).toEqual(['ENG-123']);
+    });
+
+    it('finds multiple references', () => {
+      expect(extractLinearReferences('ENG-123 and PLAT-456 are blocking')).toEqual([
+        'ENG-123',
+        'PLAT-456',
+      ]);
+    });
+
+    it('returns empty array when no references are present', () => {
+      expect(extractLinearReferences('No issues here')).toEqual([]);
+    });
+
+    it('handles trailing punctuation', () => {
+      expect(extractLinearReferences('See ENG-123.')).toEqual(['ENG-123']);
+    });
+
+    it('handles parentheses around a reference', () => {
+      expect(extractLinearReferences('(ENG-123)')).toEqual(['ENG-123']);
+    });
+
+    it('deduplicates repeated references', () => {
+      expect(extractLinearReferences('ENG-123 and also ENG-123')).toEqual(['ENG-123']);
+    });
+
+    it('does NOT match lowercase identifiers', () => {
+      expect(extractLinearReferences('eng-123')).toEqual([]);
+    });
+
+    it('returns empty array for empty string', () => {
+      expect(extractLinearReferences('')).toEqual([]);
+    });
+
+    it('handles mixed-case where prefix is all-caps but suffix is not', () => {
+      // Only all-caps prefix + digits should match; partial caps should not
+      expect(extractLinearReferences('Eng-123')).toEqual([]);
+    });
+
+    it('handles multiple occurrences of the same and different references', () => {
+      const result = extractLinearReferences('ENG-1 ENG-2 ENG-1 PLAT-9 PLAT-9');
+      expect(result).toHaveLength(3);
+      expect(result).toContain('ENG-1');
+      expect(result).toContain('ENG-2');
+      expect(result).toContain('PLAT-9');
+    });
+  });
+
+  // ============================================================================
+  // fetchWorkflowStates
+  // ============================================================================
+
+  describe('fetchWorkflowStates', () => {
+    it('returns a Map keyed by workflow state type with id and name', async () => {
+      const mockResponse = {
+        data: {
+          team: {
+            states: {
+              nodes: [
+                { id: 'state-started-1', name: 'In Progress', type: 'started' },
+                { id: 'state-unstarted-1', name: 'Todo', type: 'unstarted' },
+                { id: 'state-completed-1', name: 'Done', type: 'completed' },
+              ],
+            },
+          },
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await fetchWorkflowStates('token', 'team-1');
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get('started')).toEqual({ id: 'state-started-1', name: 'In Progress' });
+      expect(result.get('unstarted')).toEqual({ id: 'state-unstarted-1', name: 'Todo' });
+      expect(result.get('completed')).toEqual({ id: 'state-completed-1', name: 'Done' });
+    });
+
+    it('sends Authorization header with the provided token', async () => {
+      const mockResponse = {
+        data: { team: { states: { nodes: [] } } },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      await fetchWorkflowStates('my-linear-token', 'team-abc');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.linear.app/graphql',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'my-linear-token',
+          }),
+          body: expect.stringContaining('team-abc'),
+        })
+      );
+    });
+
+    it('returns empty Map when team has no states', async () => {
+      const mockResponse = {
+        data: { team: { states: { nodes: [] } } },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await fetchWorkflowStates('token', 'team-1');
+      expect(result.size).toBe(0);
+    });
+
+    it('throws on API error', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () => 'Unauthorized',
+      });
+
+      await expect(fetchWorkflowStates('bad-token', 'team-1')).rejects.toThrow('Linear API error');
+    });
+  });
+
+  // ============================================================================
+  // markIssuesInProgress
+  // ============================================================================
+
+  describe('markIssuesInProgress', () => {
+    it('calls issueUpdate for each issue ID and returns correct counts', async () => {
+      const makeSuccessResponse = (id: string) => ({
+        data: { issueUpdate: { success: true, issue: { id } } },
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: true, json: async () => makeSuccessResponse('issue-1') })
+        .mockResolvedValueOnce({ ok: true, json: async () => makeSuccessResponse('issue-2') });
+
+      const result = await markIssuesInProgress('token', ['issue-1', 'issue-2'], 'state-started-1');
+
+      expect(result.updated).toBe(2);
+      expect(result.skipped).toBe(0);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('sends the correct inProgressStateId in the mutation variables', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { issueUpdate: { success: true, issue: { id: 'issue-1' } } } }),
+      });
+
+      await markIssuesInProgress('token', ['issue-1'], 'state-started-xyz');
+
+      const callBody = JSON.parse(
+        (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body
+      );
+      expect(callBody.variables).toMatchObject({
+        stateId: 'state-started-xyz',
+      });
+    });
+
+    it('counts failed updates as skipped', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: { issueUpdate: { success: true, issue: { id: 'issue-1' } } } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: { issueUpdate: { success: false, issue: { id: 'issue-2' } } } }),
+        });
+
+      const result = await markIssuesInProgress('token', ['issue-1', 'issue-2'], 'state-started-1');
+
+      expect(result.updated).toBe(1);
+      expect(result.skipped).toBe(1);
+    });
+
+    it('handles API errors per issue and counts them as skipped', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { issueUpdate: { success: true, issue: { id: 'issue-1' } } } }) })
+        .mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'Server Error' });
+
+      const result = await markIssuesInProgress('token', ['issue-1', 'issue-2'], 'state-started-1');
+
+      expect(result.updated).toBe(1);
+      expect(result.skipped).toBe(1);
+    });
+
+    it('returns 0 updated and 0 skipped for empty issue list', async () => {
+      const result = await markIssuesInProgress('token', [], 'state-started-1');
+
+      expect(result.updated).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================================
+  // commentOnIssue
+  // ============================================================================
+
+  describe('commentOnIssue', () => {
+    it('returns true on successful comment creation', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { commentCreate: { success: true, comment: { id: 'comment-1' } } },
+        }),
+      });
+
+      const result = await commentOnIssue('token', 'issue-1', 'Great progress!');
+      expect(result).toBe(true);
+    });
+
+    it('sends the correct issueId and body in the mutation', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { commentCreate: { success: true, comment: { id: 'comment-1' } } },
+        }),
+      });
+
+      await commentOnIssue('token', 'issue-abc', 'Hello from standup');
+
+      const callBody = JSON.parse(
+        (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body
+      );
+      expect(callBody.variables).toMatchObject({
+        issueId: 'issue-abc',
+        body: 'Hello from standup',
+      });
+    });
+
+    it('returns false when the API reports success: false', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { commentCreate: { success: false, comment: null } },
+        }),
+      });
+
+      const result = await commentOnIssue('token', 'issue-1', 'Test comment');
+      expect(result).toBe(false);
+    });
+
+    it('throws on API error', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: async () => 'Forbidden',
+      });
+
+      await expect(commentOnIssue('token', 'issue-1', 'Test comment')).rejects.toThrow('Linear API error');
+    });
+
+    it('sends Authorization header with the provided token', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { commentCreate: { success: true, comment: { id: 'comment-1' } } },
+        }),
+      });
+
+      await commentOnIssue('my-token', 'issue-1', 'body text');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.linear.app/graphql',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'my-token' }),
+        })
+      );
+    });
+  });
+
+  // ============================================================================
+  // resolveIdentifiers
+  // ============================================================================
+
+  describe('resolveIdentifiers', () => {
+    it('returns a Map from identifier to UUID for resolved issues', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: { issue: { id: 'uuid-1', identifier: 'ENG-123' } } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: { issue: { id: 'uuid-2', identifier: 'PLAT-456' } } }),
+        });
+
+      const result = await resolveIdentifiers('token', ['ENG-123', 'PLAT-456']);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get('ENG-123')).toBe('uuid-1');
+      expect(result.get('PLAT-456')).toBe('uuid-2');
+    });
+
+    it('omits unresolvable identifiers from the Map', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: { issue: { id: 'uuid-1', identifier: 'ENG-123' } } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: { issue: null } }),
+        });
+
+      const result = await resolveIdentifiers('token', ['ENG-123', 'ENG-999']);
+
+      expect(result.size).toBe(1);
+      expect(result.get('ENG-123')).toBe('uuid-1');
+      expect(result.has('ENG-999')).toBe(false);
+    });
+
+    it('returns empty Map when no identifiers are provided', async () => {
+      const result = await resolveIdentifiers('token', []);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns empty Map on API error', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      const result = await resolveIdentifiers('token', ['ENG-123']);
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    it('sends per-identifier queries', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: { issue: { id: 'uuid-1', identifier: 'ENG-1' } } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: { issue: { id: 'uuid-2', identifier: 'ENG-2' } } }),
+        });
+
+      await resolveIdentifiers('token', ['ENG-1', 'ENG-2']);
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      const call1Body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+      const call2Body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[1][1].body);
+      expect(call1Body.variables.id).toBe('ENG-1');
+      expect(call2Body.variables.id).toBe('ENG-2');
+    });
+
+    it('handles null issue in response', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { issue: null } }),
+      });
+
+      const result = await resolveIdentifiers('token', ['ENG-999']);
+      expect(result.size).toBe(0);
     });
   });
 });

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -400,7 +400,7 @@ describe('modal builder', () => {
       expect(option?.text?.text).toContain('...');
     });
 
-    it('limits Linear issues to max 10 checkboxes', () => {
+    it('limits Linear issues to max 3 checkboxes', () => {
       const linearIssues: LinearIssue[] = Array.from({ length: 15 }, (_, i) => ({
         id: `issue-${i}`,
         identifier: `ENG-${100 + i}`,
@@ -423,10 +423,10 @@ describe('modal builder', () => {
 
       const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
 
-      expect(linearBlock?.element?.options).toHaveLength(10);
+      expect(linearBlock?.element?.options).toHaveLength(3);
     });
 
-    it('shows context message when more than 10 issues available', () => {
+    it('shows Show all button when more than 3 issues available', () => {
       const linearIssues: LinearIssue[] = Array.from({ length: 15 }, (_, i) => ({
         id: `issue-${i}`,
         identifier: `ENG-${100 + i}`,
@@ -447,12 +447,82 @@ describe('modal builder', () => {
         linearIssues
       );
 
-      const contextBlock = modal.blocks.find(
-        b => b.type === 'context' && b.elements?.[0]?.text?.includes('Showing 10 of')
+      const actionsBlock = modal.blocks.find(
+        b => b.type === 'actions' &&
+          (b.elements as any[])?.some((el: any) => el.action_id === 'show_all_linear')
       );
 
-      expect(contextBlock).toBeDefined();
-      expect(contextBlock?.elements?.[0]?.text).toContain('Showing 10 of 15 assigned tickets');
+      expect(actionsBlock).toBeDefined();
+      const showAllButton = (actionsBlock?.elements as any[])?.find(
+        (el: any) => el.action_id === 'show_all_linear'
+      );
+      expect(showAllButton).toBeDefined();
+    });
+
+    it('does not show Show all button when 3 or fewer linear issues', () => {
+      const linearIssues: LinearIssue[] = Array.from({ length: 3 }, (_, i) => ({
+        id: `issue-${i}`,
+        identifier: `ENG-${100 + i}`,
+        title: `Issue ${i}`,
+        state: { name: 'Todo', type: 'unstarted' },
+        priority: 1,
+        url: `https://linear.app/issue/ENG-${100 + i}`,
+      }));
+
+      const modal = buildStandupModal(
+        'daily-il',
+        null,
+        [],
+        undefined,
+        undefined,
+        'today',
+        undefined,
+        linearIssues
+      );
+
+      const showAllButton = modal.blocks.find(
+        b => b.type === 'actions' &&
+          (b.elements as any[])?.some((el: any) => el.action_id === 'show_all_linear')
+      );
+      expect(showAllButton).toBeUndefined();
+    });
+
+    it('shows all items when section is in expandedSections', () => {
+      const linearIssues: LinearIssue[] = Array.from({ length: 5 }, (_, i) => ({
+        id: `issue-${i}`,
+        identifier: `ENG-${100 + i}`,
+        title: `Issue ${i}`,
+        state: { name: 'Todo', type: 'unstarted' },
+        priority: 1,
+        url: `https://linear.app/issue/ENG-${100 + i}`,
+      }));
+
+      const modal = buildStandupModal(
+        'daily-il',
+        null,
+        [],
+        undefined,
+        undefined,
+        'today',
+        undefined,
+        linearIssues,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        new Set(['linear'])
+      );
+
+      const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
+      expect(linearBlock?.element?.options).toHaveLength(5);
+
+      const showAllButton = modal.blocks.find(
+        b => b.type === 'actions' &&
+          (b.elements as any[])?.some((el: any) => el.action_id === 'show_all_linear')
+      );
+      expect(showAllButton).toBeUndefined();
     });
 
     it('does not store integration maps in private_metadata (titles extracted from option text on submission)', () => {
@@ -787,6 +857,63 @@ describe('modal builder', () => {
       expect(modal.blocks.find(b => b.block_id === 'yesterday_item_0')).toBeDefined();
       expect(modal.blocks.find(b => b.block_id === 'yesterday_item_1')).toBeDefined();
       expect(modal.blocks.find(b => b.block_id === 'yesterday_item_2')).toBeDefined();
+    });
+
+    it('skips source-group headers when fewer than 4 yesterday items', () => {
+      // 3 items from mixed sources: manual, PR, Linear
+      const yesterday: YesterdayData = {
+        plans: [
+          'Manual task',
+          '[repo#1] PR task',
+          '[ENG-1] Linear task',
+        ],
+        completed: [],
+        incomplete: [],
+      };
+
+      const modal = buildStandupModal('daily-il', yesterday, []);
+
+      // No context blocks with group header emoji markers should appear
+      const groupHeaders = modal.blocks.filter(
+        (b: any) =>
+          b.type === 'context' &&
+          b.elements?.[0]?.text &&
+          (b.elements[0].text.includes('✍️') ||
+            b.elements[0].text.includes('📦') ||
+            b.elements[0].text.includes('🎫'))
+      );
+      expect(groupHeaders).toHaveLength(0);
+    });
+
+    it('shows source-group headers when 4 or more mixed-source yesterday items', () => {
+      // 4 items from mixed sources: 2 manual, 1 PR, 1 Linear
+      const yesterday: YesterdayData = {
+        plans: [
+          'Manual task A',
+          'Manual task B',
+          '[repo#1] PR task',
+          '[ENG-1] Linear task',
+        ],
+        completed: [],
+        incomplete: [],
+      };
+
+      const modal = buildStandupModal('daily-il', yesterday, []);
+
+      const groupHeaders = modal.blocks.filter(
+        (b: any) =>
+          b.type === 'context' &&
+          b.elements?.[0]?.text &&
+          (b.elements[0].text.includes('✍️') ||
+            b.elements[0].text.includes('📦') ||
+            b.elements[0].text.includes('🎫'))
+      );
+      expect(groupHeaders.length).toBeGreaterThanOrEqual(2);
+
+      const headerTexts = groupHeaders.map((b: any) => b.elements[0].text);
+      expect(headerTexts.some((t: string) => t.includes('✍️'))).toBe(true);
+      expect(headerTexts.some((t: string) => t.includes('📦'))).toBe(true);
+      expect(headerTexts.some((t: string) => t.includes('🎫'))).toBe(true);
     });
   });
 

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -702,6 +702,66 @@ describe('modal builder', () => {
     });
   });
 
+  describe('yesterday items grouping by source', () => {
+    it('groups items by source when mixed (manual, PR, Linear)', () => {
+      const yesterday: YesterdayData = {
+        plans: [
+          'Manual task',
+          '[repo#42] Fix typo',
+          '[ENG-123] Auth refactor',
+          'Another manual task',
+        ],
+        completed: [],
+        incomplete: [],
+      };
+
+      const modal = buildStandupModal('daily-il', yesterday, []);
+
+      // Should have group header context blocks when mixed
+      const contextBlocks = modal.blocks.filter(
+        (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('items')
+      );
+      expect(contextBlocks.length).toBe(3); // Manual, PR, Linear
+
+      // Verify headers exist
+      const headers = contextBlocks.map((b: any) => b.elements[0].text);
+      expect(headers).toContain('*✍️ Manual items*');
+      expect(headers).toContain('*📦 PR items*');
+      expect(headers).toContain('*🎫 Linear items*');
+    });
+
+    it('does not show group headers when all items are from one source', () => {
+      const yesterday: YesterdayData = {
+        plans: ['Task A', 'Task B', 'Task C'],
+        completed: [],
+        incomplete: [],
+      };
+
+      const modal = buildStandupModal('daily-il', yesterday, []);
+
+      // Should NOT have source group headers
+      const groupHeaders = modal.blocks.filter(
+        (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('items*')
+      );
+      expect(groupHeaders).toHaveLength(0);
+    });
+
+    it('preserves dropdown indices across groups', () => {
+      const yesterday: YesterdayData = {
+        plans: ['Manual task', '[repo#42] PR task', '[ENG-123] Linear task'],
+        completed: [],
+        incomplete: [],
+      };
+
+      const modal = buildStandupModal('daily-il', yesterday, []);
+
+      // All three items should have their original indices
+      expect(modal.blocks.find(b => b.block_id === 'yesterday_item_0')).toBeDefined();
+      expect(modal.blocks.find(b => b.block_id === 'yesterday_item_1')).toBeDefined();
+      expect(modal.blocks.find(b => b.block_id === 'yesterday_item_2')).toBeDefined();
+    });
+  });
+
   describe('plan-size warning banner', () => {
     const findWarning = (blocks: { type: string; text?: { text?: string } }[]) =>
       blocks.find(b => b.type === 'section' && b.text?.text?.includes('Teams usually stay under'));

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -484,6 +484,34 @@ describe('modal builder', () => {
       expect(metadata.prMap).toBeUndefined();
     });
 
+    it('stores prCategories in private_metadata when authored PRs are present', () => {
+      const prData: UserPRData = {
+        awaitingReview: [{
+          number: 42, title: 'Fix auth', url: 'https://github.com/org/my-repo/pull/42',
+          author: 'me', reviewsNeeded: 1, requestedReviewers: [], createdAt: '', updatedAt: '', draft: false,
+        }],
+        readyToMerge: [{
+          number: 99, title: 'Add caching', url: 'https://github.com/org/other-repo/pull/99',
+          author: 'me', reviewsNeeded: 0, requestedReviewers: [], createdAt: '', updatedAt: '', draft: false,
+        }],
+        draftPRs: [{
+          number: 7, title: 'WIP feature', url: 'https://github.com/org/draft-repo/pull/7',
+          author: 'me', reviewsNeeded: 0, requestedReviewers: [], createdAt: '', updatedAt: '', draft: true,
+        }],
+        reviewRequests: [],
+      };
+
+      const modal = buildStandupModal(
+        'daily-il', null, [], undefined, undefined, 'today', undefined, undefined, prData
+      );
+
+      const metadata = JSON.parse(modal.private_metadata);
+      expect(metadata.prCategories).toBeDefined();
+      expect(metadata.prCategories['my-repo#42']).toBe('awaiting review');
+      expect(metadata.prCategories['other-repo#99']).toBe('ready to merge');
+      expect(metadata.prCategories['draft-repo#7']).toBe('draft');
+    });
+
     it('filters out Linear issues that already appear in yesterday plans', () => {
       const yesterday: YesterdayData = {
         plans: ['[ENG-123] Fix authentication bug', 'Write unit tests'],

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -886,4 +886,94 @@ describe('modal builder', () => {
       expect(warning?.text?.text).toContain('5 items');
     });
   });
+
+  describe('standup template sections', () => {
+    it('hides blockers block when sections.blockers is false', () => {
+      const modal = buildStandupModal(
+        'daily-il', null, [], undefined, undefined, 'today', undefined,
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        { blockers: false, unplanned: true }
+      );
+
+      const blockersBlock = modal.blocks.find(b => b.block_id === 'blockers');
+      expect(blockersBlock).toBeUndefined();
+    });
+
+    it('hides unplanned block when sections.unplanned is false (first-time user)', () => {
+      const modal = buildStandupModal(
+        'daily-il', null, [], undefined, undefined, 'today', undefined,
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        { blockers: true, unplanned: false }
+      );
+
+      const unplannedBlock = modal.blocks.find(b => b.block_id === 'unplanned');
+      expect(unplannedBlock).toBeUndefined();
+    });
+
+    it('hides unplanned block when sections.unplanned is false (returning user)', () => {
+      const yesterday: YesterdayData = {
+        plans: ['Task A'],
+        completed: [],
+        incomplete: [],
+      };
+
+      const modal = buildStandupModal(
+        'daily-il', yesterday, [], undefined, undefined, 'today', undefined,
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        { blockers: true, unplanned: false }
+      );
+
+      const unplannedBlock = modal.blocks.find(b => b.block_id === 'unplanned');
+      expect(unplannedBlock).toBeUndefined();
+    });
+
+    it('hides both blockers and unplanned when both are false', () => {
+      const modal = buildStandupModal(
+        'daily-il', null, [], undefined, undefined, 'today', undefined,
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        { blockers: false, unplanned: false }
+      );
+
+      expect(modal.blocks.find(b => b.block_id === 'blockers')).toBeUndefined();
+      expect(modal.blocks.find(b => b.block_id === 'unplanned')).toBeUndefined();
+    });
+
+    it('shows both by default when sections parameter is undefined', () => {
+      const modal = buildStandupModal('daily-il', null, []);
+
+      expect(modal.blocks.find(b => b.block_id === 'blockers')).toBeDefined();
+      expect(modal.blocks.find(b => b.block_id === 'unplanned')).toBeDefined();
+    });
+
+    it('includes sections in private_metadata when provided', () => {
+      const sections = { blockers: false, unplanned: true };
+      const modal = buildStandupModal(
+        'daily-il', null, [], undefined, undefined, 'today', undefined,
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        sections
+      );
+
+      const metadata = JSON.parse(modal.private_metadata);
+      expect(metadata.sections).toEqual(sections);
+    });
+
+    it('omits sections from private_metadata when not provided', () => {
+      const modal = buildStandupModal('daily-il', null, []);
+
+      const metadata = JSON.parse(modal.private_metadata);
+      expect(metadata.sections).toBeUndefined();
+    });
+
+    it('still shows today_plans and custom questions when sections are disabled', () => {
+      const questions = [{ text: 'How are you?', required: false }];
+      const modal = buildStandupModal(
+        'daily-il', null, questions, undefined, undefined, 'today', undefined,
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        { blockers: false, unplanned: false }
+      );
+
+      expect(modal.blocks.find(b => b.block_id === 'today_plans')).toBeDefined();
+      expect(modal.blocks.find(b => b.block_id === 'custom_0')).toBeDefined();
+    });
+  });
 });

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -12,12 +12,43 @@ vi.mock('../lib/config', () => ({
   loadConfig: vi.fn(),
   getConfigError: vi.fn(() => null),
   getReminderMinutesBefore: vi.fn(() => 90),
+  getNudgeMinutesBefore: vi.fn(() => 0),
+  getDigestTime: vi.fn(() => '14:00'),
 }));
 
 // Mock slack module (makes API calls)
 vi.mock('../lib/slack', () => ({
   getUserInfo: vi.fn(),
   postMessage: vi.fn(),
+}));
+
+// Mock db module (for nudge cron tests)
+vi.mock('../lib/db', () => ({
+  getAllParticipants: vi.fn(() => Promise.resolve([])),
+  getOrCreatePrompt: vi.fn(),
+  updatePromptSent: vi.fn(),
+  getCachedUser: vi.fn(() => Promise.resolve(null)),
+  upsertCachedUser: vi.fn(),
+  getActiveOOO: vi.fn(() => Promise.resolve(null)),
+  getUnpostedSubmissions: vi.fn(() => Promise.resolve([])),
+  markSubmissionPosted: vi.fn(),
+  markItemsDone: vi.fn(),
+  markItemsDropped: vi.fn(),
+  incrementCarryCount: vi.fn(),
+  markItemsInProgress: vi.fn(),
+  createWorkItems: vi.fn(),
+  getGitHubUsername: vi.fn(() => Promise.resolve(null)),
+  getUsersWithGitHubLinks: vi.fn(() => Promise.resolve([])),
+  wasReminderSent: vi.fn(() => Promise.resolve(false)),
+  recordReminderSent: vi.fn(),
+  getDmStandupPreference: vi.fn(() => Promise.resolve(true)),
+  getMissingSubmissions: vi.fn(() => Promise.resolve([])),
+}));
+
+// Mock format module
+vi.mock('../lib/format', () => ({
+  postStandupToChannel: vi.fn(),
+  sendStandupDM: vi.fn(),
 }));
 
 import {
@@ -29,7 +60,11 @@ import {
   formatDate,
   getMinutesLate,
   formatLatenessPrefix,
+  runNudgeCron,
 } from '../lib/prompt';
+import { getDailies, getSchedule, getConfigError, getNudgeMinutesBefore, getDigestTime } from '../lib/config';
+import { postMessage } from '../lib/slack';
+import { getMissingSubmissions } from '../lib/db';
 
 describe('prompt utilities', () => {
   describe('formatDate', () => {
@@ -297,5 +332,93 @@ describe('prompt utilities', () => {
       expect(formatLatenessPrefix(75)).toBe('1h 15m late · ');
       expect(formatLatenessPrefix(90)).toBe('1h 30m late · ');
     });
+  });
+});
+
+describe('runNudgeCron', () => {
+  const mockDb = {} as any;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getConfigError).mockReturnValue(null);
+    vi.mocked(getDailies).mockReturnValue([]);
+    vi.mocked(getNudgeMinutesBefore).mockReturnValue(0);
+    vi.mocked(getDigestTime).mockReturnValue('14:00');
+    vi.mocked(getMissingSubmissions).mockResolvedValue([]);
+    vi.mocked(postMessage).mockResolvedValue('ts-123');
+  });
+
+  it('skips when nudge_minutes_before is 0', async () => {
+    vi.mocked(getDailies).mockReturnValue([
+      { name: 'daily-il', channel: 'C1', schedule: 'sched' } as any,
+    ]);
+    vi.mocked(getNudgeMinutesBefore).mockReturnValue(0);
+
+    const result = await runNudgeCron(mockDb, 'xoxb-test');
+    expect(result.skipped).toBeGreaterThan(0);
+    expect(result.sent).toBe(0);
+  });
+
+  it('skips when config has errors', async () => {
+    vi.mocked(getConfigError).mockReturnValue('bad config');
+    const result = await runNudgeCron(mockDb, 'xoxb-test');
+    expect(result.sent).toBe(0);
+  });
+
+  it('sends DMs to users who have not submitted when in nudge window', async () => {
+    // digest at 14:00 UTC, nudge 30 min before = 13:30 UTC
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-06T13:35:00Z')); // Wednesday 13:35 UTC
+
+    vi.mocked(getDigestTime).mockReturnValue('14:00');
+    vi.mocked(getDailies).mockReturnValue([
+      { name: 'daily-il', channel: 'C1', schedule: 'sched' } as any,
+    ]);
+    vi.mocked(getNudgeMinutesBefore).mockReturnValue(30);
+    vi.mocked(getSchedule).mockReturnValue({
+      name: 'sched',
+      timezone: 'UTC',
+      days: ['mon', 'tue', 'wed', 'thu', 'fri'],
+      default_time: '10:00',
+    } as any);
+    vi.mocked(getMissingSubmissions).mockResolvedValue(['U_ALICE', 'U_BOB']);
+
+    const result = await runNudgeCron(mockDb, 'xoxb-test');
+
+    expect(result.sent).toBe(2);
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    expect(postMessage).toHaveBeenCalledWith(
+      'xoxb-test',
+      'U_ALICE',
+      expect.stringContaining('digest posts in'),
+      expect.any(Array)
+    );
+
+    vi.useRealTimers();
+  });
+
+  it('skips when not in nudge time window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-06T10:00:00Z')); // Wednesday 10:00 UTC — well before 13:30
+
+    vi.mocked(getDigestTime).mockReturnValue('14:00');
+    vi.mocked(getDailies).mockReturnValue([
+      { name: 'daily-il', channel: 'C1', schedule: 'sched' } as any,
+    ]);
+    vi.mocked(getNudgeMinutesBefore).mockReturnValue(30);
+    vi.mocked(getSchedule).mockReturnValue({
+      name: 'sched',
+      timezone: 'UTC',
+      days: ['mon', 'tue', 'wed', 'thu', 'fri'],
+      default_time: '10:00',
+    } as any);
+
+    const result = await runNudgeCron(mockDb, 'xoxb-test');
+
+    expect(result.skipped).toBeGreaterThan(0);
+    expect(result.sent).toBe(0);
+    expect(getMissingSubmissions).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
   });
 });

--- a/tests/slack.test.ts
+++ b/tests/slack.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   parseUserId,
+  extractMentionedUserIds,
   parseCommandPayload,
   ephemeralResponse,
   inChannelResponse,
@@ -29,6 +30,32 @@ describe('slack utilities', () => {
 
     it('extracts from text with surrounding content', () => {
       expect(parseUserId('add <@UABCD1234> to team')).toBe('UABCD1234');
+    });
+  });
+
+  describe('extractMentionedUserIds', () => {
+    it('returns empty array for text with no mentions', () => {
+      expect(extractMentionedUserIds('waiting on API review')).toEqual([]);
+    });
+
+    it('returns empty array for empty string', () => {
+      expect(extractMentionedUserIds('')).toEqual([]);
+    });
+
+    it('extracts a single mention', () => {
+      expect(extractMentionedUserIds('blocked by <@U123ABC>')).toEqual(['U123ABC']);
+    });
+
+    it('extracts multiple distinct mentions', () => {
+      expect(extractMentionedUserIds('need <@UAAA> and <@UBBB> to review')).toEqual(['UAAA', 'UBBB']);
+    });
+
+    it('deduplicates repeated mentions', () => {
+      expect(extractMentionedUserIds('<@UAAA> and <@UAAA> again')).toEqual(['UAAA']);
+    });
+
+    it('handles mention with display name suffix', () => {
+      expect(extractMentionedUserIds('<@U123|alice>')).toEqual(['U123']);
     });
   });
 

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Tests for lib/handlers/webhooks.ts
+ * Covers signature verification and Linear webhook processing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Mocks (must be declared before imports that use them)
+// ============================================================================
+
+vi.mock('../lib/db', () => ({
+  getActiveWorkItemsBySourceRef: vi.fn(),
+  updateWorkItemStatus: vi.fn(() => Promise.resolve(true)),
+  updateSubmissionArrays: vi.fn(() => Promise.resolve()),
+  getSubmissionForDate: vi.fn(() => Promise.resolve(null)),
+  getInProgressCarryCounts: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock('../lib/slack', () => ({
+  sendDM: vi.fn(() => Promise.resolve()),
+  updateMessage: vi.fn(() => Promise.resolve(true)),
+  publishHomeView: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock('../lib/config', () => ({
+  getDaily: vi.fn(() => ({
+    name: 'eng-daily',
+    channel: 'C123',
+    questions: [],
+    field_order: [],
+    integrations: {},
+  })),
+  getLinearIntelligenceConfig: vi.fn(() => ({
+    enabled: true,
+    cross_reference: true,
+    auto_update: true,
+    priority_alignment: true,
+  })),
+  getGitHubConfig: vi.fn(() => null),
+}));
+
+vi.mock('../lib/format', () => ({
+  formatStandupBlocks: vi.fn(() => []),
+}));
+
+vi.mock('../lib/prompt', () => ({
+  formatDate: vi.fn(() => '2026-05-07'),
+  getUserDate: vi.fn(() => new Date('2026-05-07T10:00:00Z')),
+}));
+
+vi.mock('../lib/handlers/home', () => ({
+  handleAppHomeOpened: vi.fn(() => Promise.resolve()),
+}));
+
+// ============================================================================
+// Imports (after mocks)
+// ============================================================================
+
+import { verifyLinearSignature, handleLinearWebhook, LinearWebhookPayload } from '../lib/handlers/webhooks';
+import {
+  getActiveWorkItemsBySourceRef,
+  updateWorkItemStatus,
+  updateSubmissionArrays,
+  getSubmissionForDate,
+} from '../lib/db';
+import { sendDM, updateMessage } from '../lib/slack';
+import { getDaily, getLinearIntelligenceConfig, getGitHubConfig } from '../lib/config';
+import type { WorkItem } from '../lib/db';
+import type { DbClient } from '../lib/db';
+import type { Env } from '../api/index';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Compute a real HMAC-SHA256 signature using the Web Crypto API (Node 18+) */
+async function signBody(body: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(body));
+  return Array.from(new Uint8Array(sig))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Build a minimal mock Request */
+function makeRequest(body: string, signature: string): Request {
+  return new Request('https://example.com/api/webhooks/linear', {
+    method: 'POST',
+    headers: { 'Linear-Signature': signature },
+    body,
+  });
+}
+
+/** Build a minimal env object */
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    SLACK_BOT_TOKEN: 'xoxb-test-token',
+    SLACK_SIGNING_SECRET: 'slack-secret',
+    DATABASE_URL: 'postgres://test',
+    LINEAR_WEBHOOK_SECRET: 'webhook-secret-123',
+    ...overrides,
+  };
+}
+
+/** Build a minimal DbClient that never touches a real DB */
+function makeDb(): DbClient {
+  return {
+    query: vi.fn(() => Promise.resolve([])),
+  };
+}
+
+/** Build a valid LinearWebhookPayload for an issue state change */
+function makeIssueUpdatePayload(overrides: Partial<LinearWebhookPayload['data']> = {}): LinearWebhookPayload {
+  return {
+    action: 'update',
+    type: 'Issue',
+    data: {
+      id: 'uuid-1',
+      identifier: 'ENG-123',
+      title: 'Fix auth bug',
+      state: { id: 'state-uuid', name: 'Done', type: 'completed' },
+      priority: 2,
+      url: 'https://linear.app/team/issue/ENG-123',
+      ...overrides,
+    },
+    updatedFrom: { stateId: 'old-state-uuid' },
+    url: 'https://linear.app/team/issue/ENG-123',
+    createdAt: '2026-05-07T09:00:00Z',
+    webhookTimestamp: 1746604800000,
+  };
+}
+
+/** Build a minimal active WorkItem */
+function makeActiveItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 42,
+    slack_user_id: 'U123',
+    daily_name: 'eng-daily',
+    text: '[ENG-123] Fix auth bug',
+    created_date: '2026-05-07',
+    status: 'pending',
+    carry_count: 0,
+    completed_date: null,
+    snoozed_until: null,
+    submission_id: null,
+    source: 'linear_ticket',
+    source_ref: 'ENG-123',
+    source_url: 'https://linear.app/team/issue/ENG-123',
+    item_type: 'plan',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// verifyLinearSignature
+// ============================================================================
+
+describe('verifyLinearSignature', () => {
+  it('returns true for a valid HMAC-SHA256 signature', async () => {
+    const body = JSON.stringify({ action: 'update', type: 'Issue' });
+    const secret = 'my-webhook-secret';
+    const signature = await signBody(body, secret);
+
+    const result = await verifyLinearSignature(body, signature, secret);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false for an invalid signature', async () => {
+    const body = JSON.stringify({ action: 'update', type: 'Issue' });
+    const secret = 'my-webhook-secret';
+    const wrongSig = 'deadbeef'.repeat(8); // 64-char hex but wrong value
+
+    const result = await verifyLinearSignature(body, wrongSig, secret);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false for an empty signature', async () => {
+    const body = JSON.stringify({ action: 'update', type: 'Issue' });
+    const secret = 'my-webhook-secret';
+
+    const result = await verifyLinearSignature(body, '', secret);
+
+    expect(result).toBe(false);
+  });
+});
+
+// ============================================================================
+// handleLinearWebhook
+// ============================================================================
+
+describe('handleLinearWebhook', () => {
+  const SECRET = 'webhook-secret-123';
+
+  beforeEach(() => {
+    // resetAllMocks clears both call history AND mock implementations set by mockReturnValue.
+    // This prevents test-order contamination (e.g. a mockReturnValue set in test N affecting test N+1).
+    vi.resetAllMocks();
+
+    // Re-apply defaults that the module-level vi.mock factories provide.
+    vi.mocked(getActiveWorkItemsBySourceRef).mockResolvedValue([makeActiveItem()]);
+    vi.mocked(updateWorkItemStatus).mockResolvedValue(true);
+    vi.mocked(updateSubmissionArrays).mockResolvedValue(undefined);
+    vi.mocked(getSubmissionForDate).mockResolvedValue(null);
+    vi.mocked(sendDM).mockResolvedValue(undefined as any);
+    vi.mocked(updateMessage).mockResolvedValue(true as any);
+    vi.mocked(getDaily).mockReturnValue({
+      name: 'eng-daily',
+      channel: 'C123',
+      questions: [],
+      field_order: [],
+      integrations: {},
+    } as any);
+    vi.mocked(getLinearIntelligenceConfig).mockReturnValue({
+      enabled: true,
+      cross_reference: true,
+      auto_update: true,
+      priority_alignment: true,
+    });
+    vi.mocked(getGitHubConfig).mockReturnValue(null);
+  });
+
+  it('returns 200 and marks items done for a completed state change', async () => {
+    const payload = makeIssueUpdatePayload({ state: { id: 's1', name: 'Done', type: 'completed' } });
+    const body = JSON.stringify(payload);
+    const sig = await signBody(body, SECRET);
+    const request = makeRequest(body, sig);
+    const db = makeDb();
+    const env = makeEnv();
+
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(200);
+    expect(updateWorkItemStatus).toHaveBeenCalledWith(
+      db,
+      42,
+      'done',
+      '2026-05-07'
+    );
+  });
+
+  it('returns 200 and marks items in_progress for a started state change', async () => {
+    const payload = makeIssueUpdatePayload({ state: { id: 's2', name: 'In Progress', type: 'started' } });
+    const body = JSON.stringify(payload);
+    const sig = await signBody(body, SECRET);
+    const request = makeRequest(body, sig);
+    const db = makeDb();
+    const env = makeEnv();
+
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(200);
+    expect(updateWorkItemStatus).toHaveBeenCalledWith(db, 42, 'in_progress', undefined);
+  });
+
+  it('returns 200 and skips processing for non-update actions', async () => {
+    const payload: LinearWebhookPayload = {
+      ...makeIssueUpdatePayload(),
+      action: 'create',
+    };
+    const body = JSON.stringify(payload);
+    const sig = await signBody(body, SECRET);
+    const request = makeRequest(body, sig);
+    const db = makeDb();
+    const env = makeEnv();
+
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(200);
+    expect(updateWorkItemStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 and skips processing for non-Issue types', async () => {
+    const payload: LinearWebhookPayload = {
+      ...makeIssueUpdatePayload(),
+      type: 'Comment',
+    };
+    const body = JSON.stringify(payload);
+    const sig = await signBody(body, SECRET);
+    const request = makeRequest(body, sig);
+    const db = makeDb();
+    const env = makeEnv();
+
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(200);
+    expect(updateWorkItemStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 when no matching work items found', async () => {
+    vi.mocked(getActiveWorkItemsBySourceRef).mockResolvedValue([]);
+
+    const payload = makeIssueUpdatePayload();
+    const body = JSON.stringify(payload);
+    const sig = await signBody(body, SECRET);
+    const request = makeRequest(body, sig);
+    const db = makeDb();
+    const env = makeEnv();
+
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(200);
+    expect(updateWorkItemStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for an invalid signature', async () => {
+    const body = JSON.stringify(makeIssueUpdatePayload());
+    const request = makeRequest(body, 'invalid-signature');
+    const db = makeDb();
+    const env = makeEnv();
+
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(401);
+    expect(updateWorkItemStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 and skips processing when LINEAR_WEBHOOK_SECRET is not configured', async () => {
+    const body = JSON.stringify(makeIssueUpdatePayload());
+    const request = makeRequest(body, 'any-sig');
+    const db = makeDb();
+    const env = makeEnv({ LINEAR_WEBHOOK_SECRET: undefined });
+
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(200);
+    expect(updateWorkItemStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 and skips processing when auto_update is disabled in config', async () => {
+    vi.mocked(getLinearIntelligenceConfig).mockReturnValue({
+      enabled: true,
+      cross_reference: true,
+      auto_update: false, // disabled
+      priority_alignment: true,
+    });
+
+    const payload = makeIssueUpdatePayload();
+    const body = JSON.stringify(payload);
+    const sig = await signBody(body, SECRET);
+    const request = makeRequest(body, sig);
+    const db = makeDb();
+    const env = makeEnv();
+
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(200);
+    expect(updateWorkItemStatus).not.toHaveBeenCalled();
+  });
+
+  it('sends a DM notification when an item is auto-updated', async () => {
+    const payload = makeIssueUpdatePayload({ state: { id: 's1', name: 'Done', type: 'completed' } });
+    const body = JSON.stringify(payload);
+    const sig = await signBody(body, SECRET);
+    const request = makeRequest(body, sig);
+    const db = makeDb();
+    const env = makeEnv();
+
+    await handleLinearWebhook(request, env, db);
+
+    expect(sendDM).toHaveBeenCalledWith(
+      env.SLACK_BOT_TOKEN,
+      'U123',
+      expect.stringContaining('ENG-123')
+    );
+    expect(sendDM).toHaveBeenCalledWith(
+      env.SLACK_BOT_TOKEN,
+      'U123',
+      expect.stringContaining('marked done')
+    );
+  });
+
+  it('handles idempotent delivery — item already done causes no error', async () => {
+    // Item is already in 'done' status — updateWorkItemStatus resolves false (no rows updated)
+    vi.mocked(getActiveWorkItemsBySourceRef).mockResolvedValue([
+      makeActiveItem({ status: 'done' }),
+    ]);
+    vi.mocked(updateWorkItemStatus).mockResolvedValue(false);
+
+    const payload = makeIssueUpdatePayload({ state: { id: 's1', name: 'Done', type: 'completed' } });
+    const body = JSON.stringify(payload);
+    const sig = await signBody(body, SECRET);
+    const request = makeRequest(body, sig);
+    const db = makeDb();
+    const env = makeEnv();
+
+    // Should complete without throwing
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(200);
+    // updateWorkItemStatus was still called — idempotency is the DB's concern
+    expect(updateWorkItemStatus).toHaveBeenCalled();
+  });
+
+  it('updates the channel post when submission is posted', async () => {
+    const submission = {
+      id: 77,
+      slack_user_id: 'U123',
+      daily_name: 'eng-daily',
+      submitted_at: new Date(),
+      date: '2026-05-07',
+      yesterday_completed: [],
+      yesterday_incomplete: [],
+      yesterday_in_progress: [],
+      unplanned: [],
+      today_plans: ['[ENG-123] Fix auth bug'],
+      blockers: null,
+      custom_answers: null,
+      slack_message_ts: '1234567890.000100',
+      posted: true,
+      items_normalized: true,
+    };
+    vi.mocked(getActiveWorkItemsBySourceRef).mockResolvedValue([
+      makeActiveItem({ submission_id: 77 }),
+    ]);
+    vi.mocked(getSubmissionForDate).mockResolvedValue(submission);
+
+    const payload = makeIssueUpdatePayload({ state: { id: 's1', name: 'Done', type: 'completed' } });
+    const body = JSON.stringify(payload);
+    const sig = await signBody(body, SECRET);
+    const request = makeRequest(body, sig);
+    const db = makeDb();
+    const env = makeEnv();
+
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(200);
+    expect(updateMessage).toHaveBeenCalledWith(
+      env.SLACK_BOT_TOKEN,
+      'C123',
+      '1234567890.000100',
+      expect.any(String),
+      expect.any(Array)
+    );
+  });
+
+  it('skips state change processing when updatedFrom has no stateId', async () => {
+    const payload: LinearWebhookPayload = {
+      ...makeIssueUpdatePayload(),
+      updatedFrom: {}, // No stateId — not a state change
+    };
+    const body = JSON.stringify(payload);
+    const sig = await signBody(body, SECRET);
+    const request = makeRequest(body, sig);
+    const db = makeDb();
+    const env = makeEnv();
+
+    const response = await handleLinearWebhook(request, env, db);
+
+    expect(response.status).toBe(200);
+    expect(updateWorkItemStatus).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,20 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, Plugin } from 'vitest/config';
+import { readFileSync } from 'fs';
+
+function yamlTextPlugin(): Plugin {
+  return {
+    name: 'yaml-text',
+    transform(_code: string, id: string) {
+      if (id.endsWith('.yaml') || id.endsWith('.yml')) {
+        const content = readFileSync(id, 'utf-8');
+        return { code: `export default ${JSON.stringify(content)};`, map: null };
+      }
+    },
+  };
+}
 
 export default defineConfig({
+  plugins: [yamlTextPlugin()],
   test: {
     globals: true,
     environment: 'node',
@@ -9,7 +23,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       include: ['lib/**/*.ts'],
-      exclude: ['lib/handlers/**/*.ts'], // Integration tests separately
+      exclude: ['lib/handlers/**/*.ts'],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

### Features (from prior work)
- **Blocker @-mention DMs** — notify mentioned participants when someone reports a blocker
- **Nudge reminder** — DM users before digest if standup not submitted
- **Standup templates** — per-daily sections config to toggle blockers and unplanned
- **Weekly personal recap DM** — summarize each participant's week
- **Edit after submit** — reopen modal with prefill, update post in place

### Post & Modal Compactness (new)
- **Today-first ordering** — Today section renders above Yesterday in channel posts
- **Collapsed yesterday** — count summary ("3 done · 1 unplanned") instead of full item list
- **Inline PR status** — PR category (to review, awaiting review, draft) embedded in plan text; separate PR section removed
- **Trimmed annotations** — removed redundant _(carried over)_ and _(in progress)_; shortened day-count labels
- **Stripped ceremony** — removed "submitted their standup" header, daily name footer, separator line
- **Inline blockers** — dropped section header, each line gets 🚧 prefix directly
- **Modal 3-item limit** — checkbox lists show 3 items with "Show all N" expand button; source-group headers hidden for small lists

### Infra
- Integration tests for Slack HTTP flows (signature verification, commands, modals, events)
- Dev-mode helpers (`/dailyl` alias, skip scheduled-time queueing)
- Schema migration cleanup

## Test plan
- [x] 559 tests passing across 15 test files
- [x] Local dev testing via ngrok
- [ ] Verify compact post format in staging channel
- [ ] Verify "Show all" expand works in modal
- [ ] Test checkbox state preservation on views.update

✌️