### PR TITLE
Release: instant standup modal open + airtight state (dev → main)

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -51,7 +51,7 @@ export default {
 
       // Slack commands
       if (path === '/api/slack/commands') {
-        return handleSlackCommands(request, env);
+        return handleSlackCommands(request, env, ctx);
       }
 
       // Slack interactions (modals, buttons)
@@ -161,7 +161,7 @@ function handleHealthCheck(): Response {
 }
 
 /** Slack slash commands endpoint */
-async function handleSlackCommands(request: Request, env: Env): Promise<Response> {
+async function handleSlackCommands(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   if (request.method !== 'POST') {
     return new Response('Method not allowed', { status: 405 });
   }
@@ -198,6 +198,7 @@ async function handleSlackCommands(request: Request, env: Env): Promise<Response
       slackToken: env.SLACK_BOT_TOKEN,
       triggerId: payload.trigger_id,
       env,
+      waitUntil: ctx.waitUntil.bind(ctx),
     });
 
     return new Response(JSON.stringify(response), {

--- a/lib/handlers/commands.ts
+++ b/lib/handlers/commands.ts
@@ -3,12 +3,12 @@
  * Handles: help, prompt, add, remove, list, digest, week, daily
  */
 
-import { getDailies, getDaily, getSchedule, isAdmin, isSuperAdmin, getAdmins, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getLinearTeamIdForUser, clearConfigCache, loadConfigOverrides, isDailyEnabled, getAllDailiesIncludingDisabled, getDailyManagers, getOverride } from '../config';
+import { getDailies, getDaily, getSchedule, isAdmin, isSuperAdmin, getAdmins, getConfigError, getBottleneckThreshold, getGitHubUsernameFromConfig, getLinearUserIdFromConfig, getLinearConfig, getGitHubConfig, getLinearTeamIdForUser, clearConfigCache, loadConfigOverrides, isDailyEnabled, getAllDailiesIncludingDisabled, getDailyManagers, getOverride } from '../config';
 import { DbClient, addParticipant, removeParticipant, getParticipants, getSubmissionsForDate, getSubmissionsInRange, getParticipationStats, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, getBottleneckItems, getHighDropUsers, getPeriodStats, setOOO, clearOOO, getUserOOO, getActiveOOOForDaily, OOORecord, getSubmissionForDate, getPreviousSubmission, getGitHubUsername, setGitHubUsername, getLinearUserId, setLinearUserId, setConfigOverride, deleteConfigOverride, getAllConfigOverrides, getBlockerStreaks, getUnplannedOverload } from '../db';
 import { formatDailyDigest, formatWeeklySummary, formatManagerDigest, formatFullReport, DigestPeriod, TrendData } from '../format';
 import { fetchLinearIssuesForUser, fetchGitHubPRsForUser } from './interactions';
 import { formatDate, getUserDate, getUserTimezone, sendPromptDM } from '../prompt';
-import { parseUserId, ephemeralResponse, sendDM, SlackCommandResponse, openModal } from '../slack';
+import { parseUserId, ephemeralResponse, sendDM, SlackCommandResponse, openModal, openModalAndGetViewId, updateModal } from '../slack';
 import { buildStandupModal, YesterdayData, SubmissionPrefill } from '../modal';
 
 // ============================================================================
@@ -23,6 +23,7 @@ export interface CommandContext {
   devMode?: boolean;
   triggerId?: string; // For opening modals directly from slash commands
   env?: Record<string, string | undefined>; // For accessing integration tokens
+  waitUntil?: (promise: Promise<unknown>) => void; // Run work after the HTTP response (Workers ExecutionContext.waitUntil)
 }
 
 /** Re-export for convenience */
@@ -883,15 +884,14 @@ export async function handleDaily(ctx: CommandContext): Promise<CommandResponse>
       }
     }
 
-    // Fetch Linear issues and GitHub PRs in parallel
     const interactionCtx = { db: ctx.db, slackToken: ctx.slackToken, env: ctx.env || {} };
-    const [linearResult, githubResult] = await Promise.all([
-      fetchLinearIssuesForUser(daily, ctx.userId, interactionCtx),
-      fetchGitHubPRsForUser(daily, ctx.userId, interactionCtx),
-    ]);
 
-    // Build and open modal
-    const modal = buildStandupModal(
+    // Everything passed to buildStandupModal except the integration data.
+    const buildModal = (
+      linearIssues?: Awaited<ReturnType<typeof fetchLinearIssuesForUser>>['issues'],
+      prData?: Awaited<ReturnType<typeof fetchGitHubPRsForUser>>['prData'],
+      reviewerMap?: Awaited<ReturnType<typeof fetchGitHubPRsForUser>>['reviewerMap'],
+    ) => buildStandupModal(
       targetDailyName,
       yesterdayData,
       daily.questions || [],
@@ -899,25 +899,67 @@ export async function handleDaily(ctx: CommandContext): Promise<CommandResponse>
       targetDate,
       mode,
       prefill,
-      linearResult.issues,
-      githubResult.prData,
-      githubResult.reviewerMap
+      linearIssues,
+      prData,
+      reviewerMap,
     );
+
+    const message = mode === 'tomorrow'
+      ? (prefill
+          ? `📝 Editing *tomorrow's* scheduled standup for *${targetDailyName}*...`
+          : `📅 Opening *tomorrow's* standup for *${targetDailyName}*...`)
+      : `📋 Opening standup for *${targetDailyName}*...`;
+
+    const hasIntegrations = !!getLinearConfig(daily) || !!getGitHubConfig(daily);
+
+    // Fast path: open the modal immediately (well inside Slack's 3-second
+    // trigger_id window) without waiting on Linear/GitHub, then fill those
+    // sections in the background via views.update — which has no time limit.
+    // Slack preserves typed input across the update by block_id, so anything the
+    // user types before the fill lands is kept.
+    if (ctx.waitUntil && hasIntegrations) {
+      const loadingModal = buildModal();
+      const plansIdx = loadingModal.blocks.findIndex(b => b.block_id === 'today_plans');
+      loadingModal.blocks.splice(plansIdx >= 0 ? plansIdx : loadingModal.blocks.length, 0, {
+        type: 'context',
+        block_id: 'integrations_loading',
+        elements: [{ type: 'mrkdwn', text: '⏳ Loading your Linear tickets & GitHub PRs…' }],
+      });
+
+      const viewId = await openModalAndGetViewId(ctx.slackToken, ctx.triggerId, loadingModal);
+      if (!viewId) {
+        return ephemeralResponse('❌ Failed to open standup form. Please try again.');
+      }
+
+      ctx.waitUntil((async () => {
+        try {
+          const [linearResult, githubResult] = await Promise.all([
+            fetchLinearIssuesForUser(daily, ctx.userId, interactionCtx),
+            fetchGitHubPRsForUser(daily, ctx.userId, interactionCtx),
+          ]);
+          const filledModal = buildModal(linearResult.issues, githubResult.prData, githubResult.reviewerMap);
+          await updateModal(ctx.slackToken, viewId, filledModal);
+        } catch (err) {
+          console.error('Failed to fill standup modal with integrations:', err);
+        }
+      })());
+
+      return ephemeralResponse(message);
+    }
+
+    // Legacy path: no background execution available (e.g. tests) or no
+    // integrations to load — fetch synchronously, then open the full modal.
+    const [linearResult, githubResult] = await Promise.all([
+      fetchLinearIssuesForUser(daily, ctx.userId, interactionCtx),
+      fetchGitHubPRsForUser(daily, ctx.userId, interactionCtx),
+    ]);
+    const modal = buildModal(linearResult.issues, githubResult.prData, githubResult.reviewerMap);
 
     const opened = await openModal(ctx.slackToken, ctx.triggerId, modal);
     if (!opened) {
       return ephemeralResponse('❌ Failed to open standup form. Please try again.');
     }
 
-    // Return empty response (modal is shown)
-    let message: string;
-    if (mode === 'tomorrow') {
-      message = prefill
-        ? `📝 Editing *tomorrow's* scheduled standup for *${targetDailyName}*...`
-        : `📅 Opening *tomorrow's* standup for *${targetDailyName}*...`;
-    } else {
-      message = `📋 Opening standup for *${targetDailyName}*...`;
-    }
     return ephemeralResponse(message);
   } catch (err) {
     console.error('Failed to handle /daily:', err);

--- a/lib/handlers/interactions.ts
+++ b/lib/handlers/interactions.ts
@@ -1969,7 +1969,7 @@ async function handleShowAllInModal(
       new Set([section]),
     );
 
-    const blocks = applyExpandedSection(currentBlocks, rebuilt.blocks, section, currentView.state);
+    const blocks = applyExpandedSection(currentBlocks, rebuilt.blocks, section);
 
     // Expanding a PR section reveals PRs whose reviewer/category tags weren't in
     // the original private_metadata; merge the rebuilt ones in so the submission

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -276,14 +276,19 @@ export function buildStandupModal(
           : YESTERDAY_ITEM_OPTIONS[0];  // Carry over
       }
 
+      // Rendered as an input block (not a section + accessory) so Slack preserves
+      // the chosen status across views.update — e.g. the async integration fill on
+      // modal open, or a "Show all" expansion. Section accessories are not preserved.
       blocks.push({
-        type: 'section',
+        type: 'input',
         block_id: `yesterday_item_${index}`,
-        text: {
-          type: 'mrkdwn',
+        optional: true,
+        label: {
+          type: 'plain_text',
           text: plan.length > 60 ? plan.substring(0, 57) + '...' : plan,
+          emoji: true,
         },
-        accessory: {
+        element: {
           type: 'static_select',
           action_id: `item_status_${index}`,
           options: YESTERDAY_ITEM_OPTIONS,
@@ -350,13 +355,15 @@ export function buildStandupModal(
           const index = yesterdayPlans.length;
           yesterdayPlans.push(planText);
           blocks.push({
-            type: 'section',
+            type: 'input',
             block_id: `yesterday_item_${index}`,
-            text: {
-              type: 'mrkdwn',
+            optional: true,
+            label: {
+              type: 'plain_text',
               text: planText.length > 60 ? planText.substring(0, 57) + '...' : planText,
+              emoji: true,
             },
-            accessory: {
+            element: {
               type: 'static_select',
               action_id: `item_status_${index}`,
               options: YESTERDAY_ITEM_OPTIONS,
@@ -844,18 +851,16 @@ export const EXPANDABLE_SECTIONS = {
 
 export type ExpandableSection = keyof typeof EXPANDABLE_SECTIONS;
 
-/** Minimal shape of the view state Slack echoes back in a block_actions payload. */
-type ViewStateValues = Record<string, Record<string, { selected_option?: { value: string } }>>;
-
 /**
  * Produce the updated block list for a "Show all" expansion without re-fetching
  * the other integration's data. Starts from the modal's current (echoed) blocks and:
  *  - swaps the target section's checkbox block for its freshly-built expanded
- *    version, and replaces or drops the "Show all" button,
- *  - re-applies the user's yesterday-item picks (static_select state is NOT
- *    auto-preserved across views.update, unlike input blocks), and
+ *    version, and replaces or drops the "Show all" button, and
  *  - leaves every other block untouched — including the other integration's
- *    section and the user's typed input — so Slack preserves their state.
+ *    section, the user's typed input, and the yesterday-status selects.
+ *
+ * Everything carried over is in `input` blocks, so Slack preserves the user's
+ * entries/selections across the views.update automatically.
  *
  * `rebuiltBlocks` is a full modal built with ONLY the target integration's data;
  * we pull just the target section's blocks out of it by block_id.
@@ -863,8 +868,7 @@ type ViewStateValues = Record<string, Record<string, { selected_option?: { value
 export function applyExpandedSection(
   currentBlocks: Block[],
   rebuiltBlocks: Block[],
-  section: ExpandableSection,
-  viewState: { values: ViewStateValues } | undefined
+  section: ExpandableSection
 ): Block[] {
   const { inputBlockId, showAllBlockId } = EXPANDABLE_SECTIONS[section];
   // The expanded section may be split across several checkbox chunks (Slack caps
@@ -874,7 +878,6 @@ export function applyExpandedSection(
     !!id && (id === inputBlockId || chunkRe.test(id));
   const newInputBlocks = rebuiltBlocks.filter((b) => isSectionInput(b.block_id));
   const newShowAll = rebuiltBlocks.find((b) => b.block_id === showAllBlockId);
-  const values = viewState?.values || {};
 
   const result: Block[] = [];
   for (const block of currentBlocks) {
@@ -895,17 +898,6 @@ export function applyExpandedSection(
       // Replace with the still-needed button (more than the expanded limit) or drop it.
       if (newShowAll) result.push(newShowAll);
       continue;
-    }
-    const ydayMatch = block.block_id?.match(/^yesterday_item_(\d+)$/);
-    if (ydayMatch && block.accessory) {
-      const index = ydayMatch[1];
-      const selected = values[`yesterday_item_${index}`]?.[`item_status_${index}`]?.selected_option;
-      if (selected) {
-        const options = (block.accessory.options as Array<{ value: string }> | undefined) || [];
-        const match = options.find((o) => o.value === selected.value);
-        result.push({ ...block, accessory: { ...block.accessory, initial_option: match ?? selected } });
-        continue;
-      }
     }
     result.push(block);
   }

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -270,11 +270,11 @@ export async function sendDMWithBlocks(
 /**
  * Open a modal dialog
  */
-export async function openModal(
+export async function openModalAndGetViewId(
   slackToken: string,
   triggerId: string,
   view: unknown
-): Promise<boolean> {
+): Promise<string | null> {
   try {
     const response = await fetch('https://slack.com/api/views.open', {
       method: 'POST',
@@ -288,18 +288,30 @@ export async function openModal(
       }),
     });
 
-    const data = await response.json() as { ok: boolean; error?: string; response_metadata?: { messages?: string[] } };
+    const data = await response.json() as { ok: boolean; error?: string; view?: { id?: string }; response_metadata?: { messages?: string[] } };
 
     if (!data.ok) {
       console.error('Failed to open modal:', data.error, data.response_metadata?.messages);
-      return false;
+      return null;
     }
 
-    return true;
+    return data.view?.id ?? null;
   } catch (error) {
     console.error('Error opening modal:', error);
-    return false;
+    return null;
   }
+}
+
+/**
+ * Open a modal dialog. Returns whether it opened successfully.
+ * Use openModalAndGetViewId when you need to views.update the modal afterward.
+ */
+export async function openModal(
+  slackToken: string,
+  triggerId: string,
+  view: unknown
+): Promise<boolean> {
+  return (await openModalAndGetViewId(slackToken, triggerId, view)) !== null;
 }
 
 /**

--- a/product-docs/roadmap.md
+++ b/product-docs/roadmap.md
@@ -266,6 +266,12 @@ See `requirements.md` and `architecture.md`
 - [x] Dedup merged PRs against existing yesterday items by source_ref
 - [x] Cap auto-populated merged PRs at 5 (modal block limit)
 
+### Standup Modal Reliability ✅
+- [x] "Show all" expansion acks fast and updates in the background (no 3s timeout)
+- [x] "Show all" chunks Linear tickets into groups of 10 (Slack's per-element checkbox cap) so >10 tickets expand correctly
+- [x] `/standup` opens the modal instantly, then fills Linear/GitHub sections via `views.update` in the background — integration fetches no longer race Slack's 3-second `trigger_id` window
+- [x] Yesterday status selects rendered as `input` blocks so Slack preserves the user's picks across the background fill and "Show all" updates
+
 ---
 
 ## Up Next

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -11,6 +11,9 @@ vi.mock('../lib/config', () => ({
   getAdmins: vi.fn(() => ({ superAdmins: [], dbAdmins: [] })),
   getOverride: vi.fn(() => undefined),
   getDaily: vi.fn(),
+  getLinearConfig: vi.fn(() => null),
+  getGitHubConfig: vi.fn(() => null),
+  getMaxPlanItems: vi.fn(() => 0),
   getSchedule: vi.fn(),
   getDailies: vi.fn(),
   getDailyManagers: vi.fn(() => []),
@@ -30,6 +33,8 @@ vi.mock('../lib/db', () => ({
   getSubmissionsInRange: vi.fn(),
   getParticipationStats: vi.fn(),
   getUserDailies: vi.fn(),
+  getSubmissionForDate: vi.fn(() => Promise.resolve(null)),
+  getPreviousSubmission: vi.fn(() => Promise.resolve(null)),
   getTeamStats: vi.fn(),
   getMissingSubmissions: vi.fn(),
   countWorkdays: vi.fn(),
@@ -49,6 +54,14 @@ vi.mock('../lib/slack', () => ({
   ephemeralResponse: vi.fn((text: string) => ({ response_type: 'ephemeral', text })),
   sendDM: vi.fn(),
   openModal: vi.fn(() => Promise.resolve(true)),
+  openModalAndGetViewId: vi.fn(() => Promise.resolve('V_LOADING')),
+  updateModal: vi.fn(() => Promise.resolve(true)),
+}));
+
+// Mock interactions module (integration fetchers used by /daily)
+vi.mock('../lib/handlers/interactions', () => ({
+  fetchLinearIssuesForUser: vi.fn(() => Promise.resolve({ issues: [], allActiveIdentifiers: [] })),
+  fetchGitHubPRsForUser: vi.fn(() => Promise.resolve({})),
 }));
 
 // Mock prompt module
@@ -76,12 +89,14 @@ import {
   handleWeek,
   handleOOO,
   handleCommand,
+  handleDaily,
   CommandContext,
 } from '../lib/handlers/commands';
 
-import { isAdmin, isSuperAdmin, getAdmins, getOverride, getDaily, getSchedule, getDailies, getDailyManagers, getConfigError, getAllDailiesIncludingDisabled, isDailyEnabled, clearConfigCache, loadConfigOverrides } from '../lib/config';
+import { isAdmin, isSuperAdmin, getAdmins, getOverride, getDaily, getLinearConfig, getGitHubConfig, getSchedule, getDailies, getDailyManagers, getConfigError, getAllDailiesIncludingDisabled, isDailyEnabled, clearConfigCache, loadConfigOverrides } from '../lib/config';
 import { addParticipant, removeParticipant, getParticipants, getSubmissionsInRange, getUserDailies, getTeamStats, getMissingSubmissions, countWorkdays, setOOO, clearOOO, getUserOOO, setConfigOverride, deleteConfigOverride } from '../lib/db';
-import { parseUserId, sendDM, openModal } from '../lib/slack';
+import { parseUserId, sendDM, openModal, openModalAndGetViewId, updateModal } from '../lib/slack';
+import { fetchLinearIssuesForUser, fetchGitHubPRsForUser } from '../lib/handlers/interactions';
 import { getUserTimezone, getUserDate, formatDate, sendPromptDM } from '../lib/prompt';
 import { formatManagerDigest } from '../lib/format';
 
@@ -956,5 +971,89 @@ describe('command handlers', () => {
       const response = await handlePrompt(createContextWithTrigger(['prompt', 'all']));
       expect(response.text).toContain('Sent prompts for 1 dailies');
     });
+  });
+});
+
+describe('handleDaily — instant modal open + background fill', () => {
+  const makeCtx = (over: Partial<CommandContext> = {}) => {
+    const promises: Promise<unknown>[] = [];
+    const ctx = {
+      userId: 'U12345',
+      args: ['daily-il'],
+      db: {} as any,
+      slackToken: 'xoxb-test',
+      triggerId: 'trig-1',
+      env: {},
+      waitUntil: (p: Promise<unknown>) => { promises.push(p); },
+      ...over,
+    } as CommandContext;
+    return { ctx, promises };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getUserDailies).mockResolvedValue([{ daily_name: 'daily-il' }] as any);
+    vi.mocked(getDaily).mockReturnValue({ name: 'daily-il', questions: [] } as any);
+    vi.mocked(getUserTimezone).mockResolvedValue({ tz_offset: 0 } as any);
+    vi.mocked(getUserDate).mockReturnValue(new Date('2024-01-15'));
+    vi.mocked(formatDate).mockReturnValue('2024-01-15');
+    vi.mocked(openModal).mockResolvedValue(true);
+    vi.mocked(openModalAndGetViewId).mockResolvedValue('V_LOADING');
+    vi.mocked(updateModal).mockResolvedValue(true);
+    vi.mocked(fetchLinearIssuesForUser).mockResolvedValue({ issues: [], allActiveIdentifiers: [] } as any);
+    vi.mocked(fetchGitHubPRsForUser).mockResolvedValue({} as any);
+  });
+
+  it('opens a loading modal immediately, then fills via views.update in the background', async () => {
+    vi.mocked(getLinearConfig).mockReturnValue({ tokenEnvVar: 'LINEAR_TOKEN' } as any);
+    const { ctx, promises } = makeCtx();
+
+    const res = await handleDaily(ctx);
+
+    // Modal opened immediately, with a loading indicator.
+    expect(openModalAndGetViewId).toHaveBeenCalledTimes(1);
+    const loadingView = vi.mocked(openModalAndGetViewId).mock.calls[0][2] as any;
+    expect(loadingView.blocks.some((b: any) => b.block_id === 'integrations_loading')).toBe(true);
+    expect((res as any).text).toContain('Opening standup');
+
+    // The modal is opened BEFORE integrations are fetched (the whole point —
+    // the trigger_id is consumed inside the 3s window, fetches come after).
+    expect(vi.mocked(openModalAndGetViewId).mock.invocationCallOrder[0])
+      .toBeLessThan(vi.mocked(fetchLinearIssuesForUser).mock.invocationCallOrder[0]);
+    // The fill (views.update) has NOT happened on the critical path.
+    expect(updateModal).not.toHaveBeenCalled();
+
+    // Background work fetches integrations and updates the same view.
+    await Promise.all(promises);
+    expect(fetchLinearIssuesForUser).toHaveBeenCalledTimes(1);
+    expect(fetchGitHubPRsForUser).toHaveBeenCalledTimes(1);
+    expect(updateModal).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(updateModal).mock.calls[0][1]).toBe('V_LOADING');
+    const filledView = vi.mocked(updateModal).mock.calls[0][2] as any;
+    expect(filledView.blocks.some((b: any) => b.block_id === 'integrations_loading')).toBe(false);
+  });
+
+  it('falls back to a synchronous open (no views.update) when waitUntil is unavailable', async () => {
+    vi.mocked(getLinearConfig).mockReturnValue({ tokenEnvVar: 'LINEAR_TOKEN' } as any);
+    const { ctx } = makeCtx({ waitUntil: undefined });
+
+    await handleDaily(ctx);
+
+    expect(openModal).toHaveBeenCalledTimes(1);
+    expect(openModalAndGetViewId).not.toHaveBeenCalled();
+    expect(updateModal).not.toHaveBeenCalled();
+    expect(fetchLinearIssuesForUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens directly without a background fill when the daily has no integrations', async () => {
+    vi.mocked(getLinearConfig).mockReturnValue(null);
+    vi.mocked(getGitHubConfig).mockReturnValue(null);
+    const { ctx } = makeCtx();
+
+    await handleDaily(ctx);
+
+    expect(openModal).toHaveBeenCalledTimes(1);
+    expect(openModalAndGetViewId).not.toHaveBeenCalled();
+    expect(updateModal).not.toHaveBeenCalled();
   });
 });

--- a/tests/modal.test.ts
+++ b/tests/modal.test.ts
@@ -88,8 +88,8 @@ describe('modal builder', () => {
       expect(dropdownBlocks).toHaveLength(2);
 
       // Check first item
-      expect(dropdownBlocks[0].text?.text).toContain('Task A');
-      expect(dropdownBlocks[0].accessory?.type).toBe('static_select');
+      expect(dropdownBlocks[0].label?.text).toContain('Task A');
+      expect(dropdownBlocks[0].element?.type).toBe('static_select');
     });
 
     it('truncates long plan items in dropdown', () => {
@@ -105,8 +105,8 @@ describe('modal builder', () => {
       const dropdownBlock = modal.blocks.find(b =>
         b.block_id === 'yesterday_item_0'
       );
-      expect(dropdownBlock?.text?.text?.length).toBeLessThanOrEqual(60);
-      expect(dropdownBlock?.text?.text).toContain('...');
+      expect(dropdownBlock?.label?.text?.length).toBeLessThanOrEqual(60);
+      expect(dropdownBlock?.label?.text).toContain('...');
     });
 
     it('includes today_plans input block', () => {
@@ -229,7 +229,7 @@ describe('modal builder', () => {
       const dropdownBlock = modal.blocks.find(b =>
         b.block_id === 'yesterday_item_0'
       );
-      const options = dropdownBlock?.accessory?.options as any[];
+      const options = dropdownBlock?.element?.options as any[];
       expect(options).toHaveLength(4);
       expect(options.map((o: any) => o.value)).toEqual(['continue', 'in_progress', 'done', 'drop']);
       expect(options[1].text.text).toContain('In progress');
@@ -248,7 +248,7 @@ describe('modal builder', () => {
         b.block_id === 'yesterday_item_0'
       );
 
-      expect(dropdownBlock?.accessory?.initial_option?.text?.text).toContain('Carry over');
+      expect(dropdownBlock?.element?.initial_option?.text?.text).toContain('Carry over');
     });
 
     it('interleaves custom questions with standard fields based on order', () => {
@@ -872,11 +872,11 @@ describe('modal builder', () => {
       const item2 = modal.blocks.find(b => b.block_id === 'yesterday_item_2');
 
       // ENG-100 should default to Done
-      expect(item0?.accessory?.initial_option?.value).toBe('done');
+      expect(item0?.element?.initial_option?.value).toBe('done');
       // "Write tests" (not a Linear item) should default to Carry over
-      expect(item1?.accessory?.initial_option?.value).toBe('continue');
+      expect(item1?.element?.initial_option?.value).toBe('continue');
       // ENG-200 (not auto-completed) should default to Carry over
-      expect(item2?.accessory?.initial_option?.value).toBe('continue');
+      expect(item2?.element?.initial_option?.value).toBe('continue');
     });
 
     it('auto-completed overrides in-progress default', () => {
@@ -895,7 +895,7 @@ describe('modal builder', () => {
 
       const item0 = modal.blocks.find(b => b.block_id === 'yesterday_item_0');
       // Auto-completed takes precedence over in-progress
-      expect(item0?.accessory?.initial_option?.value).toBe('done');
+      expect(item0?.element?.initial_option?.value).toBe('done');
     });
 
     it('does not include Linear block when no issues provided', () => {
@@ -1286,7 +1286,7 @@ describe('modal builder', () => {
       const before = current.find(b => b.block_id === 'linear_tickets');
       expect((before?.element?.options as unknown[])?.length).toBe(3);
 
-      const result = applyExpandedSection(current, rebuiltLinear(), 'linear', undefined);
+      const result = applyExpandedSection(current, rebuiltLinear(), 'linear');
       const after = result.find(b => b.block_id === 'linear_tickets');
       expect((after?.element?.options as unknown[])?.length).toBeGreaterThan(3);
     });
@@ -1296,7 +1296,7 @@ describe('modal builder', () => {
       // element, which Slack rejects with invalid_arguments, so "Show all" silently
       // failed. The expansion must now chunk into <=10-option blocks.
       const current = collapsedView();
-      const result = applyExpandedSection(current, rebuiltLinear(), 'linear', undefined);
+      const result = applyExpandedSection(current, rebuiltLinear(), 'linear');
 
       const checkboxBlocks = result.filter(
         (b) => (b.element as { type?: string } | undefined)?.type === 'checkboxes'
@@ -1317,7 +1317,7 @@ describe('modal builder', () => {
     it('leaves the other integration section untouched (no GitHub re-fetch)', () => {
       const current = collapsedView();
       const prBefore = current.find(b => b.block_id === 'my_prs');
-      const result = applyExpandedSection(current, rebuiltLinear(), 'linear', undefined);
+      const result = applyExpandedSection(current, rebuiltLinear(), 'linear');
       const prAfter = result.find(b => b.block_id === 'my_prs');
       // Same object content carried over verbatim — the PR section was not rebuilt.
       expect(prAfter).toEqual(prBefore);
@@ -1328,21 +1328,20 @@ describe('modal builder', () => {
       const current = collapsedView();
       expect(current.find(b => b.block_id === 'linear_show_all')).toBeDefined();
       // 15 tickets < expanded limit of 20, so the button should disappear.
-      const result = applyExpandedSection(current, rebuiltLinear(), 'linear', undefined);
+      const result = applyExpandedSection(current, rebuiltLinear(), 'linear');
       expect(result.find(b => b.block_id === 'linear_show_all')).toBeUndefined();
     });
 
-    it('re-applies the user\'s yesterday selection from view state', () => {
+    it('carries yesterday status selects through unchanged (Slack preserves input state)', () => {
+      // Yesterday statuses are input-block static_selects, so Slack preserves the
+      // user's pick across views.update automatically — applyExpandedSection just
+      // needs to pass the block through untouched (same block_id/action_id).
       const current = collapsedView();
-      // User changed the first yesterday item to "Done" since the modal opened.
-      const state = {
-        values: {
-          yesterday_item_0: { item_status_0: { selected_option: { value: 'done' } } },
-        },
-      };
-      const result = applyExpandedSection(current, rebuiltLinear(), 'linear', state);
-      const yday = result.find(b => b.block_id === 'yesterday_item_0');
-      expect((yday?.accessory?.initial_option as { value: string })?.value).toBe('done');
+      const before = current.find(b => b.block_id === 'yesterday_item_0');
+      const result = applyExpandedSection(current, rebuiltLinear(), 'linear');
+      const after = result.find(b => b.block_id === 'yesterday_item_0');
+      expect(after).toEqual(before);
+      expect((after?.element as { type?: string } | undefined)?.type).toBe('static_select');
     });
   });
 });


### PR DESCRIPTION
Promotes `dev` to `main`. One feature commit (`d801cbf`).

## What's shipping

**Open the standup modal instantly, fill integrations in the background**
`/standup` previously fetched Linear + GitHub *before* opening the modal, racing Slack's 3-second `trigger_id` window — slow integrations meant the modal failed to open. Now:

- `handleDaily` opens a lightweight modal (with a `⏳ Loading…` indicator) inside the trigger window, then fetches Linear/GitHub and `views.update`s the same view in the background via `ctx.waitUntil` (threaded through from the commands path). Falls back to the synchronous fetch-then-open path when `waitUntil` is unavailable (tests) or the daily has no integrations.
- `slack.openModalAndGetViewId` returns the opened view id; `openModal` delegates to it and keeps its boolean contract for all other callers.
- **Airtight state:** yesterday status selects are now `input` blocks (not section accessories), so Slack preserves the user's picks across the background fill — and across "Show all" expansions, which let `applyExpandedSection` drop its manual re-apply hack.

## UX notes
- Yesterday rows render as stacked input blocks (plan as label + dropdown beneath) instead of inline text + right-aligned dropdown.
- Input labels are `plain_text`, so mrkdwn in a plan item (e.g. `_(to review)_`) renders literally.

## Checks
Full unit suite passing (580 tests), clean `tsc`. Roadmap updated (Standup Modal Reliability).

## Note
Verified via tests + `tsc`; the open→fill timing only fully exercises against live Slack — worth a `/standup` click-through after deploy (modal should open instantly, then tickets/PRs appear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)