### PR TITLE
Release: Linear "Show all" 10-option fix + e2e harness (dev → main)

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -398,12 +398,18 @@ export async function getActiveWorkItems(
   dailyName: string,
   date: string
 ): Promise<WorkItem[]> {
+  // The status-priority ORDER BY must live outside the SELECT DISTINCT: Postgres
+  // rejects a DISTINCT query whose ORDER BY expression (the CASE) isn't in the
+  // select list (SQLSTATE 42P10). Wrapping the DISTINCT in a subquery and
+  // ordering the result keeps the exact same semantics and is valid SQL.
   return db.query<WorkItem>(
-    `SELECT DISTINCT w.* FROM work_items w
-     LEFT JOIN submission_items si ON si.work_item_id = w.id
-     LEFT JOIN submissions s ON si.submission_id = s.id
-     WHERE w.slack_user_id = $1 AND w.daily_name = $2
-       AND (w.created_date = $3 OR (s.date = $3 AND si.role IN ('yesterday_incomplete', 'yesterday_in_progress')))
+    `SELECT * FROM (
+       SELECT DISTINCT w.* FROM work_items w
+       LEFT JOIN submission_items si ON si.work_item_id = w.id
+       LEFT JOIN submissions s ON si.submission_id = s.id
+       WHERE w.slack_user_id = $1 AND w.daily_name = $2
+         AND (w.created_date = $3 OR (s.date = $3 AND si.role IN ('yesterday_incomplete', 'yesterday_in_progress')))
+     ) w
      ORDER BY
        CASE w.status
          WHEN 'in_progress' THEN 1

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -498,8 +498,14 @@ export async function handleStandupSubmission(
 
   const githubOrg = daily ? getGitHubConfig(daily)?.org : undefined;
 
-  const linearSelections = values.linear_tickets?.linear_tickets_input?.selected_options;
-  if (linearSelections && linearSelections.length > 0) {
+  // Linear checkboxes are split into chunks of 10 (Slack's per-element option
+  // cap), so selections live across `linear_tickets` plus any `linear_tickets_chunk_N`
+  // blocks. Gather them all.
+  const linearSelections = Object.entries(values)
+    .filter(([blockId]) => blockId === 'linear_tickets' || /^linear_tickets_chunk_\d+$/.test(blockId))
+    .flatMap(([, actions]) => Object.values(actions))
+    .flatMap((action) => action.selected_options ?? []);
+  if (linearSelections.length > 0) {
     for (const option of linearSelections) {
       const flatText = parseOptionText(option.text?.text || option.value);
       todayPlans.push(flatText);

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -478,38 +478,54 @@ export function buildStandupModal(
         if (linearIssues && linearIssues.length > 0) {
           const linearLimit = expandedSections?.has('linear') ? 20 : 3;
           const displayIssues = linearIssues.slice(0, linearLimit);
-          const linearOptions = displayIssues.map((issue) => ({
-            text: {
-              type: 'mrkdwn' as const,
-              text: `*${issue.identifier}* ${issue.title.length > 50 ? issue.title.slice(0, 47) + '...' : issue.title}`,
-            },
-            description: {
-              type: 'plain_text' as const,
-              text: issue.state.name,
-              emoji: true,
-            },
-            value: issue.id,
-          }));
-          const inProgressOptions = linearOptions.filter((_opt, i) => displayIssues[i].state.type === 'started');
-          const checkboxElement: Record<string, unknown> = {
-            type: 'checkboxes',
-            action_id: 'linear_tickets_input',
-            options: linearOptions,
-          };
-          if (inProgressOptions.length > 0) {
-            checkboxElement.initial_options = inProgressOptions;
+          // Slack allows at most 10 options in a single checkboxes element, so
+          // split the displayed tickets into chunks of 10. The first chunk keeps
+          // the original block_id/action_id (so Slack preserves selections on
+          // expand); extra chunks get numbered ids. Selections are recombined
+          // across all chunks on submit.
+          const CHECKBOX_MAX = 10;
+          const chunkCount = Math.ceil(displayIssues.length / CHECKBOX_MAX);
+          for (let c = 0; c < chunkCount; c++) {
+            const start = c * CHECKBOX_MAX;
+            const chunkIssues = displayIssues.slice(start, start + CHECKBOX_MAX);
+            const chunkOptions = chunkIssues.map((issue) => ({
+              text: {
+                type: 'mrkdwn' as const,
+                text: `*${issue.identifier}* ${issue.title.length > 50 ? issue.title.slice(0, 47) + '...' : issue.title}`,
+              },
+              description: {
+                type: 'plain_text' as const,
+                text: issue.state.name,
+                emoji: true,
+              },
+              value: issue.id,
+            }));
+            const inProgressOptions = chunkOptions.filter((_opt, i) => chunkIssues[i].state.type === 'started');
+            const checkboxElement: Record<string, unknown> = {
+              type: 'checkboxes',
+              action_id: c === 0 ? 'linear_tickets_input' : `linear_tickets_input_chunk_${c}`,
+              options: chunkOptions,
+            };
+            if (inProgressOptions.length > 0) {
+              checkboxElement.initial_options = inProgressOptions;
+            }
+            // Single chunk keeps the descriptive label; multiple chunks show the
+            // item range so the split list reads as one continuous group.
+            const label = chunkCount === 1
+              ? '🎫 Cycle tickets (select to add to plans)'
+              : `🎫 Cycle tickets (${start + 1}–${start + chunkIssues.length})`;
+            blocks.push({
+              type: 'input',
+              block_id: c === 0 ? 'linear_tickets' : `linear_tickets_chunk_${c}`,
+              optional: true,
+              element: checkboxElement,
+              label: {
+                type: 'plain_text',
+                text: label,
+                emoji: true,
+              },
+            });
           }
-          blocks.push({
-            type: 'input',
-            block_id: 'linear_tickets',
-            optional: true,
-            element: checkboxElement,
-            label: {
-              type: 'plain_text',
-              text: '🎫 Cycle tickets (select to add to plans)',
-              emoji: true,
-            },
-          });
           if (linearIssues.length > linearLimit) {
             blocks.push({
               type: 'actions',
@@ -851,16 +867,28 @@ export function applyExpandedSection(
   viewState: { values: ViewStateValues } | undefined
 ): Block[] {
   const { inputBlockId, showAllBlockId } = EXPANDABLE_SECTIONS[section];
-  const newInput = rebuiltBlocks.find((b) => b.block_id === inputBlockId);
+  // The expanded section may be split across several checkbox chunks (Slack caps
+  // a checkboxes element at 10 options): the base block plus `<inputBlockId>_chunk_N`.
+  const chunkRe = new RegExp(`^${inputBlockId}_chunk_\\d+$`);
+  const isSectionInput = (id: string | undefined): boolean =>
+    !!id && (id === inputBlockId || chunkRe.test(id));
+  const newInputBlocks = rebuiltBlocks.filter((b) => isSectionInput(b.block_id));
   const newShowAll = rebuiltBlocks.find((b) => b.block_id === showAllBlockId);
   const values = viewState?.values || {};
 
   const result: Block[] = [];
   for (const block of currentBlocks) {
     if (block.block_id === inputBlockId) {
-      // Expanded checkboxes (more options). Same block_id/action_id, so Slack
-      // keeps the user's existing selections.
-      result.push(newInput ?? block);
+      // Expanded checkboxes (more options), possibly chunked. The first chunk
+      // reuses the original block_id/action_id so Slack keeps existing
+      // selections; extra chunks are appended right after it.
+      if (newInputBlocks.length > 0) result.push(...newInputBlocks);
+      else result.push(block);
+      continue;
+    }
+    if (chunkRe.test(block.block_id ?? '')) {
+      // Drop any chunk blocks left over from a previous expansion; the current
+      // set is re-inserted at the base block above.
       continue;
     }
     if (block.block_id === showAllBlockId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omdim",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omdim",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@neondatabase/serverless": "^1.0.2",
         "@slack/web-api": "^7.0.0",
@@ -15,11 +15,12 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251216.0",
+        "@electric-sql/pglite": "^0.5.0",
         "@types/node": "^20.0.0",
         "@vitest/coverage-v8": "^4.0.16",
         "typescript": "^5.0.0",
         "vitest": "^4.0.16",
-        "wrangler": "^4.58.0"
+        "wrangler": "^4.95.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -83,27 +84,24 @@
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.1.tgz",
-      "integrity": "sha512-Nu8ahitGFFJztxUml9oD/DLb7Z28C8cd8F46IVQ7y5Btz575pvMY8AqZsXkX7Gds29eCKdMgIHjIvzskHgPSFg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "mime": "^3.0.0"
-      },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.8.0.tgz",
-      "integrity": "sha512-oIAu6EdQ4zJuPwwKr9odIEqd8AV96z1aqi3RBEA4iKaJ+Vd3fvuI6m5EDC7/QCv+oaPIhy1SkYBYxmD09N+oZg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
-        "workerd": "^1.20251202.0"
+        "workerd": ">1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -112,9 +110,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260107.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260107.1.tgz",
-      "integrity": "sha512-Srwe/IukVppkMU2qTndkFaKCmZBI7CnZoq4Y0U0gD/8158VGzMREHTqCii4IcCeHifwrtDqTWu8EcA1VBKI4mg==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260526.1.tgz",
+      "integrity": "sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==",
       "cpu": [
         "x64"
       ],
@@ -129,9 +127,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260107.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260107.1.tgz",
-      "integrity": "sha512-aAYwU7zXW+UZFh/a4vHP5cs1ulTOcDRLzwU9547yKad06RlZ6ioRm7ovjdYvdqdmbI8mPd99v4LN9gMmecazQw==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260526.1.tgz",
+      "integrity": "sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +144,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260107.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260107.1.tgz",
-      "integrity": "sha512-Wh7xWtFOkk6WY3CXe3lSqZ1anMkFcwy+qOGIjtmvQ/3nCOaG34vKNwPIE9iwryPupqkSuDmEqkosI1UUnSTh1A==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260526.1.tgz",
+      "integrity": "sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==",
       "cpu": [
         "x64"
       ],
@@ -163,9 +161,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260107.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260107.1.tgz",
-      "integrity": "sha512-NI0/5rdssdZZKYHxNG4umTmMzODByq86vSCEk8u4HQbGhRCQo7rV1eXn84ntSBdyWBzWdYGISCbeZMsgfIjSTg==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260526.1.tgz",
+      "integrity": "sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==",
       "cpu": [
         "arm64"
       ],
@@ -180,9 +178,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260107.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260107.1.tgz",
-      "integrity": "sha512-gmBMqs606Gd/IhBEBPSL/hJAqy2L8IyPUjKtoqd/Ccy7GQxbSc0rYlRkxbQ9YzmqnuhrTVYvXuLscyWrpmAJkw==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260526.1.tgz",
+      "integrity": "sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==",
       "cpu": [
         "x64"
       ],
@@ -197,9 +195,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260111.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260111.0.tgz",
-      "integrity": "sha512-NFA2U+AqEWHkAmw6oRzNWJyc14rIvBlF/OlK3lixokunRKwyziuON07nWUZ0w0kKWlW4fJ/muA09tEUaQY07tA==",
+      "version": "4.20260527.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260527.1.tgz",
+      "integrity": "sha512-GK+C05N4fGptp1uG+pbjC/7Udonz8EhMEYvYFnVKdLLnEGS9nsmVOFi/RLQr7tq9l/0UEzcWjudzeY2ssuqyIA==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -216,10 +214,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.0.tgz",
+      "integrity": "sha512-SEsBA6yZ8JD1XIpoaSX+KDgHlHytDa6Jz8YIhzI4WyXr4x1M5YAtvNoECvlLav4EOAMYGglTRv8uwJii6XyUUA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -228,9 +233,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
       "cpu": [
         "ppc64"
       ],
@@ -245,9 +250,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
-      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
       "cpu": [
         "arm"
       ],
@@ -262,9 +267,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
-      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
       "cpu": [
         "arm64"
       ],
@@ -279,9 +284,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
-      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
       "cpu": [
         "x64"
       ],
@@ -296,9 +301,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
-      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
       "cpu": [
         "arm64"
       ],
@@ -313,9 +318,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
-      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
       "cpu": [
         "x64"
       ],
@@ -330,9 +335,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
       "cpu": [
         "arm64"
       ],
@@ -347,9 +352,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
-      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
       "cpu": [
         "x64"
       ],
@@ -364,9 +369,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
-      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
       "cpu": [
         "arm"
       ],
@@ -381,9 +386,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
-      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
       "cpu": [
         "arm64"
       ],
@@ -398,9 +403,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
-      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
       "cpu": [
         "ia32"
       ],
@@ -415,9 +420,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
-      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
       "cpu": [
         "loong64"
       ],
@@ -432,9 +437,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
-      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
       "cpu": [
         "mips64el"
       ],
@@ -449,9 +454,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
-      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
       "cpu": [
         "ppc64"
       ],
@@ -466,9 +471,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
-      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
       "cpu": [
         "riscv64"
       ],
@@ -483,9 +488,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
-      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
       "cpu": [
         "s390x"
       ],
@@ -500,9 +505,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
-      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
       "cpu": [
         "x64"
       ],
@@ -517,9 +522,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
       "cpu": [
         "arm64"
       ],
@@ -534,9 +539,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
       "cpu": [
         "x64"
       ],
@@ -551,9 +556,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
       "cpu": [
         "arm64"
       ],
@@ -568,9 +573,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
       "cpu": [
         "x64"
       ],
@@ -585,9 +590,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
       "cpu": [
         "arm64"
       ],
@@ -602,9 +607,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
-      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
       "cpu": [
         "x64"
       ],
@@ -619,9 +624,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
-      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
       "cpu": [
         "arm64"
       ],
@@ -636,9 +641,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
-      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
       "cpu": [
         "ia32"
       ],
@@ -653,9 +658,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
-      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
       "cpu": [
         "x64"
       ],
@@ -669,10 +674,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -689,13 +704,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -712,13 +727,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -733,9 +748,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -750,13 +765,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -767,13 +785,56 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -784,13 +845,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -801,13 +865,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -818,13 +885,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -835,13 +905,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -852,13 +925,16 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -871,17 +947,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -894,17 +973,72 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -917,17 +1051,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -940,17 +1077,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -963,17 +1103,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -986,13 +1129,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
@@ -1000,8 +1143,28 @@
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.7.0"
       },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1010,9 +1173,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -1030,9 +1193,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -1510,9 +1673,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
-      "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1747,29 +1910,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1858,51 +1998,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
       }
     },
     "node_modules/combined-stream": {
@@ -2045,9 +2140,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
-      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2058,100 +2153,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.0",
-        "@esbuild/android-arm": "0.27.0",
-        "@esbuild/android-arm64": "0.27.0",
-        "@esbuild/android-x64": "0.27.0",
-        "@esbuild/darwin-arm64": "0.27.0",
-        "@esbuild/darwin-x64": "0.27.0",
-        "@esbuild/freebsd-arm64": "0.27.0",
-        "@esbuild/freebsd-x64": "0.27.0",
-        "@esbuild/linux-arm": "0.27.0",
-        "@esbuild/linux-arm64": "0.27.0",
-        "@esbuild/linux-ia32": "0.27.0",
-        "@esbuild/linux-loong64": "0.27.0",
-        "@esbuild/linux-mips64el": "0.27.0",
-        "@esbuild/linux-ppc64": "0.27.0",
-        "@esbuild/linux-riscv64": "0.27.0",
-        "@esbuild/linux-s390x": "0.27.0",
-        "@esbuild/linux-x64": "0.27.0",
-        "@esbuild/netbsd-arm64": "0.27.0",
-        "@esbuild/netbsd-x64": "0.27.0",
-        "@esbuild/openbsd-arm64": "0.27.0",
-        "@esbuild/openbsd-x64": "0.27.0",
-        "@esbuild/openharmony-arm64": "0.27.0",
-        "@esbuild/sunos-x64": "0.27.0",
-        "@esbuild/win32-arm64": "0.27.0",
-        "@esbuild/win32-ia32": "0.27.0",
-        "@esbuild/win32-x64": "0.27.0"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
-      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
-      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/eventemitter3": {
@@ -2159,19 +2186,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
-    },
-    "node_modules/exit-hook": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
-      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -2298,13 +2312,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2370,13 +2377,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2517,19 +2517,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -2552,40 +2539,24 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260107.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260107.0.tgz",
-      "integrity": "sha512-X93sXczqbBq9ixoM6jnesmdTqp+4baVC/aM/DuPpRS0LK0XtcqaO75qPzNEvDEzBAHxwMAWRIum/9hg32YB8iA==",
+      "version": "4.20260526.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260526.0.tgz",
+      "integrity": "sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "acorn": "8.14.0",
-        "acorn-walk": "8.3.2",
-        "exit-hook": "2.2.1",
-        "glob-to-regexp": "0.4.1",
-        "sharp": "^0.33.5",
-        "stoppable": "1.1.0",
-        "undici": "7.14.0",
-        "workerd": "1.20260107.1",
-        "ws": "8.18.0",
-        "youch": "4.1.0-beta.10",
-        "zod": "^3.25.76"
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260526.1",
+        "ws": "8.20.1",
+        "youch": "4.1.0-beta.10"
       },
       "bin": {
         "miniflare": "bootstrap.js"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/miniflare/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/ms": {
@@ -2871,6 +2842,66 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rosie-skills": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills/-/rosie-skills-0.6.4.tgz",
+      "integrity": "sha512-ojfhSiQRdZ2QyWbmKAHOSAUbaLYrTc5zIH7mS1jKoP8KCFSQddwVhMyFqldckTeybTfW3zNcsZzyOTzGTN1SBA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "rosie-skills": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "rosie-skills-darwin-arm64": "0.6.4",
+        "rosie-skills-freebsd-x64": "0.6.4",
+        "rosie-skills-linux-x64": "0.6.4"
+      }
+    },
+    "node_modules/rosie-skills-darwin-arm64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-darwin-arm64/-/rosie-skills-darwin-arm64-0.6.4.tgz",
+      "integrity": "sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rosie-skills-freebsd-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-freebsd-x64/-/rosie-skills-freebsd-x64-0.6.4.tgz",
+      "integrity": "sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rosie-skills-linux-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-linux-x64/-/rosie-skills-linux-x64-0.6.4.tgz",
+      "integrity": "sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -2885,16 +2916,16 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -2903,25 +2934,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/siginfo": {
@@ -2930,16 +2966,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2964,17 +2990,6 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4",
-        "npm": ">=6"
-      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -3056,9 +3071,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
-      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3154,422 +3169,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
       }
     },
     "node_modules/vitest": {
@@ -3678,9 +3277,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260107.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260107.1.tgz",
-      "integrity": "sha512-4ylAQJDdJZdMAUl2SbJgTa77YHpa88l6qmhiuCLNactP933+rifs7I0w1DslhUIFgydArUX5dNLAZnZhT7Bh7g==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260526.1.tgz",
+      "integrity": "sha512-IHzymht98p10JH1zzwdCpbViAqw97HrwKl7+KfZeASFMsYSrIsAULWdPn0LRC5FTUzBpamLNyKCCKxbgXHgRHQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3691,41 +3290,42 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260107.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260107.1",
-        "@cloudflare/workerd-linux-64": "1.20260107.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260107.1",
-        "@cloudflare/workerd-windows-64": "1.20260107.1"
+        "@cloudflare/workerd-darwin-64": "1.20260526.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260526.1",
+        "@cloudflare/workerd-linux-64": "1.20260526.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260526.1",
+        "@cloudflare/workerd-windows-64": "1.20260526.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.58.0.tgz",
-      "integrity": "sha512-Jm6EYtlt8iUcznOCPSMYC54DYkwrMNESzbH0Vh3GFHv/7XVw5gBC13YJAB+nWMRGJ+6B2dMzy/NVQS4ONL51Pw==",
+      "version": "4.95.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.95.0.tgz",
+      "integrity": "sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.1",
-        "@cloudflare/unenv-preset": "2.8.0",
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.0",
-        "miniflare": "4.20260107.0",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260526.0",
         "path-to-regexp": "6.3.0",
+        "rosie-skills": "^0.6.3",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260107.1"
+        "workerd": "1.20260526.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260107.1"
+        "@cloudflare/workers-types": "^4.20260526.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -3734,9 +3334,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "TZ=UTC vitest --config vitest.e2e.config.ts",
+    "test:e2e:run": "TZ=UTC vitest run --config vitest.e2e.config.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.2",
@@ -20,10 +22,11 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251216.0",
+    "@electric-sql/pglite": "^0.5.0",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^4.0.16",
     "typescript": "^5.0.0",
     "vitest": "^4.0.16",
-    "wrangler": "^4.58.0"
+    "wrangler": "^4.95.0"
   }
 }

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -9,6 +9,7 @@ See `requirements.md` and `architecture.md`
 - [x] Unit tests for core logic (modal building, formatting, date/timezone)
 - [x] Integration tests for Slack payload parsing
 - [x] Mock Slack API responses for handler testing
+- [x] End-to-end harness (`tests/e2e/`): real worker entry + real signature verification + real SQL via in-process Postgres (PGlite on `schema.sql`) + fake Slack API at the `fetch` boundary. Verifies the bot **persists and posts** correctly across full journeys: first submit, carry-over across days, queued→scheduled-cron post, App Home task actions. Run with `npm run test:e2e`.
 
 ### Automated Digests ✅
 - [x] Scheduled daily digest at 2pm UTC

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,86 @@
+# End-to-end tests
+
+These tests drive the **real worker** (`api/index.ts`) the way Slack would — with
+genuinely signed requests — and verify both sides of every boundary: what the bot
+**persisted** and what it **sent Slack**.
+
+```
+npm run test:e2e        # watch mode
+npm run test:e2e:run    # single run (CI)
+```
+
+They run under a separate config (`vitest.e2e.config.ts`) so the main unit suite
+(`npm test`) stays fast and unaffected.
+
+## What's real vs. faked
+
+| Layer | In these tests | Why |
+|-------|----------------|-----|
+| Worker entry, routing, **signature verification** | **real** | full request path is exercised |
+| Config (`config.yaml`), handlers, formatting, timezone math | **real** | no behavior is stubbed away |
+| Database | **real Postgres** via [PGlite](https://pglite.dev) running the real `schema.sql` | catches SQL errors, `UNIQUE` constraints, JSONB/DATE quirks a stub can't |
+| Slack API | **fake** at the `fetch` boundary (`harness/slack.ts`) | records what the bot sends; serves `users.info` |
+| GitHub / Linear | not called | their tokens are left unset, so integration code short-circuits |
+| Clock | faked `Date` (`vi.setSystemTime`), `TZ=UTC` | deterministic date math |
+
+Only **one thing** is mocked at the module level: `lib/db`'s `getDb` is swapped to
+return the PGlite client. Every other `lib/db` query function runs its actual SQL.
+
+> **DATE columns come back as JS `Date` objects** from PGlite — exactly like Neon.
+> Normalize with `toDateString()` (from `lib/prompt`) in assertions instead of
+> string-matching. This fidelity is the point: it's the class of bug commit
+> `30e05f8` fixed.
+
+## Harness pieces (`tests/e2e/harness/`)
+
+- **`db.ts`** — PGlite singleton + `schema.sql` loader, the `DbClient` adapter,
+  `resetTestDb()` (truncate between tests), and row-inspection helpers
+  (`allSubmissions`, `allWorkItems`, `allSubmissionItems`, `rows`).
+- **`slack.ts`** — installs the `fetch` fake and a `SlackRecorder` with query
+  helpers: `channelPosts()`, `dmsTo(user)`, `modalsOpened`, `lastModal()`,
+  `messageUpdates`, `homeViews`. Throws on any non-Slack host so an accidental
+  real network call fails loudly.
+- **`actor.ts`** — the Slack simulator: `slashCommand()`, `interact()`,
+  `clickButton()`, `selectOption()`, `event()`, and `submitOpenedModal()` which
+  reads the modal the bot just opened and submits it (closing the
+  open→fill→submit loop). Also `makeEnv()` and a drainable `waitUntil`.
+- **`../setup.ts`** — wires the `getDb` mock, installs the Slack fake, resets the
+  DB, and pins the clock before each test. Exposes `slackRecorder()`.
+
+## Writing a new scenario
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SlackActor, makeEnv } from './harness/actor';
+import { getTestDbClient, allSubmissions } from './harness/db';
+import { slackRecorder } from './setup';
+import { addParticipant } from '../../lib/db';
+
+describe('e2e: my scenario', () => {
+  let actor: SlackActor;
+
+  beforeEach(async () => {
+    const recorder = slackRecorder();
+    recorder.setUser('U_X');                                  // serves users.info
+    await addParticipant(getTestDbClient(), 'U_X', 'daily-test', 'il-team');
+    actor = new SlackActor(recorder, makeEnv());
+  });
+
+  it('does the thing', async () => {
+    await actor.slashCommand({ command: '/daily', user_id: 'U_X' });
+    await actor.submitOpenedModal({ userId: 'U_X', todayPlans: 'A\nB' });
+
+    expect((await allSubmissions()).length).toBe(1);          // persisted
+    expect(slackRecorder().channelPosts()).toHaveLength(1);   // posted
+  });
+});
+```
+
+Notes:
+- The default clock is **2026-06-02 12:00 UTC** (Tue, 15:00 IDT) — past the
+  `il-team` 10:00 schedule, so submissions post immediately. Use
+  `vi.setSystemTime(...)` to move time (e.g. before 10:00 IDT to test queuing).
+- `daily-test` (channel `#daily-bot-test`, schedule `il-team`) is the real daily
+  in `config.yaml`. Seed participants for it; no config mocking needed.
+- To test crons, call the real functions directly, e.g.
+  `runScheduledPosts(getTestDbClient(), TEST_BOT_TOKEN, makeEnv())`.

--- a/tests/e2e/carryover.test.ts
+++ b/tests/e2e/carryover.test.ts
@@ -1,0 +1,87 @@
+/**
+ * E2E: carry-over across two days.
+ *
+ * Day 1: submit plans A + B (posts to channel, creates work items).
+ * Day 2: open /daily — the modal must pre-load A + B as "yesterday's plans"
+ *        (read back from the persisted day-1 submission). Submit marking A done,
+ *        B continue, and add C. Assert the day-2 submission and the work_items'
+ *        status/carry_count reflect the transitions.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SlackActor, makeEnv } from './harness/actor';
+import { getTestDbClient, allSubmissions, allWorkItems } from './harness/db';
+import { slackRecorder } from './setup';
+import { addParticipant } from '../../lib/db';
+import { toDateString } from '../../lib/prompt';
+
+const BOB = 'U_BOB';
+const DAY1 = new Date('2026-06-01T12:00:00.000Z'); // Mon, 15:00 IDT (after 10:00)
+const DAY2 = new Date('2026-06-02T12:00:00.000Z'); // Tue, 15:00 IDT
+
+describe('e2e: carry-over across days', () => {
+  let actor: SlackActor;
+
+  beforeEach(async () => {
+    const recorder = slackRecorder();
+    recorder.setUser(BOB);
+    await addParticipant(getTestDbClient(), BOB, 'daily-test', 'il-team');
+    actor = new SlackActor(recorder, makeEnv());
+  });
+
+  it("pre-loads yesterday's plans and records the carry transitions", async () => {
+    // --- Day 1 ---
+    vi.setSystemTime(DAY1);
+    await actor.slashCommand({ command: '/daily', user_id: BOB });
+    await actor.submitOpenedModal({ userId: BOB, todayPlans: 'Task A\nTask B' });
+
+    let subs = await allSubmissions<any>();
+    expect(subs).toHaveLength(1);
+    // PGlite returns DATE columns as JS Date objects (same as Neon) — normalize
+    // with the production helper rather than string-matching.
+    expect(toDateString(subs[0].date)).toBe('2026-06-01');
+
+    // --- Day 2: modal must show yesterday's A + B ---
+    vi.setSystemTime(DAY2);
+    slackRecorder().reset();
+    slackRecorder().setUser(BOB);
+
+    await actor.slashCommand({ command: '/daily', user_id: BOB });
+    const modal = slackRecorder().lastModal();
+    const meta = JSON.parse(modal.private_metadata);
+    expect(meta.mode).toBe('today');
+    expect(meta.yesterdayPlans).toEqual(['Task A', 'Task B']);
+
+    // Submit: A done, B continue, add C
+    await actor.submitOpenedModal({
+      userId: BOB,
+      yesterdaySelections: { 0: 'done', 1: 'continue' },
+      todayPlans: 'Task C',
+    });
+
+    // --- Day-2 submission persisted with the right split ---
+    subs = await allSubmissions<any>();
+    expect(subs).toHaveLength(2);
+    const day2 = subs.find((s) => toDateString(s.date) === '2026-06-02')!;
+    expect(day2.yesterday_completed).toEqual(['Task A']);
+    expect(day2.yesterday_incomplete).toEqual(['Task B']);
+    expect(day2.today_plans).toEqual(['Task C']);
+
+    // --- Work items reflect transitions ---
+    const items = await allWorkItems<any>();
+    const byText = Object.fromEntries(items.map((i) => [i.text, i]));
+    expect(byText['Task A'].status).toBe('done');
+    expect(toDateString(byText['Task A'].completed_date)).toBe('2026-06-02');
+    expect(byText['Task B'].status).toBe('carried');
+    expect(byText['Task B'].carry_count).toBe(1);
+    expect(byText['Task C'].status).toBe('pending');
+
+    // --- Day-2 channel post: carried B + new C under Today, A summarized as done ---
+    const posts = slackRecorder().channelPosts();
+    expect(posts).toHaveLength(1);
+    const blocks = JSON.stringify(posts[0].body.blocks);
+    expect(blocks).toContain('Task B'); // carried over
+    expect(blocks).toContain('Task C'); // new plan
+    expect(blocks).toContain('1 done'); // Task A completed, summarized as a count
+  });
+});

--- a/tests/e2e/harness/actor.ts
+++ b/tests/e2e/harness/actor.ts
@@ -1,0 +1,276 @@
+/**
+ * The Slack "actor" — simulates Slack sending signed requests to the worker.
+ *
+ * Every request is signed with a real HMAC (the worker verifies signatures for
+ * real — that path is NOT mocked), so these tests exercise the full entry point
+ * in api/index.ts: signature check → routing → handler → DB → Slack fake.
+ *
+ * It also models the round trip a human makes: the bot opens a modal (captured
+ * by the Slack fake), the actor reads that modal back, fills it in, and submits
+ * it as a `view_submission` — closing the open→fill→submit loop without
+ * hand-authoring private_metadata.
+ */
+
+import worker from '../../../api/index';
+import type { Env } from '../../../api/index';
+import type { SlackRecorder } from './slack';
+
+export const TEST_SIGNING_SECRET = 'e2e-signing-secret';
+export const TEST_BOT_TOKEN = 'xoxb-e2e-token';
+
+// ----------------------------------------------------------------------------
+// Env + ExecutionContext
+// ----------------------------------------------------------------------------
+
+export function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    SLACK_BOT_TOKEN: TEST_BOT_TOKEN,
+    SLACK_SIGNING_SECRET: TEST_SIGNING_SECRET,
+    DATABASE_URL: 'postgres://e2e-not-used', // getDb is swapped to PGlite in setup
+    ...overrides,
+  };
+}
+
+/**
+ * An ExecutionContext whose waitUntil collects background promises so the test
+ * can await them. handleStandupSubmission and the task handlers do their DB +
+ * Slack work inside waitUntil — `drain()` flushes it before assertions.
+ */
+export class TestExecutionContext {
+  private promises: Promise<unknown>[] = [];
+
+  ctx: ExecutionContext = {
+    waitUntil: (p: Promise<unknown>) => {
+      this.promises.push(p);
+    },
+    passThroughOnException: () => {},
+  } as unknown as ExecutionContext;
+
+  async drain(): Promise<void> {
+    // Loop: a drained promise may schedule more background work.
+    while (this.promises.length > 0) {
+      const batch = this.promises;
+      this.promises = [];
+      await Promise.allSettled(batch);
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Request signing
+// ----------------------------------------------------------------------------
+
+async function sign(body: string, timestamp: string): Promise<string> {
+  const base = `v0:${timestamp}:${body}`;
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(TEST_SIGNING_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(base));
+  const hex = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `v0=${hex}`;
+}
+
+/**
+ * Timestamp for signing. The worker's signature check compares this against
+ * `Date.now()`. When a test fakes `Date` (vi.setSystemTime), BOTH the actor and
+ * the worker observe the same faked clock — so the timestamps match (skew 0)
+ * and the signature stays valid regardless of how far "now" is moved.
+ */
+function epochSeconds(): string {
+  return String(Math.floor(Date.now() / 1000));
+}
+
+async function signedRequest(
+  path: string,
+  body: string,
+  contentType: string,
+): Promise<Request> {
+  const ts = epochSeconds();
+  const sig = await sign(body, ts);
+  return new Request(`https://bot.example.com${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': contentType,
+      'x-slack-request-timestamp': ts,
+      'x-slack-signature': sig,
+    },
+    body,
+  });
+}
+
+// ----------------------------------------------------------------------------
+// Actor
+// ----------------------------------------------------------------------------
+
+export interface SlashCommandFields {
+  command?: string;
+  text?: string;
+  user_id?: string;
+  user_name?: string;
+  channel_id?: string;
+  channel_name?: string;
+  team_id?: string;
+  response_url?: string;
+  trigger_id?: string;
+}
+
+export class SlackActor {
+  constructor(
+    private recorder: SlackRecorder,
+    private env: Env = makeEnv(),
+  ) {}
+
+  /** Run a slash command (/standup, /daily). Returns parsed JSON response. */
+  async slashCommand(fields: SlashCommandFields): Promise<{ status: number; json: any }> {
+    const full: Record<string, string> = {
+      command: '/standup',
+      text: '',
+      user_id: 'U_TEST',
+      user_name: 'tester',
+      channel_id: 'C_GENERAL',
+      channel_name: 'general',
+      team_id: 'T_TEST',
+      response_url: 'https://hooks.slack.com/commands/T_TEST/x',
+      trigger_id: `trigger.${this.recorder.nextTs()}`,
+      ...stripUndefined(fields),
+    };
+    const body = new URLSearchParams(full).toString();
+    const req = await signedRequest('/api/slack/commands', body, 'application/x-www-form-urlencoded');
+    return this.run(req);
+  }
+
+  /** Send an interaction payload (block_actions / view_submission). */
+  async interact(payload: object): Promise<{ status: number; json: any }> {
+    const body = `payload=${encodeURIComponent(JSON.stringify(payload))}`;
+    const req = await signedRequest('/api/slack/interact', body, 'application/x-www-form-urlencoded');
+    return this.run(req);
+  }
+
+  /** Send an Events API payload (app_home_opened, url_verification). */
+  async event(payload: object): Promise<{ status: number; json: any }> {
+    const body = JSON.stringify(payload);
+    const req = await signedRequest('/api/slack/events', body, 'application/json');
+    return this.run(req);
+  }
+
+  /** Click a block button: action_id + value, optional trigger. */
+  async clickButton(
+    actionId: string,
+    value: string,
+    opts: { userId?: string; triggerId?: string } = {},
+  ): Promise<{ status: number; json: any }> {
+    return this.interact({
+      type: 'block_actions',
+      trigger_id: opts.triggerId ?? `trigger.${this.recorder.nextTs()}`,
+      user: { id: opts.userId ?? 'U_TEST' },
+      actions: [{ action_id: actionId, value }],
+    });
+  }
+
+  /** Select an option from an overflow/static menu (task_action style). */
+  async selectOption(
+    actionId: string,
+    optionValue: string,
+    opts: { userId?: string } = {},
+  ): Promise<{ status: number; json: any }> {
+    return this.interact({
+      type: 'block_actions',
+      trigger_id: `trigger.${this.recorder.nextTs()}`,
+      user: { id: opts.userId ?? 'U_TEST' },
+      actions: [{ action_id: actionId, value: '', selected_option: { value: optionValue } }],
+    });
+  }
+
+  /**
+   * Submit the standup modal the bot most recently opened.
+   *
+   * Reads the captured modal's private_metadata so callback_id/dailyName/mode/
+   * targetDate all match what the bot built, then fills:
+   *   - yesterday item dropdowns by `yesterdaySelections` (index → status),
+   *   - the free-text today_plans / unplanned / blockers inputs.
+   * This mirrors a user filling the actual modal Slack rendered.
+   */
+  async submitOpenedModal(opts: {
+    userId?: string;
+    yesterdaySelections?: Record<number, 'done' | 'continue' | 'in_progress' | 'drop'>;
+    todayPlans?: string;
+    unplanned?: string;
+    blockers?: string;
+  } = {}): Promise<{ status: number; json: any }> {
+    const modal = this.recorder.lastModal();
+    if (!modal) throw new Error('No modal has been opened to submit');
+    const metadata = JSON.parse(modal.private_metadata) as {
+      dailyName: string;
+      yesterdayPlans?: string[];
+      mode?: string;
+      targetDate?: string;
+    };
+
+    const values: Record<string, any> = {};
+    const yesterdayPlans = metadata.yesterdayPlans ?? [];
+    yesterdayPlans.forEach((_item, i) => {
+      const status = opts.yesterdaySelections?.[i] ?? 'continue';
+      values[`yesterday_item_${i}`] = {
+        [`item_status_${i}`]: { selected_option: { value: status } },
+      };
+    });
+    if (opts.todayPlans !== undefined) {
+      values.today_plans = { plans_input: { value: opts.todayPlans } };
+    }
+    if (opts.unplanned !== undefined) {
+      values.unplanned = { unplanned_input: { value: opts.unplanned } };
+    }
+    if (opts.blockers !== undefined) {
+      values.blockers = {
+        blockers_input: {
+          rich_text_value: {
+            type: 'rich_text',
+            elements: [
+              { type: 'rich_text_section', elements: [{ type: 'text', text: opts.blockers }] },
+            ],
+          },
+        },
+      };
+    }
+
+    return this.interact({
+      type: 'view_submission',
+      trigger_id: `trigger.${this.recorder.nextTs()}`,
+      user: { id: opts.userId ?? 'U_TEST' },
+      view: {
+        callback_id: modal.callback_id,
+        private_metadata: modal.private_metadata,
+        state: { values },
+      },
+    });
+  }
+
+  private async run(req: Request): Promise<{ status: number; json: any }> {
+    const exec = new TestExecutionContext();
+    const res = await worker.fetch(req, this.env, exec.ctx);
+    await exec.drain();
+    const text = await res.text();
+    let json: any = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {
+      json = text;
+    }
+    return { status: res.status, json };
+  }
+}
+
+function stripUndefined(obj: Record<string, any>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = String(v);
+  }
+  return out;
+}

--- a/tests/e2e/harness/db.ts
+++ b/tests/e2e/harness/db.ts
@@ -1,0 +1,108 @@
+/**
+ * E2E test database harness — a real Postgres engine in-process via PGlite.
+ *
+ * The production code talks to Neon through a single `DbClient.query(sql, params)`
+ * seam (see lib/db.ts `getDb`). This harness provides a `DbClient` backed by
+ * PGlite running the real `schema.sql`, so every query function in lib/db.ts
+ * (saveSubmission, getSubmissionForDate, …) runs its actual SQL against actual
+ * Postgres. That means UNIQUE constraints, JSONB coercion, and DATE parsing all
+ * behave the way they do in production — including Neon's habit of returning
+ * DATE columns as JS Date objects (PGlite does the same), which is exactly the
+ * class of bug commit 30e05f8 fixed.
+ *
+ * A single PGlite instance is created lazily and reused across the whole test
+ * run (WASM init is the slow part); `resetTestDb()` truncates between tests.
+ */
+
+import { PGlite } from '@electric-sql/pglite';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import type { DbClient } from '../../../lib/db';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = join(HERE, '..', '..', '..', 'schema.sql');
+
+/** Every table in schema.sql — truncated between tests for isolation. */
+const ALL_TABLES = [
+  'participants',
+  'submissions',
+  'prompts',
+  'slack_users',
+  'work_items',
+  'submission_items',
+  'reminder_log',
+  'ooo',
+  'config_overrides',
+];
+
+let pg: PGlite | null = null;
+let client: DbClient | null = null;
+
+/**
+ * Adapt PGlite to the production `DbClient` interface.
+ * PGlite speaks the same `$1`-style parameterized SQL the lib/db.ts functions
+ * already emit, so this is a thin wrapper: run the query, hand back `.rows`.
+ * Undefined params are coerced to null (PGlite rejects `undefined`).
+ */
+function adapt(instance: PGlite): DbClient {
+  return {
+    query: async <T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]> => {
+      const safeParams = params?.map((p) => (p === undefined ? null : p));
+      const result = await instance.query<T>(sql, safeParams);
+      return result.rows;
+    },
+  };
+}
+
+/** Create the PGlite instance and load schema.sql (idempotent). */
+export async function initTestDb(): Promise<DbClient> {
+  if (!pg) {
+    pg = new PGlite();
+    const schema = readFileSync(SCHEMA_PATH, 'utf-8');
+    await pg.exec(schema);
+    client = adapt(pg);
+  }
+  return client!;
+}
+
+/**
+ * The live DbClient. Throws if accessed before initTestDb() — the e2e setup
+ * file initializes it before any test runs.
+ */
+export function getTestDbClient(): DbClient {
+  if (!client) {
+    throw new Error('Test DB not initialized — did the e2e setup file run initTestDb()?');
+  }
+  return client;
+}
+
+/** Truncate every table and reset SERIAL counters so IDs are deterministic. */
+export async function resetTestDb(): Promise<void> {
+  const db = getTestDbClient();
+  await db.query(`TRUNCATE ${ALL_TABLES.join(', ')} RESTART IDENTITY CASCADE`);
+}
+
+// ----------------------------------------------------------------------------
+// Inspection helpers — read raw rows so scenarios can assert on persistence.
+// ----------------------------------------------------------------------------
+
+/** Raw rows from any table (optionally filtered by daily). */
+export async function rows<T = Record<string, unknown>>(table: string): Promise<T[]> {
+  return getTestDbClient().query<T>(`SELECT * FROM ${table} ORDER BY id ASC`);
+}
+
+/** All submissions, newest date first. */
+export async function allSubmissions<T = Record<string, unknown>>(): Promise<T[]> {
+  return getTestDbClient().query<T>(`SELECT * FROM submissions ORDER BY date DESC, id ASC`);
+}
+
+/** All work_items in insertion order. */
+export async function allWorkItems<T = Record<string, unknown>>(): Promise<T[]> {
+  return getTestDbClient().query<T>(`SELECT * FROM work_items ORDER BY id ASC`);
+}
+
+/** All submission_items rows (the work_item ↔ submission link table). */
+export async function allSubmissionItems<T = Record<string, unknown>>(): Promise<T[]> {
+  return getTestDbClient().query<T>(`SELECT * FROM submission_items ORDER BY id ASC`);
+}

--- a/tests/e2e/harness/slack.ts
+++ b/tests/e2e/harness/slack.ts
@@ -1,0 +1,175 @@
+/**
+ * Fake Slack API at the `fetch` boundary.
+ *
+ * The bot makes every Slack call through `fetch('https://slack.com/api/<method>')`
+ * in lib/slack.ts. This installs a `globalThis.fetch` that:
+ *   - records each Slack call (method + parsed JSON body) into a recorder,
+ *   - returns a realistic `{ ok: true, ts }` (or method-specific) response so the
+ *     REAL lib/slack.ts code path runs end to end,
+ *   - serves `users.info` from a configurable user directory (so timezone logic
+ *     runs for real — no need to mock lib/prompt),
+ *   - throws on any non-Slack host, turning an accidental real network call
+ *     (GitHub, Linear, Neon) into a loud test failure instead of a silent hang.
+ *
+ * Scenarios assert against the recorder: "the bot posted these blocks to this
+ * channel", "it opened a modal with this callback_id", etc.
+ */
+
+export interface SlackCall {
+  /** API method, e.g. "chat.postMessage", "views.open". */
+  method: string;
+  /** Parsed JSON request body. */
+  body: any;
+}
+
+/** Default timezone served by users.info unless overridden per user. */
+const DEFAULT_TZ = { tz: 'Asia/Jerusalem', tz_offset: 10800 };
+
+export class SlackRecorder {
+  /** Every Slack API call in order. */
+  calls: SlackCall[] = [];
+
+  /** users.info directory: userId → tz info. */
+  private users = new Map<string, { tz: string; tz_offset: number }>();
+
+  /** Monotonic ts generator so each posted message gets a unique id. */
+  private tsCounter = 1000;
+
+  /** Configure the timezone returned by users.info for a given user. */
+  setUser(userId: string, tz: Partial<{ tz: string; tz_offset: number }> = {}): void {
+    this.users.set(userId, { ...DEFAULT_TZ, ...tz });
+  }
+
+  userTz(userId: string): { tz: string; tz_offset: number } {
+    return this.users.get(userId) ?? DEFAULT_TZ;
+  }
+
+  nextTs(): string {
+    this.tsCounter += 1;
+    return `${this.tsCounter}.0001`;
+  }
+
+  // --- Query helpers used by scenario assertions -------------------------
+
+  /** All calls to a given API method. */
+  byMethod(method: string): SlackCall[] {
+    return this.calls.filter((c) => c.method === method);
+  }
+
+  /** chat.postMessage calls (channel posts + DMs both go through this). */
+  get posts(): SlackCall[] {
+    return this.byMethod('chat.postMessage');
+  }
+
+  /** chat.postMessage calls targeting a real channel (starts with "#" or "C"). */
+  channelPosts(): SlackCall[] {
+    return this.posts.filter((c) => /^[#C]/.test(String(c.body.channel)));
+  }
+
+  /** chat.postMessage calls targeting a user DM (channel is a Uxxx id). */
+  dms(): SlackCall[] {
+    return this.posts.filter((c) => /^U/.test(String(c.body.channel)));
+  }
+
+  /** DMs sent to a specific user. */
+  dmsTo(userId: string): SlackCall[] {
+    return this.posts.filter((c) => c.body.channel === userId);
+  }
+
+  get modalsOpened(): SlackCall[] {
+    return this.byMethod('views.open');
+  }
+
+  get modalsUpdated(): SlackCall[] {
+    return this.byMethod('views.update');
+  }
+
+  get homeViews(): SlackCall[] {
+    return this.byMethod('views.publish');
+  }
+
+  get messageUpdates(): SlackCall[] {
+    return this.byMethod('chat.update');
+  }
+
+  /** The most recently opened modal view object (what views.open received). */
+  lastModal(): any | undefined {
+    const m = this.modalsOpened;
+    return m.length ? m[m.length - 1].body.view : undefined;
+  }
+
+  reset(): void {
+    this.calls = [];
+    this.tsCounter = 1000;
+    // user directory intentionally NOT cleared — scenarios set it up per test
+    this.users.clear();
+  }
+}
+
+/**
+ * Install the fake. Returns the recorder and an uninstall function.
+ * Pass the recorder around to assert on what the bot sent Slack.
+ */
+export function installSlackFake(): { recorder: SlackRecorder; uninstall: () => void } {
+  const recorder = new SlackRecorder();
+  const realFetch = globalThis.fetch;
+
+  const fake = async (input: any, init?: any): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.url;
+
+    if (!url.startsWith('https://slack.com/api/')) {
+      throw new Error(
+        `Unexpected non-Slack fetch in e2e test: ${url}\n` +
+          `(GitHub/Linear/Neon calls must not happen — leave their tokens unset.)`,
+      );
+    }
+
+    const method = url.replace('https://slack.com/api/', '').split('?')[0];
+
+    // users.info is sent as GET with a query param; everything else is POST JSON.
+    if (method === 'users.info') {
+      const u = new URL(url);
+      const userId = u.searchParams.get('user') || '';
+      recorder.calls.push({ method, body: { user: userId } });
+      const tz = recorder.userTz(userId);
+      return jsonResponse({ ok: true, user: { id: userId, tz: tz.tz, tz_offset: tz.tz_offset } });
+    }
+
+    const body = init?.body ? JSON.parse(init.body) : {};
+    recorder.calls.push({ method, body });
+
+    return jsonResponse(responseFor(method, recorder));
+  };
+
+  globalThis.fetch = fake as typeof fetch;
+
+  return {
+    recorder,
+    uninstall: () => {
+      globalThis.fetch = realFetch;
+    },
+  };
+}
+
+/** Method-specific canned success responses, matching what lib/slack.ts reads. */
+function responseFor(method: string, recorder: SlackRecorder): object {
+  switch (method) {
+    case 'chat.postMessage':
+      return { ok: true, ts: recorder.nextTs() };
+    case 'chat.update':
+      return { ok: true, ts: recorder.nextTs() };
+    case 'views.open':
+    case 'views.update':
+    case 'views.publish':
+      return { ok: true };
+    default:
+      return { ok: true };
+  }
+}
+
+function jsonResponse(obj: object): Response {
+  return new Response(JSON.stringify(obj), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/tests/e2e/scheduled-post.test.ts
+++ b/tests/e2e/scheduled-post.test.ts
@@ -1,0 +1,89 @@
+/**
+ * E2E: queued submission posts when its scheduled time arrives.
+ *
+ * Submitting before the schedule's posting time queues the standup
+ * (posted=false, no channel post yet, confirmation DM). Later, the scheduled
+ * cron posts it. This exercises the exact DATE-handling path that commit 30e05f8
+ * fixed: getUnpostedSubmissions → toDateString(submission.date) compared against
+ * getDateInTimezone(scheduleTz). Because PGlite returns DATE as a JS Date object
+ * (like Neon), a regression in that parsing would make the cron silently skip.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SlackActor, makeEnv, TEST_BOT_TOKEN } from './harness/actor';
+import { getTestDbClient, allSubmissions, allWorkItems } from './harness/db';
+import { slackRecorder } from './setup';
+import { addParticipant } from '../../lib/db';
+import { runScheduledPosts } from '../../lib/prompt';
+
+const CAROL = 'U_CAROL';
+const BEFORE_TIME = new Date('2026-06-02T05:00:00.000Z'); // 08:00 IDT — before 10:00
+const AFTER_TIME = new Date('2026-06-02T08:00:00.000Z'); // 11:00 IDT — after 10:00
+
+describe('e2e: scheduled (queued) post', () => {
+  let actor: SlackActor;
+
+  beforeEach(async () => {
+    const recorder = slackRecorder();
+    recorder.setUser(CAROL);
+    await addParticipant(getTestDbClient(), CAROL, 'daily-test', 'il-team');
+    actor = new SlackActor(recorder, makeEnv());
+  });
+
+  it('queues before the posting time, then the cron posts it after', async () => {
+    // --- Submit before 10:00 → queued, not posted ---
+    vi.setSystemTime(BEFORE_TIME);
+    await actor.slashCommand({ command: '/daily', user_id: CAROL });
+    await actor.submitOpenedModal({ userId: CAROL, todayPlans: 'Ship the thing' });
+
+    let subs = await allSubmissions<any>();
+    expect(subs).toHaveLength(1);
+    expect(subs[0].posted).toBe(false);
+    expect(subs[0].slack_message_ts).toBeNull();
+
+    // No channel post yet; user got a "scheduled" confirmation DM.
+    expect(slackRecorder().channelPosts()).toHaveLength(0);
+    const dm = slackRecorder().dmsTo(CAROL);
+    expect(dm.length).toBeGreaterThanOrEqual(1);
+    expect(JSON.stringify(dm.map((d) => d.body.text))).toContain('scheduled');
+
+    // --- Time passes to after 10:00; run the scheduled-posts cron ---
+    vi.setSystemTime(AFTER_TIME);
+    slackRecorder().reset();
+    slackRecorder().setUser(CAROL);
+
+    const stats = await runScheduledPosts(getTestDbClient(), TEST_BOT_TOKEN, makeEnv());
+    expect(stats).toMatchObject({ posted: 1, errors: 0 });
+
+    // --- Now it's posted to the channel and marked posted in the DB ---
+    const posts = slackRecorder().channelPosts();
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body.channel).toBe('#daily-bot-test');
+    expect(JSON.stringify(posts[0].body.blocks)).toContain('Ship the thing');
+
+    subs = await allSubmissions<any>();
+    expect(subs[0].posted).toBe(true);
+    expect(subs[0].slack_message_ts).toBeTruthy();
+
+    // Work items are tracked at post time (not at queue time).
+    const items = await allWorkItems<any>();
+    expect(items.map((i) => i.text)).toContain('Ship the thing');
+  });
+
+  it('does not post a queued submission whose time has not yet arrived', async () => {
+    vi.setSystemTime(BEFORE_TIME);
+    await actor.slashCommand({ command: '/daily', user_id: CAROL });
+    await actor.submitOpenedModal({ userId: CAROL, todayPlans: 'Not yet' });
+
+    slackRecorder().reset();
+    slackRecorder().setUser(CAROL);
+
+    // Still before 10:00 — cron should skip, nothing posted.
+    const stats = await runScheduledPosts(getTestDbClient(), TEST_BOT_TOKEN, makeEnv());
+    expect(stats).toMatchObject({ posted: 0 });
+    expect(slackRecorder().channelPosts()).toHaveLength(0);
+
+    const subs = await allSubmissions<any>();
+    expect(subs[0].posted).toBe(false);
+  });
+});

--- a/tests/e2e/setup.ts
+++ b/tests/e2e/setup.ts
@@ -1,0 +1,64 @@
+/**
+ * Global setup for the e2e suite. Runs before every e2e test file.
+ *
+ * Responsibilities:
+ *   1. Swap ONLY lib/db's `getDb` to return the PGlite-backed client — every
+ *      other query function stays real, so real SQL runs against real Postgres.
+ *   2. Install the fake Slack API at the fetch boundary and expose its recorder
+ *      globally (scenarios read it via `slackRecorder()`).
+ *   3. Initialize the DB once, truncate between tests, and pin the clock + TZ so
+ *      date math is deterministic.
+ *
+ * Nothing else is mocked: signature verification, config loading (real
+ * config.yaml), all handlers, formatting, and timezone logic run for real.
+ * GitHub/Linear integration code short-circuits because their tokens are unset.
+ */
+
+import { beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { initTestDb, resetTestDb } from './harness/db';
+import { installSlackFake, SlackRecorder } from './harness/slack';
+
+// --- 1. DB: swap getDb → PGlite client, keep all query functions real --------
+vi.mock('../../lib/db', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../lib/db')>();
+  const { getTestDbClient } = await import('./harness/db');
+  return {
+    ...real,
+    getDb: () => getTestDbClient(),
+  };
+});
+
+// --- 2. Slack fake -----------------------------------------------------------
+let _slack: { recorder: SlackRecorder; uninstall: () => void } | null = null;
+
+/** The active Slack recorder for the current test. */
+export function slackRecorder(): SlackRecorder {
+  if (!_slack) throw new Error('Slack fake not installed');
+  return _slack.recorder;
+}
+
+/** Default "now" for tests that don't set their own — a Tuesday, after 10:00
+ *  Jerusalem time (12:00Z = 15:00 IDT) so "post immediately" is the default. */
+export const DEFAULT_NOW = new Date('2026-06-02T12:00:00.000Z');
+
+beforeAll(async () => {
+  await initTestDb();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  _slack = installSlackFake();
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(DEFAULT_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  _slack?.uninstall();
+  _slack = null;
+  vi.clearAllMocks();
+});
+
+afterAll(() => {
+  // PGlite instance is process-scoped; nothing to tear down explicitly.
+});

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Smoke test — proves the e2e harness is wired correctly before scenarios rely
+ * on it: the db mock swaps in PGlite, real query functions persist & read back,
+ * the Slack fake records calls, and the worker's signature check runs for real.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SlackActor, makeEnv } from './harness/actor';
+import { getTestDbClient } from './harness/db';
+import { slackRecorder } from './setup';
+import { saveSubmission, getSubmissionForDate } from '../../lib/db';
+
+describe('e2e harness smoke test', () => {
+  it('getDb is swapped: real query functions persist and read back via PGlite', async () => {
+    const db = getTestDbClient();
+
+    const saved = await saveSubmission(db, {
+      slackUserId: 'U_SMOKE',
+      dailyName: 'daily-test',
+      date: '2026-06-02',
+      yesterdayCompleted: [],
+      yesterdayIncomplete: ['carried'],
+      unplanned: [],
+      todayPlans: ['plan one', 'plan two'],
+      blockers: '',
+      customAnswers: {},
+    });
+
+    expect(saved.id).toBe(1); // RESTART IDENTITY → deterministic
+    const readBack = await getSubmissionForDate(db, 'U_SMOKE', 'daily-test', '2026-06-02');
+    expect(readBack).not.toBeNull();
+    expect(readBack!.today_plans).toEqual(['plan one', 'plan two']);
+    expect(readBack!.yesterday_incomplete).toEqual(['carried']);
+  });
+
+  it('drives a real signed request through the worker entry point', async () => {
+    const actor = new SlackActor(slackRecorder(), makeEnv());
+    const { status, json } = await actor.slashCommand({ command: '/standup', text: 'help' });
+    expect(status).toBe(200);
+    expect(JSON.stringify(json)).toContain('/standup');
+  });
+
+  it('Slack fake records calls and serves users.info', async () => {
+    const recorder = slackRecorder();
+    recorder.setUser('U_TZ', { tz: 'Asia/Jerusalem', tz_offset: 10800 });
+
+    // Hit users.info through the real lib/slack helper path indirectly:
+    const res = await fetch('https://slack.com/api/users.info?user=U_TZ');
+    const data = (await res.json()) as any;
+    expect(data.ok).toBe(true);
+    expect(data.user.tz).toBe('Asia/Jerusalem');
+    expect(recorder.byMethod('users.info').length).toBe(1);
+  });
+});

--- a/tests/e2e/standup-submit.test.ts
+++ b/tests/e2e/standup-submit.test.ts
@@ -1,0 +1,91 @@
+/**
+ * E2E: first-time standup submission.
+ *
+ * Journey: a participant runs `/daily`, the bot opens the modal, they fill in
+ * today's plans and submit. We assert on BOTH sides of the boundary:
+ *   - what the bot persisted (submissions row, work_items, submission_items),
+ *   - what the bot sent Slack (a channel post with the plans in its blocks).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SlackActor, makeEnv } from './harness/actor';
+import { getTestDbClient, allSubmissions, allWorkItems, allSubmissionItems } from './harness/db';
+import { slackRecorder } from './setup';
+import { addParticipant } from '../../lib/db';
+
+const ALICE = 'U_ALICE';
+
+describe('e2e: first standup submission', () => {
+  let actor: SlackActor;
+
+  beforeEach(async () => {
+    const recorder = slackRecorder();
+    recorder.setUser(ALICE);
+    await addParticipant(getTestDbClient(), ALICE, 'daily-test', 'il-team');
+    actor = new SlackActor(recorder, makeEnv());
+  });
+
+  it('opens the standup modal on /daily', async () => {
+    const { status, json } = await actor.slashCommand({ command: '/daily', user_id: ALICE });
+    expect(status).toBe(200);
+    expect(JSON.stringify(json)).toContain('Opening standup');
+
+    const recorder = slackRecorder();
+    expect(recorder.modalsOpened).toHaveLength(1);
+    expect(recorder.lastModal().callback_id).toBe('standup_submission');
+  });
+
+  it('persists the submission and posts it to the channel', async () => {
+    await actor.slashCommand({ command: '/daily', user_id: ALICE });
+    const { status } = await actor.submitOpenedModal({
+      userId: ALICE,
+      todayPlans: 'Build login page\nFix flaky test',
+    });
+    expect(status).toBe(200);
+
+    // --- Persistence ---
+    const subs = await allSubmissions<any>();
+    expect(subs).toHaveLength(1);
+    const sub = subs[0];
+    expect(sub.slack_user_id).toBe(ALICE);
+    expect(sub.daily_name).toBe('daily-test');
+    expect(sub.today_plans).toEqual(['Build login page', 'Fix flaky test']);
+    expect(sub.posted).toBe(true);
+    // posted immediately (15:00 IDT is past the 10:00 schedule) → message ts recorded
+    expect(sub.slack_message_ts).toBeTruthy();
+
+    // Work items: one per plan, manual source, pending status
+    const items = await allWorkItems<any>();
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => i.text)).toEqual(['Build login page', 'Fix flaky test']);
+    expect(items.every((i) => i.status === 'pending')).toBe(true);
+    expect(items.every((i) => i.source === 'manual' && i.item_type === 'plan')).toBe(true);
+
+    // Link rows tie the work items to the submission as today_plan
+    const links = await allSubmissionItems<any>();
+    expect(links).toHaveLength(2);
+    expect(links.every((l) => l.role === 'today_plan' && l.submission_id === sub.id)).toBe(true);
+
+    // --- Slack output ---
+    const recorder = slackRecorder();
+    const posts = recorder.channelPosts();
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body.channel).toBe('#daily-bot-test');
+    const blocksJson = JSON.stringify(posts[0].body.blocks);
+    expect(blocksJson).toContain('Build login page');
+    expect(blocksJson).toContain('Fix flaky test');
+  });
+
+  it('rejects an empty submission with a validation error and persists nothing', async () => {
+    await actor.slashCommand({ command: '/daily', user_id: ALICE });
+    const { status, json } = await actor.submitOpenedModal({ userId: ALICE, todayPlans: '' });
+
+    expect(status).toBe(200);
+    expect(json.response_action).toBe('errors');
+    expect(json.errors.today_plans).toBeTruthy();
+
+    const subs = await allSubmissions();
+    expect(subs).toHaveLength(0);
+    expect(slackRecorder().channelPosts()).toHaveLength(0);
+  });
+});

--- a/tests/e2e/task-action.test.ts
+++ b/tests/e2e/task-action.test.ts
@@ -1,0 +1,68 @@
+/**
+ * E2E: task overflow-menu action from App Home.
+ *
+ * After a standup is posted, the user marks an item "done" from the App Home
+ * task list. Assert the whole chain: the work item flips to done, the
+ * submission's JSONB arrays are re-derived from work-item state, the channel
+ * post is updated in place, and the App Home view is re-published. This relies
+ * on getActiveWorkItems running against real Postgres (the query the harness
+ * just exposed as broken).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SlackActor, makeEnv } from './harness/actor';
+import { getTestDbClient, allSubmissions, allWorkItems } from './harness/db';
+import { slackRecorder } from './setup';
+import { addParticipant } from '../../lib/db';
+
+const DAVE = 'U_DAVE';
+
+describe('e2e: App Home task action', () => {
+  let actor: SlackActor;
+
+  beforeEach(async () => {
+    const recorder = slackRecorder();
+    recorder.setUser(DAVE);
+    await addParticipant(getTestDbClient(), DAVE, 'daily-test', 'il-team');
+    actor = new SlackActor(recorder, makeEnv());
+  });
+
+  it('marks an item done → updates DB, channel post, and App Home', async () => {
+    // Submit two plans (posts to channel, creates work items).
+    await actor.slashCommand({ command: '/daily', user_id: DAVE });
+    await actor.submitOpenedModal({ userId: DAVE, todayPlans: 'Task A\nTask B' });
+
+    const sub = (await allSubmissions<any>())[0];
+    const items = await allWorkItems<any>();
+    const taskA = items.find((i) => i.text === 'Task A')!;
+    expect(taskA.status).toBe('pending');
+
+    slackRecorder().reset();
+    slackRecorder().setUser(DAVE);
+
+    // Mark Task A done via the overflow menu (task_action).
+    const value = JSON.stringify({ itemId: taskA.id, dailyName: 'daily-test', action: 'done' });
+    const { status } = await actor.selectOption('task_action', value, { userId: DAVE });
+    expect(status).toBe(200);
+
+    // --- Work item flipped to done ---
+    const after = await allWorkItems<any>();
+    expect(after.find((i) => i.text === 'Task A')!.status).toBe('done');
+
+    // --- Submission arrays re-derived: A → completed, B stays a plan ---
+    const sub2 = (await allSubmissions<any>())[0];
+    expect(sub2.yesterday_completed).toEqual(['Task A']);
+    expect(sub2.today_plans).toEqual(['Task B']);
+
+    // --- Channel post updated in place (same ts) ---
+    const updates = slackRecorder().messageUpdates;
+    expect(updates).toHaveLength(1);
+    expect(updates[0].body.channel).toBe('#daily-bot-test');
+    expect(updates[0].body.ts).toBe(sub.slack_message_ts);
+
+    // --- App Home re-published with the task list ---
+    const homes = slackRecorder().homeViews;
+    expect(homes.length).toBeGreaterThanOrEqual(1);
+    expect(JSON.stringify(homes[homes.length - 1].body.view)).toContain('Task B');
+  });
+});

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -1177,6 +1177,54 @@ describe('standup template sections - submission parsing', () => {
   });
 });
 
+describe('Linear ticket selections - submission parsing', () => {
+  const makePayload = (): InteractionPayload => ({
+    type: 'view_submission',
+    trigger_id: 'trigger123',
+    user: { id: 'U12345' },
+    view: {
+      callback_id: 'standup_submission',
+      private_metadata: JSON.stringify({ dailyName: 'daily-il', yesterdayPlans: [], mode: 'today' }),
+      state: {
+        values: {
+          today_plans: { plans_input: { value: '' } },
+          // First checkbox chunk (base block).
+          linear_tickets: {
+            linear_tickets_input: {
+              selected_options: [
+                { value: 'issue-1', text: { type: 'mrkdwn', text: '*ENG-101* First ticket' } },
+              ],
+            },
+          },
+          // Second chunk produced when a user has >10 tickets and clicks "Show all".
+          linear_tickets_chunk_1: {
+            linear_tickets_input_chunk_1: {
+              selected_options: [
+                { value: 'issue-11', text: { type: 'mrkdwn', text: '*ENG-111* Eleventh ticket' } },
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(saveSubmission).mockResolvedValue({ id: 1 } as any);
+    vi.mocked(getMaxPlanItems).mockReturnValue(0);
+    vi.mocked(parseRichText).mockReturnValue('');
+  });
+
+  it('collects selections from the base block and chunk blocks', async () => {
+    await handleStandupSubmission(makePayload(), { db: {} as any, slackToken: 'xoxb-test' });
+
+    const saveCall = vi.mocked(saveSubmission).mock.calls[0][1];
+    expect(saveCall.todayPlans).toContain('[ENG-101] First ticket');
+    expect(saveCall.todayPlans).toContain('[ENG-111] Eleventh ticket');
+  });
+});
+
 describe('blocker @-mention DMs', () => {
   const makeSubmissionPayload = (blockerText: string): InteractionPayload => ({
     type: 'view_submission',

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -511,6 +511,37 @@ describe('modal builder', () => {
       expect(linearBlock?.element?.options).toHaveLength(3);
     });
 
+    it('chunks expanded Linear checkboxes into groups of 10 (Slack option cap)', () => {
+      const linearIssues: LinearIssue[] = Array.from({ length: 13 }, (_, i) => ({
+        id: `issue-${i}`,
+        identifier: `ENG-${100 + i}`,
+        title: `Issue ${i}`,
+        state: { name: 'Todo', type: 'unstarted' },
+        priority: 1,
+        url: `https://linear.app/issue/ENG-${100 + i}`,
+      }));
+
+      const modal = buildStandupModal(
+        'daily-il', null, [], undefined, undefined, 'today', undefined,
+        linearIssues, undefined, undefined, undefined, undefined, undefined, undefined,
+        new Set(['linear'])
+      );
+
+      const base = modal.blocks.find(b => b.block_id === 'linear_tickets');
+      const chunk1 = modal.blocks.find(b => b.block_id === 'linear_tickets_chunk_1');
+      expect((base?.element?.options as unknown[])).toHaveLength(10);
+      expect((chunk1?.element?.options as unknown[])).toHaveLength(3);
+      expect(base?.element?.action_id).toBe('linear_tickets_input');
+      expect(chunk1?.element?.action_id).toBe('linear_tickets_input_chunk_1');
+
+      // No checkboxes element may exceed Slack's 10-option maximum.
+      const overCap = modal.blocks.filter(
+        b => (b.element as { type?: string } | undefined)?.type === 'checkboxes'
+          && (b.element?.options as unknown[]).length > 10
+      );
+      expect(overCap).toHaveLength(0);
+    });
+
     it('shows Show all button when more than 3 issues available', () => {
       const linearIssues: LinearIssue[] = Array.from({ length: 15 }, (_, i) => ({
         id: `issue-${i}`,
@@ -1258,6 +1289,29 @@ describe('modal builder', () => {
       const result = applyExpandedSection(current, rebuiltLinear(), 'linear', undefined);
       const after = result.find(b => b.block_id === 'linear_tickets');
       expect((after?.element?.options as unknown[])?.length).toBeGreaterThan(3);
+    });
+
+    it('splits the expanded section into chunks of <=10 (Slack option cap)', () => {
+      // Regression: 15 tickets used to render as a single 15-option checkboxes
+      // element, which Slack rejects with invalid_arguments, so "Show all" silently
+      // failed. The expansion must now chunk into <=10-option blocks.
+      const current = collapsedView();
+      const result = applyExpandedSection(current, rebuiltLinear(), 'linear', undefined);
+
+      const checkboxBlocks = result.filter(
+        (b) => (b.element as { type?: string } | undefined)?.type === 'checkboxes'
+      );
+      for (const b of checkboxBlocks) {
+        expect((b.element?.options as unknown[]).length).toBeLessThanOrEqual(10);
+      }
+
+      // 15 tickets → base block (10) + one chunk (5).
+      const base = result.find((b) => b.block_id === 'linear_tickets');
+      const chunk1 = result.find((b) => b.block_id === 'linear_tickets_chunk_1');
+      expect((base?.element?.options as unknown[]).length).toBe(10);
+      expect((chunk1?.element?.options as unknown[]).length).toBe(5);
+      expect(base?.element?.action_id).toBe('linear_tickets_input');
+      expect(chunk1?.element?.action_id).toBe('linear_tickets_input_chunk_1');
     });
 
     it('leaves the other integration section untouched (no GitHub re-fetch)', () => {

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, Plugin } from 'vitest/config';
 import { readFileSync } from 'fs';
 
+// Same YAML-as-text loader the main config uses, so lib/config.ts can
+// `import '../config.yaml'` and load the real config in tests.
 function yamlTextPlugin(): Plugin {
   return {
     name: 'yaml-text',
@@ -18,15 +20,11 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['tests/**/*.test.ts'],
-    // e2e tests need the PGlite + Slack-fake setup; run them via vitest.e2e.config.ts
-    exclude: ['tests/e2e/**', 'node_modules/**'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'html'],
-      include: ['lib/**/*.ts'],
-      exclude: ['lib/handlers/**/*.ts'],
-    },
+    include: ['tests/e2e/**/*.test.ts'],
+    setupFiles: ['tests/e2e/setup.ts'],
+    // Pin the process timezone so DATE→string conversion (lib/prompt toDateString,
+    // which uses local-time accessors, matching Neon) is deterministic.
+    env: { TZ: 'UTC' },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Promotes `dev` to `main`. Three commits since the last release (PR #41).

## What's shipping

**Linear "Show all" silently did nothing for >10 tickets** (`7ec1f35`)
- Expanding set the limit to 20 and rendered every ticket as options in a single `checkboxes` element, but Slack caps a checkboxes element at **10 options** — so `views.update` returned `invalid_arguments` and the modal never updated. Collapsed (3 options) always worked, which is why it looked intermittent.
- `buildStandupModal` now splits displayed Linear tickets into chunks of 10, one input block per chunk. The first chunk keeps the original `block_id`/`action_id` so Slack preserves selections on expand; extra chunks use `linear_tickets_chunk_N`. In-progress pre-checks applied per chunk.
- `applyExpandedSection` splices in all of a section's chunk blocks (and drops stale ones).
- Submission parsing recombines `selected_options` across the base block + all chunk blocks, so both the plan items and the mark-in-progress path see every pick.
- Regression tests: chunking in `buildStandupModal`, chunked splice in `applyExpandedSection` (asserts no element exceeds 10 options), multi-chunk submission parsing.

**Other**
- `9d4653a` — `getActiveWorkItems` fails on real Postgres (`SELECT DISTINCT` + `ORDER BY`)
- `4777533` — add end-to-end harness with real Postgres + fake Slack API

## Checks
Full unit suite passing (577 tests), clean `tsc`.

## Note
Root cause confirmed against live worker logs (`views.update` → `invalid_arguments`) and Slack's documented 10-option checkbox cap. Worth a live click-through of "Show all" with >10 tickets after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)