### PR TITLE
Release: standup modal fixes, Linear cycle tickets, Home tab improvements

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -399,10 +399,13 @@ export async function getActiveWorkItems(
   date: string
 ): Promise<WorkItem[]> {
   return db.query<WorkItem>(
-    `SELECT * FROM work_items
-     WHERE slack_user_id = $1 AND daily_name = $2 AND created_date = $3
+    `SELECT DISTINCT w.* FROM work_items w
+     LEFT JOIN submission_items si ON si.work_item_id = w.id
+     LEFT JOIN submissions s ON si.submission_id = s.id
+     WHERE w.slack_user_id = $1 AND w.daily_name = $2
+       AND (w.created_date = $3 OR (s.date = $3 AND si.role IN ('yesterday_incomplete', 'yesterday_in_progress')))
      ORDER BY
-       CASE status
+       CASE w.status
          WHEN 'in_progress' THEN 1
          WHEN 'carried'     THEN 2
          WHEN 'pending'     THEN 3
@@ -410,7 +413,7 @@ export async function getActiveWorkItems(
          WHEN 'dropped'     THEN 5
          ELSE 6
        END,
-       id ASC`,
+       w.id ASC`,
     [slackUserId, dailyName, date]
   );
 }
@@ -467,8 +470,11 @@ export async function updateSubmissionArrays(
   date: string
 ): Promise<void> {
   const items = await db.query<WorkItem>(
-    `SELECT * FROM work_items
-     WHERE slack_user_id = $1 AND daily_name = $2 AND created_date = $3`,
+    `SELECT DISTINCT w.* FROM work_items w
+     LEFT JOIN submission_items si ON si.work_item_id = w.id
+     LEFT JOIN submissions s ON si.submission_id = s.id
+     WHERE w.slack_user_id = $1 AND w.daily_name = $2
+       AND (w.created_date = $3 OR (s.date = $3 AND si.role IN ('yesterday_incomplete', 'yesterday_in_progress')))`,
     [slackUserId, dailyName, date]
   );
 

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -1896,6 +1896,21 @@ async function handleShowAllInModal(
   const daily = getDaily(metadata.dailyName);
   if (!daily) return false;
 
+  // Reconstruct yesterday data and dropdown selections from current view state
+  const yesterdayPlans = metadata.yesterdayPlans || [];
+  const yesterdayData: YesterdayData | null = yesterdayPlans.length > 0
+    ? { plans: yesterdayPlans, completed: [], incomplete: [] }
+    : null;
+
+  const values = payload.view.state?.values || {};
+  const yesterdayStatuses: Record<number, string> = {};
+  yesterdayPlans.forEach((_item, index) => {
+    const selected = values[`yesterday_item_${index}`]?.[`item_status_${index}`]?.selected_option;
+    if (selected?.value) {
+      yesterdayStatuses[index] = selected.value;
+    }
+  });
+
   // Re-fetch integration data (same as modal open)
   const [{ prData, reviewerMap }, linearResult] = await Promise.all([
     fetchGitHubPRsForUser(daily, userId, ctx),
@@ -1910,7 +1925,7 @@ async function handleShowAllInModal(
 
   const modal = buildStandupModal(
     metadata.dailyName,
-    null,
+    yesterdayData,
     daily.questions || [],
     daily.field_order,
     userDate,
@@ -1924,6 +1939,7 @@ async function handleShowAllInModal(
     undefined,
     metadata.sections || getDailySections(daily),
     expandedSections,
+    Object.keys(yesterdayStatuses).length > 0 ? yesterdayStatuses : undefined,
   );
 
   await updateModal(ctx.slackToken, payload.view.id, modal);

--- a/lib/linear.ts
+++ b/lib/linear.ts
@@ -101,6 +101,7 @@ interface UserAssignedIssuesResponse {
         state: { name: string; type: string };
         priority: number;
         url: string;
+        cycle: { endsAt: string } | null;
       }>;
     };
   };
@@ -123,6 +124,7 @@ const USER_ASSIGNED_ISSUES_QUERY = `
           state { name type }
           priority
           url
+          cycle { endsAt }
         }
       }
     }
@@ -158,7 +160,13 @@ export async function fetchUserAssignedIssues(
     }));
 
     const allActiveIdentifiers = allIssues.map(i => i.identifier);
-    const issues = allIssues.filter((issue) => issue.state.type === 'started' || issue.priority === 1);
+
+    const now = new Date();
+    const issues = allIssues.filter((issue) => {
+      if (issue.state.type === 'started' || issue.priority === 1) return true;
+      if (issue.cycle?.endsAt && new Date(issue.cycle.endsAt) > now) return true;
+      return false;
+    });
 
     // Sort by priority (1=Urgent first) then by state type (started before unstarted)
     const stateOrder: Record<string, number> = {

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -476,7 +476,7 @@ export function buildStandupModal(
       case 'today_plans':
         // Integration checkboxes go right above today's plans
         if (linearIssues && linearIssues.length > 0) {
-          const linearLimit = expandedSections?.has('linear') ? 10 : 3;
+          const linearLimit = expandedSections?.has('linear') ? 20 : 3;
           const displayIssues = linearIssues.slice(0, linearLimit);
           const linearOptions = displayIssues.map((issue) => ({
             text: {

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -117,7 +117,8 @@ export function buildStandupModal(
   autoCompletedIds?: Set<string>,
   mergedPRs?: MergedPR[],
   sections?: { blockers: boolean; unplanned: boolean },
-  expandedSections?: Set<string>
+  expandedSections?: Set<string>,
+  yesterdayStatuses?: Record<number, string>
 ): ModalView {
   const blocks: Block[] = [];
   const isFirstDay = !yesterday || yesterday.plans.length === 0;
@@ -259,9 +260,21 @@ export function buildStandupModal(
     const hasMixedSources = [manualItems, prItems, linearItems].filter(g => g.length > 0).length > 1 && totalYesterdayItems >= 4;
 
     const renderYesterdayItem = (plan: string, index: number) => {
-      const isInProgress = yesterday?.inProgressCount != null && index < yesterday.inProgressCount;
-      const linearId = plan.match(/^\[([^\]]+)\]\s/)?.[1];
-      const isAutoCompleted = linearId && autoCompletedIds?.has(linearId);
+      const statusMap: Record<string, number> = { continue: 0, in_progress: 1, done: 2, drop: 3 };
+      let initialOption: typeof YESTERDAY_ITEM_OPTIONS[number];
+
+      if (yesterdayStatuses && index in yesterdayStatuses) {
+        initialOption = YESTERDAY_ITEM_OPTIONS[statusMap[yesterdayStatuses[index]] ?? 0];
+      } else {
+        const isInProgress = yesterday?.inProgressCount != null && index < yesterday.inProgressCount;
+        const linearId = plan.match(/^\[([^\]]+)\]\s/)?.[1];
+        const isAutoCompleted = linearId && autoCompletedIds?.has(linearId);
+        initialOption = isAutoCompleted
+          ? YESTERDAY_ITEM_OPTIONS[2]   // Done
+          : isInProgress
+          ? YESTERDAY_ITEM_OPTIONS[1]   // In progress
+          : YESTERDAY_ITEM_OPTIONS[0];  // Carry over
+      }
 
       blocks.push({
         type: 'section',
@@ -274,11 +287,7 @@ export function buildStandupModal(
           type: 'static_select',
           action_id: `item_status_${index}`,
           options: YESTERDAY_ITEM_OPTIONS,
-          initial_option: isAutoCompleted
-            ? YESTERDAY_ITEM_OPTIONS[2]   // Done
-            : isInProgress
-            ? YESTERDAY_ITEM_OPTIONS[1]   // In progress
-            : YESTERDAY_ITEM_OPTIONS[0],  // Carry over
+          initial_option: initialOption,
         },
       });
     };

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -481,15 +481,20 @@ export function buildStandupModal(
             },
             value: issue.id,
           }));
+          const inProgressOptions = linearOptions.filter((_opt, i) => displayIssues[i].state.type === 'started');
+          const checkboxElement: Record<string, unknown> = {
+            type: 'checkboxes',
+            action_id: 'linear_tickets_input',
+            options: linearOptions,
+          };
+          if (inProgressOptions.length > 0) {
+            checkboxElement.initial_options = inProgressOptions;
+          }
           blocks.push({
             type: 'input',
             block_id: 'linear_tickets',
             optional: true,
-            element: {
-              type: 'checkboxes',
-              action_id: 'linear_tickets_input',
-              options: linearOptions,
-            },
+            element: checkboxElement,
             label: {
               type: 'plain_text',
               text: '🎫 Cycle tickets (select to add to plans)',

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -798,6 +798,87 @@ describe('handleAppHomeOpened - Today\'s Plans from submission', () => {
     expect(addBlock).toBeDefined();
   });
 
+  it('shows carried/in-progress items alongside newly added plans', async () => {
+    vi.mocked(getUserDailies).mockResolvedValueOnce([
+      { id: 1, slack_user_id: 'U12345', daily_name: 'daily-test', schedule_name: 'il-team', time_override: null, created_at: new Date() },
+    ]);
+    vi.mocked(getSubmissionForDate)
+      .mockResolvedValueOnce({
+        id: 5,
+        slack_user_id: 'U12345',
+        daily_name: 'daily-test',
+        date: '2025-12-22',
+        submitted_at: new Date(),
+        yesterday_completed: [],
+        yesterday_incomplete: ['Carried task'],
+        yesterday_in_progress: ['WIP task'],
+        unplanned: null,
+        today_plans: ['Extra plan'],
+        blockers: null,
+        custom_answers: null,
+        slack_message_ts: 'ts-abc',
+        posted: true,
+        items_normalized: true,
+      })
+      .mockResolvedValueOnce(null);
+    vi.mocked(getPreviousSubmission).mockResolvedValueOnce(null);
+    // Simulate: carried/in-progress items from prior days + a newly added plan today
+    vi.mocked(getActiveWorkItems).mockResolvedValueOnce([
+      {
+        id: 50, slack_user_id: 'U12345', daily_name: 'daily-test',
+        text: 'WIP task', created_date: '2025-12-21', status: 'in_progress',
+        carry_count: 1, completed_date: null, snoozed_until: null,
+        submission_id: 4, source: 'manual', source_ref: null, source_url: null, item_type: 'plan',
+      },
+      {
+        id: 51, slack_user_id: 'U12345', daily_name: 'daily-test',
+        text: 'Carried task', created_date: '2025-12-21', status: 'carried',
+        carry_count: 1, completed_date: null, snoozed_until: null,
+        submission_id: 4, source: 'manual', source_ref: null, source_url: null, item_type: 'plan',
+      },
+      {
+        id: 60, slack_user_id: 'U12345', daily_name: 'daily-test',
+        text: 'Extra plan', created_date: '2025-12-22', status: 'pending',
+        carry_count: 0, completed_date: null, snoozed_until: null,
+        submission_id: 5, source: 'manual', source_ref: null, source_url: null, item_type: 'plan',
+      },
+    ]);
+    vi.mocked(publishHomeView).mockResolvedValueOnce(true);
+
+    const event: AppHomeOpenedEvent = { type: 'app_home_opened', user: 'U12345', tab: 'home' };
+    const ctx: HomeContext = { db: {} as any, slackToken: 'xoxb-test' };
+
+    await handleAppHomeOpened(event, ctx);
+
+    const publishCall = vi.mocked(publishHomeView).mock.calls[0];
+    const view = publishCall[2] as { blocks: Array<Record<string, unknown>> };
+
+    // All three items must render — carried/in-progress items must not vanish
+    const wipBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('WIP task')
+    );
+    expect(wipBlock).toBeDefined();
+    expect((wipBlock as any).text.text).toContain('🔄 WIP task');
+
+    const carriedBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Carried task')
+    );
+    expect(carriedBlock).toBeDefined();
+    expect((carriedBlock as any).text.text).toContain('➡️ Carried task');
+
+    const extraBlock = view.blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Extra plan')
+    );
+    expect(extraBlock).toBeDefined();
+    expect((extraBlock as any).text.text).toContain('🎯 Extra plan');
+
+    // All items have IDs so they should have overflow menus
+    const blocksWithOverflow = view.blocks.filter(
+      (b: any) => b.type === 'section' && b.accessory?.type === 'overflow'
+    );
+    expect(blocksWithOverflow).toHaveLength(3);
+  });
+
   it('builds tomorrow plan items from scheduled submission', async () => {
     vi.mocked(getUserDailies).mockResolvedValueOnce([
       { id: 1, slack_user_id: 'U12345', daily_name: 'daily-test', schedule_name: 'il-team', time_override: null, created_at: new Date() },

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -337,6 +337,81 @@ describe('modal builder', () => {
       expect(linearBlock?.element?.options).toHaveLength(2);
     });
 
+    it('pre-checks Linear issues that are in progress', () => {
+      const linearIssues: LinearIssue[] = [
+        {
+          id: 'issue-1',
+          identifier: 'ENG-123',
+          title: 'Fix authentication bug',
+          state: { name: 'In Progress', type: 'started' },
+          priority: 1,
+          url: 'https://linear.app/issue/ENG-123',
+        },
+        {
+          id: 'issue-2',
+          identifier: 'ENG-124',
+          title: 'Add new dashboard feature',
+          state: { name: 'Todo', type: 'unstarted' },
+          priority: 2,
+          url: 'https://linear.app/issue/ENG-124',
+        },
+        {
+          id: 'issue-3',
+          identifier: 'ENG-125',
+          title: 'Refactor payment module',
+          state: { name: 'In Review', type: 'started' },
+          priority: 3,
+          url: 'https://linear.app/issue/ENG-125',
+        },
+      ];
+
+      const modal = buildStandupModal(
+        'daily-il',
+        null,
+        [],
+        undefined,
+        undefined,
+        'today',
+        undefined,
+        linearIssues
+      );
+
+      const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
+      const initialOptions = linearBlock?.element?.initial_options;
+
+      expect(initialOptions).toBeDefined();
+      expect(initialOptions).toHaveLength(2);
+      expect(initialOptions?.[0]?.value).toBe('issue-1');
+      expect(initialOptions?.[1]?.value).toBe('issue-3');
+    });
+
+    it('does not set initial_options when no issues are in progress', () => {
+      const linearIssues: LinearIssue[] = [
+        {
+          id: 'issue-1',
+          identifier: 'ENG-123',
+          title: 'Backlog item',
+          state: { name: 'Todo', type: 'unstarted' },
+          priority: 2,
+          url: 'https://linear.app/issue/ENG-123',
+        },
+      ];
+
+      const modal = buildStandupModal(
+        'daily-il',
+        null,
+        [],
+        undefined,
+        undefined,
+        'today',
+        undefined,
+        linearIssues
+      );
+
+      const linearBlock = modal.blocks.find(b => b.block_id === 'linear_tickets');
+      expect(linearBlock?.element?.initial_options).toBeUndefined();
+    });
+
     it('formats Linear issue checkboxes with identifier and title', () => {
       const linearIssues: LinearIssue[] = [
         {


### PR DESCRIPTION
## Summary
- **fix: show active-cycle tickets in standup modal regardless of state** — unstarted tickets in active cycles across teams were being filtered out
- **fix: preserve yesterday selections when expanding Linear tickets** — expanding "show more" no longer resets checked items
- **feat: pre-check in-progress Linear issues** — started tickets are auto-selected in the modal
- **fix: carried/in-progress items vanish when adding extra plans on Home tab**
- Plus all prior unreleased work on dev (Linear sync-back, GitHub alignment, admin commands, App Home tasks, weekly recap, and more)

## Test plan
- [x] 570 tests passing
- [ ] Open standup modal and verify unstarted cycle tickets (e.g. INT-511) appear
- [ ] Click "show more" and confirm all cross-team cycle tickets are listed
- [ ] Verify yesterday selections persist after expanding
- [ ] Check Home tab plans don't vanish when adding items

🤖 Generated with [Claude Code](https://claude.com/claude-code)