### PR TITLE
fix: carried/in-progress items vanish when adding extra plans

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -399,10 +399,13 @@ export async function getActiveWorkItems(
   date: string
 ): Promise<WorkItem[]> {
   return db.query<WorkItem>(
-    `SELECT * FROM work_items
-     WHERE slack_user_id = $1 AND daily_name = $2 AND created_date = $3
+    `SELECT DISTINCT w.* FROM work_items w
+     LEFT JOIN submission_items si ON si.work_item_id = w.id
+     LEFT JOIN submissions s ON si.submission_id = s.id
+     WHERE w.slack_user_id = $1 AND w.daily_name = $2
+       AND (w.created_date = $3 OR (s.date = $3 AND si.role IN ('yesterday_incomplete', 'yesterday_in_progress')))
      ORDER BY
-       CASE status
+       CASE w.status
          WHEN 'in_progress' THEN 1
          WHEN 'carried'     THEN 2
          WHEN 'pending'     THEN 3
@@ -410,7 +413,7 @@ export async function getActiveWorkItems(
          WHEN 'dropped'     THEN 5
          ELSE 6
        END,
-       id ASC`,
+       w.id ASC`,
     [slackUserId, dailyName, date]
   );
 }
@@ -467,8 +470,11 @@ export async function updateSubmissionArrays(
   date: string
 ): Promise<void> {
   const items = await db.query<WorkItem>(
-    `SELECT * FROM work_items
-     WHERE slack_user_id = $1 AND daily_name = $2 AND created_date = $3`,
+    `SELECT DISTINCT w.* FROM work_items w
+     LEFT JOIN submission_items si ON si.work_item_id = w.id
+     LEFT JOIN submissions s ON si.submission_id = s.id
+     WHERE w.slack_user_id = $1 AND w.daily_name = $2
+       AND (w.created_date = $3 OR (s.date = $3 AND si.role IN ('yesterday_incomplete', 'yesterday_in_progress')))`,
     [slackUserId, dailyName, date]
   );
 

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -798,6 +798,87 @@ describe('handleAppHomeOpened - Today\'s Plans from submission', () => {
     expect(addBlock).toBeDefined();
   });
 
+  it('shows carried/in-progress items alongside newly added plans', async () => {
+    vi.mocked(getUserDailies).mockResolvedValueOnce([
+      { id: 1, slack_user_id: 'U12345', daily_name: 'daily-test', schedule_name: 'il-team', time_override: null, created_at: new Date() },
+    ]);
+    vi.mocked(getSubmissionForDate)
+      .mockResolvedValueOnce({
+        id: 5,
+        slack_user_id: 'U12345',
+        daily_name: 'daily-test',
+        date: '2025-12-22',
+        submitted_at: new Date(),
+        yesterday_completed: [],
+        yesterday_incomplete: ['Carried task'],
+        yesterday_in_progress: ['WIP task'],
+        unplanned: null,
+        today_plans: ['Extra plan'],
+        blockers: null,
+        custom_answers: null,
+        slack_message_ts: 'ts-abc',
+        posted: true,
+        items_normalized: true,
+      })
+      .mockResolvedValueOnce(null);
+    vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+    // Simulate: carried/in-progress items from prior days + a newly added plan today
+    vi.mocked(getActiveWorkItems).mockResolvedValueOnce([
+      {
+        id: 50, slack_user_id: 'U12345', daily_name: 'daily-test',
+        text: 'WIP task', created_date: '2025-12-21', status: 'in_progress',
+        carry_count: 1, completed_date: null, snoozed_until: null,
+        submission_id: 4, source: 'manual', source_ref: null, source_url: null, item_type: 'plan',
+      },
+      {
+        id: 51, slack_user_id: 'U12345', daily_name: 'daily-test',
+        text: 'Carried task', created_date: '2025-12-21', status: 'carried',
+        carry_count: 1, completed_date: null, snoozed_until: null,
+        submission_id: 4, source: 'manual', source_ref: null, source_url: null, item_type: 'plan',
+      },
+      {
+        id: 60, slack_user_id: 'U12345', daily_name: 'daily-test',
+        text: 'Extra plan', created_date: '2025-12-22', status: 'pending',
+        carry_count: 0, completed_date: null, snoozed_until: null,
+        submission_id: 5, source: 'manual', source_ref: null, source_url: null, item_type: 'plan',
+      },
+    ]);
+    vi.mocked(publishHomeView).mockResolvedValueOnce(true);
+
+    const event: AppHomeOpenedEvent = { type: 'app_home_opened', user: 'U12345', tab: 'home' };
+    const ctx: HomeContext = { db: {} as any, slackToken: 'xoxb-test' };
+
+    await handleAppHomeOpened(event, ctx);
+
+    const publishCall = vi.mocked(publishHomeView).mock.calls[0];
+    const view = publishCall[2] as { blocks: Array<Record<string, unknown>> };
+
+    // All three items must render — carried/in-progress items must not vanish
+    const wipBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('WIP task')
+    );
+    expect(wipBlock).toBeDefined();
+    expect((wipBlock as any).text.text).toContain('🔄 WIP task');
+
+    const carriedBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Carried task')
+    );
+    expect(carriedBlock).toBeDefined();
+    expect((carriedBlock as any).text.text).toContain('➡️ Carried task');
+
+    const extraBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Extra plan')
+    );
+    expect(extraBlock).toBeDefined();
+    expect((extraBlock as any).text.text).toContain('🎯 Extra plan');
+
+    // All items have IDs so they should have overflow menus
+    const blocksWithOverflow = view.blocks.filter(
+      (b: any) => b.type === 'section' && b.accessory?.type === 'overflow'
+    );
+    expect(blocksWithOverflow).toHaveLength(3);
+  });
+
   it('builds tomorrow plan items from scheduled submission', async () => {
     vi.mocked(getUserDailies).mockResolvedValueOnce([
       { id: 1, slack_user_id: 'U12345', daily_name: 'daily-test', schedule_name: 'il-team', time_override: null, created_at: new Date() },


### PR DESCRIPTION
## Summary
- **Bug**: When a user added extra plans via "Add Item" on the Home tab, any carried-over or in-progress items from previous days disappeared
- **Root cause**: `getActiveWorkItems()` and `updateSubmissionArrays()` filtered work items by `created_date = today`, but carried/in-progress items retain their original creation date from prior days
- **Fix**: Both queries now join through `submission_items` to include items linked to today's submission as `yesterday_incomplete` or `yesterday_in_progress`, regardless of `created_date`

## Test plan
- [x] Added regression test: carried + in-progress + newly added plan all render together
- [x] All 568 tests pass