### PR TITLE
fix: standup modal "Show all" reliably expands and fetches only what it needs

### DIFF
--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -43,7 +43,7 @@ import { handleAppHomeOpened, AppHomeOpenedEvent, HomeContext } from './home';
 import { fetchUserPRData, UserPRData, fetchMergedPRs, MergedPR } from '../github';
 import { fetchUserAssignedIssues, fetchUserLinearData, LinearIssue, UserLinearData, extractLinearReferences, fetchWorkflowStates, markIssuesInProgress as markLinearIssuesInProgress, commentOnIssue, resolveIdentifiers } from '../linear';
 import { postStandupToChannel, sendStandupDM, formatStandupBlocks, StandupData } from '../format';
-import { buildStandupModal, YesterdayData, SubmissionPrefill } from '../modal';
+import { buildStandupModal, YesterdayData, SubmissionPrefill, Block, EXPANDABLE_SECTIONS, ExpandableSection, applyExpandedSection } from '../modal';
 import { formatDate, getDateInTimezone, getUserDate, getUserTimezone, hasScheduledTimePassed, sendPromptDM } from '../prompt';
 import { openModal, parseRichText, RichTextBlock, sendDM, updateMessage, extractMentionedUserIds, updateModal } from '../slack';
 import { StandupMode } from '../modal';
@@ -79,6 +79,12 @@ export interface InteractionPayload {
     hash?: string;
     callback_id: string;
     private_metadata: string;
+    // Slack echoes the full rendered view back in block_actions payloads; these
+    // let "Show all" expansions reuse the current blocks instead of re-fetching.
+    title?: unknown;
+    submit?: unknown;
+    close?: unknown;
+    blocks?: Block[];
     state: {
       values: Record<string, Record<string, {
         value?: string;
@@ -1884,7 +1890,7 @@ async function handleShowAllInModal(
   const actionId = payload.actions?.[0]?.action_id;
   if (!actionId || !payload.view?.id) return false;
 
-  const sectionMap: Record<string, string> = {
+  const sectionMap: Record<string, ExpandableSection> = {
     show_all_linear: 'linear',
     show_all_reviews: 'reviews',
     show_all_my_prs: 'my_prs',
@@ -1892,9 +1898,14 @@ async function handleShowAllInModal(
   const section = sectionMap[actionId];
   if (!section) return false;
 
-  let metadata: { dailyName: string; yesterdayPlans?: string[]; mode?: string; targetDate?: string; sections?: { blockers: boolean; unplanned: boolean } };
+  const currentView = payload.view;
+  const viewId = currentView.id;
+  const currentBlocks = currentView.blocks;
+  if (!viewId || !currentBlocks) return false;
+
+  let metadata: { dailyName: string; yesterdayPlans?: string[]; mode?: string; targetDate?: string; sections?: { blockers: boolean; unplanned: boolean }; prReviewerTags?: Record<string, string>; prCategories?: Record<string, string>; unmappedReviewers?: string[] };
   try {
-    metadata = JSON.parse(payload.view.private_metadata);
+    metadata = JSON.parse(currentView.private_metadata);
   } catch {
     return false;
   }
@@ -1903,53 +1914,93 @@ async function handleShowAllInModal(
   const daily = getDaily(metadata.dailyName);
   if (!daily) return false;
 
-  // Reconstruct yesterday data and dropdown selections from current view state
+  // Reconstruct yesterday data for dedup when rebuilding the target section.
   const yesterdayPlans = metadata.yesterdayPlans || [];
   const yesterdayData: YesterdayData | null = yesterdayPlans.length > 0
     ? { plans: yesterdayPlans, completed: [], incomplete: [] }
     : null;
 
-  const values = payload.view.state?.values || {};
-  const yesterdayStatuses: Record<number, string> = {};
-  yesterdayPlans.forEach((_item, index) => {
-    const selected = values[`yesterday_item_${index}`]?.[`item_status_${index}`]?.selected_option;
-    if (selected?.value) {
-      yesterdayStatuses[index] = selected.value;
+  // Fetch ONLY the integration this button expands (Linear button → Linear,
+  // PR buttons → GitHub), then splice the expanded section into the modal's
+  // existing blocks. The other integration's section, the user's typed input,
+  // and yesterday's selections are carried over from the current view — so we
+  // never re-fetch data we're not changing. The work runs in the background to
+  // stay inside Slack's 3-second interaction ack window (same pattern as
+  // handleTaskAddSubmission).
+  const integration = EXPANDABLE_SECTIONS[section].integration;
+  const bgWork = (async () => {
+    let linearIssues: LinearIssue[] | undefined;
+    let prData: UserPRData | undefined;
+    let reviewerMap: Map<string, string> | undefined;
+
+    if (integration === 'linear') {
+      linearIssues = (await fetchLinearIssuesForUser(daily, userId, ctx)).issues;
+    } else {
+      const github = await fetchGitHubPRsForUser(daily, userId, ctx);
+      prData = github.prData;
+      reviewerMap = github.reviewerMap;
     }
-  });
 
-  // Re-fetch integration data (same as modal open)
-  const [{ prData, reviewerMap }, linearResult] = await Promise.all([
-    fetchGitHubPRsForUser(daily, userId, ctx),
-    fetchLinearIssuesForUser(daily, userId, ctx),
-  ]);
+    // Build a throwaway full modal with ONLY the fetched integration's data so we
+    // can lift the freshly-expanded section's blocks (and its updated PR metadata)
+    // out of it. userDate is irrelevant here — we reuse the current view's header
+    // and private_metadata rather than the rebuilt ones.
+    const rebuilt = buildStandupModal(
+      metadata.dailyName,
+      yesterdayData,
+      daily.questions || [],
+      daily.field_order,
+      undefined,
+      (metadata.mode as StandupMode) || 'today',
+      undefined,
+      linearIssues,
+      prData,
+      reviewerMap,
+      undefined,
+      undefined,
+      undefined,
+      metadata.sections || getDailySections(daily),
+      new Set([section]),
+    );
 
-  const userInfo = await getUserTimezone(ctx.slackToken, userId);
-  const tzOffset = userInfo?.tz_offset || 0;
-  const userDate = getUserDate(tzOffset);
+    const blocks = applyExpandedSection(currentBlocks, rebuilt.blocks, section, currentView.state);
 
-  const expandedSections = new Set([section]);
+    // Expanding a PR section reveals PRs whose reviewer/category tags weren't in
+    // the original private_metadata; merge the rebuilt ones in so the submission
+    // handler can still label them. Linear expansion adds no metadata.
+    let privateMetadata = currentView.private_metadata;
+    if (integration === 'github') {
+      try {
+        const rebuiltMeta = JSON.parse(rebuilt.private_metadata) as typeof metadata;
+        privateMetadata = JSON.stringify({
+          ...metadata,
+          ...(rebuiltMeta.prReviewerTags ? { prReviewerTags: { ...metadata.prReviewerTags, ...rebuiltMeta.prReviewerTags } } : {}),
+          ...(rebuiltMeta.prCategories ? { prCategories: { ...metadata.prCategories, ...rebuiltMeta.prCategories } } : {}),
+          ...(rebuiltMeta.unmappedReviewers ? { unmappedReviewers: rebuiltMeta.unmappedReviewers } : {}),
+        });
+      } catch {
+        // Fall back to the existing metadata if the rebuilt copy can't be parsed.
+      }
+    }
 
-  const modal = buildStandupModal(
-    metadata.dailyName,
-    yesterdayData,
-    daily.questions || [],
-    daily.field_order,
-    userDate,
-    (metadata.mode as StandupMode) || 'today',
-    undefined,
-    linearResult.issues,
-    prData,
-    reviewerMap,
-    undefined,
-    undefined,
-    undefined,
-    metadata.sections || getDailySections(daily),
-    expandedSections,
-    Object.keys(yesterdayStatuses).length > 0 ? yesterdayStatuses : undefined,
-  );
+    const updatedView = {
+      type: 'modal' as const,
+      callback_id: currentView.callback_id,
+      private_metadata: privateMetadata,
+      title: currentView.title,
+      submit: currentView.submit,
+      close: currentView.close,
+      blocks,
+    };
 
-  await updateModal(ctx.slackToken, payload.view.id, modal);
+    await updateModal(ctx.slackToken, viewId, updatedView);
+  })().catch(err => console.error('handleShowAllInModal background work failed:', err));
+
+  if (ctx.waitUntil) {
+    ctx.waitUntil(bgWork);
+  } else {
+    await bgWork;
+  }
   return true;
 }
 

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -21,7 +21,7 @@ interface Option {
   value: string;
 }
 
-interface Block {
+export interface Block {
   type: string;
   block_id?: string;
   text?: TextObject;
@@ -812,5 +812,75 @@ export function buildStandupModal(
     },
     blocks,
   };
+}
+
+/**
+ * The three "Show all" expandable sections, each mapped to the input block that
+ * holds its checkboxes and the actions block that holds its expand button. Linear
+ * tickets are backed by the Linear integration; review requests and "my PRs" are
+ * both backed by GitHub, so expanding either only needs a GitHub fetch.
+ */
+export const EXPANDABLE_SECTIONS = {
+  linear: { inputBlockId: 'linear_tickets', showAllBlockId: 'linear_show_all', integration: 'linear' },
+  reviews: { inputBlockId: 'review_requests', showAllBlockId: 'reviews_show_all', integration: 'github' },
+  my_prs: { inputBlockId: 'my_prs', showAllBlockId: 'my_prs_show_all', integration: 'github' },
+} as const;
+
+export type ExpandableSection = keyof typeof EXPANDABLE_SECTIONS;
+
+/** Minimal shape of the view state Slack echoes back in a block_actions payload. */
+type ViewStateValues = Record<string, Record<string, { selected_option?: { value: string } }>>;
+
+/**
+ * Produce the updated block list for a "Show all" expansion without re-fetching
+ * the other integration's data. Starts from the modal's current (echoed) blocks and:
+ *  - swaps the target section's checkbox block for its freshly-built expanded
+ *    version, and replaces or drops the "Show all" button,
+ *  - re-applies the user's yesterday-item picks (static_select state is NOT
+ *    auto-preserved across views.update, unlike input blocks), and
+ *  - leaves every other block untouched — including the other integration's
+ *    section and the user's typed input — so Slack preserves their state.
+ *
+ * `rebuiltBlocks` is a full modal built with ONLY the target integration's data;
+ * we pull just the target section's blocks out of it by block_id.
+ */
+export function applyExpandedSection(
+  currentBlocks: Block[],
+  rebuiltBlocks: Block[],
+  section: ExpandableSection,
+  viewState: { values: ViewStateValues } | undefined
+): Block[] {
+  const { inputBlockId, showAllBlockId } = EXPANDABLE_SECTIONS[section];
+  const newInput = rebuiltBlocks.find((b) => b.block_id === inputBlockId);
+  const newShowAll = rebuiltBlocks.find((b) => b.block_id === showAllBlockId);
+  const values = viewState?.values || {};
+
+  const result: Block[] = [];
+  for (const block of currentBlocks) {
+    if (block.block_id === inputBlockId) {
+      // Expanded checkboxes (more options). Same block_id/action_id, so Slack
+      // keeps the user's existing selections.
+      result.push(newInput ?? block);
+      continue;
+    }
+    if (block.block_id === showAllBlockId) {
+      // Replace with the still-needed button (more than the expanded limit) or drop it.
+      if (newShowAll) result.push(newShowAll);
+      continue;
+    }
+    const ydayMatch = block.block_id?.match(/^yesterday_item_(\d+)$/);
+    if (ydayMatch && block.accessory) {
+      const index = ydayMatch[1];
+      const selected = values[`yesterday_item_${index}`]?.[`item_status_${index}`]?.selected_option;
+      if (selected) {
+        const options = (block.accessory.options as Array<{ value: string }> | undefined) || [];
+        const match = options.find((o) => o.value === selected.value);
+        result.push({ ...block, accessory: { ...block.accessory, initial_option: match ?? selected } });
+        continue;
+      }
+    }
+    result.push(block);
+  }
+  return result;
 }
 

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -17,9 +17,19 @@ vi.mock('../lib/slack', () => ({
   openModal: vi.fn(),
 }));
 
-import { buildStandupModal, YesterdayData } from '../lib/modal';
+import { buildStandupModal, YesterdayData, applyExpandedSection, type Block } from '../lib/modal';
 import type { LinearIssue } from '../lib/linear';
 import type { UserPRData, GitHubPR } from '../lib/github';
+
+const makeLinearIssues = (n: number): LinearIssue[] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `issue-${i}`,
+    identifier: `ENG-${100 + i}`,
+    title: `Issue ${i}`,
+    state: { name: 'Todo', type: 'unstarted' as const },
+    priority: 1,
+    url: `https://linear.app/issue/ENG-${100 + i}`,
+  }));
 
 describe('modal builder', () => {
   describe('buildStandupModal', () => {
@@ -1204,6 +1214,81 @@ describe('modal builder', () => {
 
       expect(modal.blocks.find(b => b.block_id === 'today_plans')).toBeDefined();
       expect(modal.blocks.find(b => b.block_id === 'custom_0')).toBeDefined();
+    });
+  });
+
+  describe('applyExpandedSection', () => {
+    // A collapsed modal (3 linear tickets shown out of 15) plus a PR section and a
+    // yesterday item — the kind of view Slack echoes back on a "Show all" click.
+    const collapsedView = (): Block[] => {
+      const collapsed = buildStandupModal(
+        'daily-il',
+        { plans: ['Ship feature X'], completed: [], incomplete: [], inProgressCount: 1 },
+        [], undefined, undefined, 'today', undefined,
+        makeLinearIssues(15),
+        {
+          reviewRequests: [],
+          awaitingReview: Array.from({ length: 6 }, (_, i): GitHubPR => ({
+            number: i, title: `PR ${i}`, url: `https://github.com/org/repo/pull/${i}`,
+            author: 'me', requestedReviewers: [], isDraft: false,
+          })),
+          readyToMerge: [], draftPRs: [],
+        } as UserPRData,
+        new Map(),
+      );
+      return collapsed.blocks;
+    };
+
+    // A full rebuild with only Linear data (expanded), as the handler produces.
+    const rebuiltLinear = (): Block[] =>
+      buildStandupModal(
+        'daily-il',
+        { plans: ['Ship feature X'], completed: [], incomplete: [] },
+        [], undefined, undefined, 'today', undefined,
+        makeLinearIssues(15),
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        new Set(['linear']),
+      ).blocks;
+
+    it('expands the target section in place (3 → expanded count)', () => {
+      const current = collapsedView();
+      const before = current.find(b => b.block_id === 'linear_tickets');
+      expect((before?.element?.options as unknown[])?.length).toBe(3);
+
+      const result = applyExpandedSection(current, rebuiltLinear(), 'linear', undefined);
+      const after = result.find(b => b.block_id === 'linear_tickets');
+      expect((after?.element?.options as unknown[])?.length).toBeGreaterThan(3);
+    });
+
+    it('leaves the other integration section untouched (no GitHub re-fetch)', () => {
+      const current = collapsedView();
+      const prBefore = current.find(b => b.block_id === 'my_prs');
+      const result = applyExpandedSection(current, rebuiltLinear(), 'linear', undefined);
+      const prAfter = result.find(b => b.block_id === 'my_prs');
+      // Same object content carried over verbatim — the PR section was not rebuilt.
+      expect(prAfter).toEqual(prBefore);
+      expect(result.find(b => b.block_id === 'my_prs_show_all')).toBeDefined();
+    });
+
+    it('drops the Show all button once everything fits the expanded limit', () => {
+      const current = collapsedView();
+      expect(current.find(b => b.block_id === 'linear_show_all')).toBeDefined();
+      // 15 tickets < expanded limit of 20, so the button should disappear.
+      const result = applyExpandedSection(current, rebuiltLinear(), 'linear', undefined);
+      expect(result.find(b => b.block_id === 'linear_show_all')).toBeUndefined();
+    });
+
+    it('re-applies the user\'s yesterday selection from view state', () => {
+      const current = collapsedView();
+      // User changed the first yesterday item to "Done" since the modal opened.
+      const state = {
+        values: {
+          yesterday_item_0: { item_status_0: { selected_option: { value: 'done' } } },
+        },
+      };
+      const result = applyExpandedSection(current, rebuiltLinear(), 'linear', state);
+      const yday = result.find(b => b.block_id === 'yesterday_item_0');
+      expect((yday?.accessory?.initial_option as { value: string })?.value).toBe('done');
     });
   });
 });


### PR DESCRIPTION
## Problem

The **Show all X tickets / review requests / PRs** buttons in the standup modal showed a spinner but never expanded their section.

`handleShowAllInModal` re-fetched GitHub PRs **and** Linear issues **and** the user's timezone *synchronously* before acking Slack and calling `views.update`. Those are the same slow integration fetches the submission path deliberately backgrounds (`6084fbf`), so they blew past Slack's **3-second interaction ack window** — the button spun and the view never updated.

## Fixes

**1. Ack fast, update in the background.** The view rebuild + `views.update` now runs via `ctx.waitUntil`, the same pattern as `handleTaskAddSubmission`. The interaction acks immediately, so the modal reliably updates.

**2. Each button fetches only the integration it expands.** Previously every button fetched both integrations. Now:
- **Show all Linear tickets** → Linear fetch only
- **Show all review requests / Show all PRs** → GitHub fetch only (both GitHub-backed)
- the timezone lookup is gone entirely

Instead of rebuilding the whole modal (which needs *all* data, or the other section vanishes), a new pure helper `applyExpandedSection` splices the freshly-expanded section into the view Slack echoes back. Everything else — the other integration's section, the user's typed input, and yesterday's selections — is carried over untouched, so Slack preserves their state.

Two correctness details handled:
- Expanding a PR section reveals PRs whose reviewer/category tags weren't in the original `private_metadata`; the rebuilt PR metadata is merged in so they're still labeled on submit.
- The timezone-correct `targetDate` in `private_metadata` is preserved rather than recomputed.

Static_select state (the yesterday-item pickers) isn't auto-preserved by Slack across `views.update`, so the helper re-applies those picks from `view.state` — same concern `fef0d63` addressed.

## Tests

Adds 4 unit tests for `applyExpandedSection`: expands the target in place, leaves the other section byte-identical (proving no cross-integration re-fetch), drops the button once items fit the expanded limit, and restores the yesterday selection from state. Full suite: **574 passing**, clean `tsc`.

## Manual check recommended

This is timing- and Slack-payload-dependent; it only fully exercises against live Slack. Worth clicking each of the three buttons in a real modal before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)